### PR TITLE
fix: use brick ID as folder name for api-docs

### DIFF
--- a/docs_generator/runner.py
+++ b/docs_generator/runner.py
@@ -8,8 +8,19 @@ from docs_generator.extractor import extract_docstrings_with_types
 from docs_generator.markdown_writer import generate_markdown
 import logging
 import ast
+import yaml
 
 logger = logging.getLogger(__name__)
+
+def get_brick_id_from_yaml(yaml_path):
+    try:
+        with open(yaml_path+"/brick_config.yaml", "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        id = config.get("id", None)
+        return id.split(":")[1] if id and ":" in id else None
+    except Exception:
+        logger.warning("unable to get brick id")
+        return None
 
 
 def process_app_bricks(src_root: str, output_dir: str):
@@ -107,6 +118,9 @@ def process_app_bricks(src_root: str, output_dir: str):
             else:
                 all_docstrings = list(docstrings_by_name.values())
             # Create output folder for this brick
+            brick_id = get_brick_id_from_yaml(folder_path)
+            if brick_id:
+                folder = brick_id
             brick_output_dir = os.path.join(output_dir, "arduino", "app_bricks", folder)
             os.makedirs(brick_output_dir, exist_ok=True)
             if all_docstrings:

--- a/docs_generator/runner.py
+++ b/docs_generator/runner.py
@@ -12,9 +12,10 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+
 def get_brick_id_from_yaml(yaml_path):
     try:
-        with open(yaml_path+"/brick_config.yaml", "r", encoding="utf-8") as f:
+        with open(yaml_path + "/brick_config.yaml", "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
         id = config.get("id", None)
         return id.split(":")[1] if id and ":" in id else None

--- a/docs_generator/runner.py
+++ b/docs_generator/runner.py
@@ -18,8 +18,8 @@ def get_brick_id_from_yaml(yaml_path):
             config = yaml.safe_load(f)
         id = config.get("id", None)
         return id.split(":")[1] if id and ":" in id else None
-    except Exception:
-        logger.warning("unable to get brick id")
+    except Exception as e:
+        logger.warning("unable to get brick id from yaml: %s", e)
         return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77,<81", "wheel", "setuptools_scm>=8", "docstring_parser>=0.16", "msgpack>=1.0.0", "watchdog", "requests", "Pillow", "numpy"]
+requires = ["setuptools>=77,<81", "wheel", "setuptools_scm>=8", "docstring_parser>=0.16", "msgpack>=1.0.0", "watchdog", "requests", "Pillow", "numpy", "pyyaml"]
 build-backend = "builder"
 backend-path = ["src/arduino/app_tools"]
 


### PR DESCRIPTION
The App Lab can't read the `API.md` files because the folder name of the brick doesn't match the brick ID.