### PR TITLE
Video object detection - fix runner parameters

### DIFF
--- a/src/arduino/app_bricks/video_objectdetection/brick_compose.yaml
+++ b/src/arduino/app_bricks/video_objectdetection/brick_compose.yaml
@@ -13,7 +13,7 @@ services:
     volumes:
       - "${CUSTOM_MODEL_PATH:-/home/arduino/.arduino-bricks/ei-models/}:${CUSTOM_MODEL_PATH:-/home/arduino/.arduino-bricks/ei-models/}"
       - "/run/udev:/run/udev"
-    command: ["--model-file", "${EI_OBJ_DETECTION_MODEL:-/models/ootb/ei/yolo-x-nano.eim}", "--dont-print-predictions", "--mode", "streaming", "--force-target", "--preview-original-resolution", "--camera", "${VIDEO_DEVICE:-/dev/video1}"]
+    command: ["--model-file", "${EI_OBJ_DETECTION_MODEL:-/models/ootb/ei/yolo-x-nano.eim}", "--dont-print-predictions", "--mode", "streaming", "--preview-original-resolution", "--camera", "${VIDEO_DEVICE:-/dev/video1}"]
     healthcheck:
       test: [ "CMD-SHELL", "wget -q --spider http://ei-video-obj-detection-runner:4912 || exit 1" ]
       interval: 2s


### PR DESCRIPTION
**Description**

Fix runner parameter, removing "--force-target" parameter that is wrongly added and not configured. 
This is making subsequent parameter to not be applied, lowering video output quality.