### PR TITLE
Test llm interaction with tools and mcp servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,5 +191,8 @@ Taskfile.yml
 
 *.exe
 
+# DeepEval
+.deepeval/
+
 # Other
 design/

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -46,9 +46,14 @@ tasks:
       - python -m docs_generator.runner
 
   test:
-    desc: Run all tests
+    desc: Run all unit tests
     cmds:
-      - pytest -vs ./tests
+      - pytest -vs ./tests --ignore=tests/arduino/app_bricks/cloud_llm/
+
+  llm_test:
+    desc: Run all LLM tests
+    cmds:
+      - deepeval test run tests/arduino/app_bricks/cloud_llm/ -n 4 -vs
 
   test:*:
     desc: Run tests for a specific folder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dev = [
     "ruff",
     "docstring_parser>=0.16",
     "arduino_app_bricks[all]",
+    "deepeval",
+    "mcp",
 ]
 dbstorage_influx = [
     "influxdb_client>=1.48.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ dev = [
     "arduino_app_bricks[all]",
     "deepeval",
     "mcp",
+    "langchain_mcp_adapters",
+    "langchain_ollama",
 ]
 dbstorage_influx = [
     "influxdb_client>=1.48.0",

--- a/src/arduino/app_bricks/cloud_llm/cloud_llm.py
+++ b/src/arduino/app_bricks/cloud_llm/cloud_llm.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+import asyncio
 import base64
 import os
 import threading
@@ -178,7 +179,12 @@ class CloudLLM:
             if tool_name in self._tools_map:
                 logger.debug(f"Invoking tool function for: {tool_name}")
                 tool_func = self._tools_map[tool_name]
-                tool_output = tool_func.invoke(tool_args, config={"callbacks": self._callbacks},)
+                tool_output = asyncio.run(
+                    tool_func.ainvoke(
+                        tool_args,
+                        config={"callbacks": self._callbacks},
+                    )
+                )
                 logger.debug(f"Tool '{tool_name}' returned: {tool_output}")
 
                 # Append tool output message to current message scope

--- a/src/arduino/app_bricks/cloud_llm/cloud_llm.py
+++ b/src/arduino/app_bricks/cloud_llm/cloud_llm.py
@@ -40,6 +40,7 @@ class CloudLLM:
         model: Union[str, CloudModel] = CloudModel.ANTHROPIC_CLAUDE,
         system_prompt: str = "",
         temperature: Optional[float] = 0.7,
+        max_tool_loops: int = 8,
         timeout: int = 30,
         tools: List[Callable[..., Any]] = None,
         callbacks: Any = None,
@@ -59,6 +60,8 @@ class CloudLLM:
             temperature (Optional[float]): The sampling temperature between 0.0 and 1.0.
                 Higher values make output more random/creative; lower values make it more
                 deterministic. Defaults to 0.7.
+            max_tool_loops (int): The maximum number of consecutive tool-call loops
+                allowed during a single chat interaction. Defaults to 8.
             timeout (int): The maximum duration in seconds to wait for a response before
                 timing out. Defaults to 30.
             callbacks (Any): Optional callbacks for monitoring generation events.
@@ -77,6 +80,7 @@ class CloudLLM:
         self._model = model
         self._system_prompt = system_prompt
         self._temperature = temperature
+        self._max_tool_loops = max_tool_loops
         self._timeout = timeout
         self._callbacks = callbacks
 
@@ -225,15 +229,25 @@ class CloudLLM:
 
         try:
             input_messages = self._get_message_with_history(message, images)
-            message = self._model.invoke(input=input_messages, config={"callbacks": self._callbacks})
-            if message is None:
-                raise RuntimeError("Received empty response from the LLM.")
+            loops = 0
 
-            logger.debug(f"Model invoked. Full response: {message}")
-            if message.tool_calls and len(message.tool_calls) > 0:
-                input_messages.append(message)  # Add the previous AI message to scoped history
-                input_messages = self._process_tool_calls(message.tool_calls, input_messages.copy())
+            while True:
                 message = self._model.invoke(input=input_messages, config={"callbacks": self._callbacks})
+                if message is None:
+                    raise RuntimeError("Received empty response from the LLM.")
+
+                logger.debug(f"Model invoked. Full response: {message}")
+
+                tool_calls = getattr(message, "tool_calls", None) or []
+                if not tool_calls:
+                    break
+
+                loops += 1
+                if loops > self._max_tool_loops:
+                    raise RuntimeError(f"Too many consecutive tool-call loops ({self._max_tool_loops}). Possible tool loop.")
+
+                input_messages.append(message)
+                input_messages = self._process_tool_calls(tool_calls, input_messages.copy())
 
             # Add the AI message to long term history
             self._history.add_messages([message])

--- a/src/arduino/app_bricks/cloud_llm/cloud_llm.py
+++ b/src/arduino/app_bricks/cloud_llm/cloud_llm.py
@@ -42,6 +42,7 @@ class CloudLLM:
         temperature: Optional[float] = 0.7,
         timeout: int = 30,
         tools: List[Callable[..., Any]] = None,
+        callbacks: Any = None,
         **kwargs,
     ):
         """Initializes the CloudLLM brick with the specified provider and configuration.
@@ -60,6 +61,7 @@ class CloudLLM:
                 deterministic. Defaults to 0.7.
             timeout (int): The maximum duration in seconds to wait for a response before
                 timing out. Defaults to 30.
+            callbacks (Any): Optional callbacks for monitoring generation events.
             tools (List[Callable[..., Any]]): A list of callable tool functions to register. Defaults to None.
             **kwargs: Additional arguments passed to the model constructor
 
@@ -76,6 +78,7 @@ class CloudLLM:
         self._system_prompt = system_prompt
         self._temperature = temperature
         self._timeout = timeout
+        self._callbacks = callbacks
 
         # Registered tools
         self._tools_map = {}
@@ -171,7 +174,7 @@ class CloudLLM:
             if tool_name in self._tools_map:
                 logger.debug(f"Invoking tool function for: {tool_name}")
                 tool_func = self._tools_map[tool_name]
-                tool_output = tool_func.invoke(tool_args)
+                tool_output = tool_func.invoke(tool_args, config={"callbacks": self._callbacks},)
                 logger.debug(f"Tool '{tool_name}' returned: {tool_output}")
 
                 # Append tool output message to current message scope
@@ -222,7 +225,7 @@ class CloudLLM:
 
         try:
             input_messages = self._get_message_with_history(message, images)
-            message = self._model.invoke(input_messages)
+            message = self._model.invoke(input=input_messages, config={"callbacks": self._callbacks})
             if message is None:
                 raise RuntimeError("Received empty response from the LLM.")
 
@@ -230,7 +233,7 @@ class CloudLLM:
             if message.tool_calls and len(message.tool_calls) > 0:
                 input_messages.append(message)  # Add the previous AI message to scoped history
                 input_messages = self._process_tool_calls(message.tool_calls, input_messages.copy())
-                message = self._model.invoke(input_messages)
+                message = self._model.invoke(input=input_messages, config={"callbacks": self._callbacks})
 
             # Add the AI message to long term history
             self._history.add_messages([message])
@@ -280,7 +283,7 @@ class CloudLLM:
             # If there were tool calls, process them
             if len(tool_calls) > 0:
                 input_messages = self._process_tool_calls(tool_calls, input_messages.copy())
-                for token in self._model.stream(input_messages):
+                for token in self._model.stream(input=input_messages, config={"callbacks": self._callbacks}):
                     if not self._keep_streaming.is_set():
                         break
                     if token.content:

--- a/src/arduino/app_bricks/cloud_llm/memory.py
+++ b/src/arduino/app_bricks/cloud_llm/memory.py
@@ -10,10 +10,10 @@ class WindowedChatMessageHistory:
     """A chat history store that automatically keeps a window of the last k messages."""
 
     k: int
-    messages: list[BaseMessage] = []
 
     def __init__(self, k: int, system_message: str = ""):
         self.k = k
+        self._messages: list[BaseMessage] = []
         if system_message != "":
             self._system_message = SystemMessage(content=system_message)
         else:
@@ -25,10 +25,10 @@ class WindowedChatMessageHistory:
             return
 
         for message in messages:
-            self.messages.append(message)
+            self._messages.append(message)
 
-        if len(self.messages) > self.k:
-            self.messages = self.messages[-self.k :]
+        if len(self._messages) > self.k:
+            self._messages = self._messages[-self.k :]
 
     def get_messages(self) -> List[BaseMessage]:
         """Get all messages in the history, including system message if set."""
@@ -40,7 +40,7 @@ class WindowedChatMessageHistory:
                 return []
 
         if self._system_message:
-            return [self._system_message] + self.messages
+            return [self._system_message] + self._messages
         else:
             return self.messages
 

--- a/tests/arduino/app_bricks/cloud_llm/cases/home_automation.json
+++ b/tests/arduino/app_bricks/cloud_llm/cases/home_automation.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "home_automation_01",
+    "runners": ["home_automation.run_granular"],
+    "prompt": "Turn on the living room lights.",
+    "must_call_tools": [
+      { "name": "turn_on_light", "input_parameters": { "room": "living room" } }
+    ],
+    "forbidden": ["I don't", "I'm not", "I can't"]
+  },
+  {
+    "id": "home_automation_02",
+    "runners": ["home_automation.run_object"],
+    "prompt": "Turn on the living room lights.",
+    "must_call_tools": [
+      {
+        "name": "light_control",
+        "input_parameters": { "state": true, "room": "living room" }
+      }
+    ],
+    "forbidden": ["I don't", "I'm not", "I can't"]
+  },
+  {
+    "id": "home_automation_03",
+    "runners": ["home_automation.run_granular"],
+    "prompt": "Set the thermostat to 22 degrees in the bedroom.",
+    "must_call_tools": [
+      {
+        "name": "set_thermostat",
+        "input_parameters": { "room": "bedroom", "temperature": 22 }
+      }
+    ],
+    "forbidden": ["I don't", "I'm not", "I can't"]
+  },
+  {
+    "id": "home_automation_04",
+    "runners": ["home_automation.run_object"],
+    "prompt": "Set the thermostat to 22 degrees in the bedroom.",
+    "must_call_tools": [
+      {
+        "name": "air_conditioner_control",
+        "input_parameters": {
+          "state": true,
+          "temperature": 22,
+          "room": "bedroom"
+        }
+      }
+    ],
+    "forbidden": ["I don't", "I'm not", "I can't"]
+  },
+  {
+    "id": "home_automation_05",
+    "runners": ["home_automation.run_granular"],
+    "prompt": "I am in the living room and I'm feeling very hot. Do something about it.",
+    "must_call_tools": [{ "name": "turn_on_ac", "room": "living room" }],
+    "forbidden": ["I don't", "I'm not", "I can't"]
+  },
+  {
+    "id": "home_automation_06",
+    "runners": ["home_automation.run_object"],
+    "prompt": "I am in the living room and I'm feeling very hot. Do something about it.",
+    "must_call_tools": [
+      {
+        "name": "air_conditioner_control",
+        "input_parameters": {
+          "state": true,
+          "temperature": 22,
+          "room": "living room"
+        }
+      }
+    ],
+    "forbidden": ["I don't", "I'm not", "I can't"]
+  },
+  {
+    "id": "home_automation_07",
+    "runners": ["home_automation.run_granular_with_weather"],
+    "prompt": "I'm in Boston, if outside is cold set the thermostat in the living room to 22 degrees",
+    "must_call_tools": [
+      { "name": "get_current_weather", "args": { "location": "Boston" } },
+      {
+        "name": "set_thermostat",
+        "input_parameters": { "room": "living room", "temperature": 22 }
+      }
+    ],
+    "forbidden": ["I don't", "I'm not", "I can't"]
+  },
+  {
+    "id": "home_automation_08",
+    "runners": ["home_automation.run_object_with_weather"],
+    "prompt": "I'm in Boston, if outside is cold set the thermostat in the living room to 22 degrees",
+    "must_call_tools": [
+      { "name": "get_current_weather", "args": { "location": "Boston" } },
+      {
+        "name": "air_conditioner_control",
+        "input_parameters": {
+          "state": true,
+          "temperature": 22,
+          "room": "living room"
+        }
+      }
+    ],
+    "forbidden": ["I don't", "I'm not", "I can't"]
+  }
+]

--- a/tests/arduino/app_bricks/cloud_llm/cases/weather.json
+++ b/tests/arduino/app_bricks/cloud_llm/cases/weather.json
@@ -1,0 +1,20 @@
+{
+  "id": "weather_01",
+  "runners": ["weather.run"],
+  "prompt": "What's the weather like today in Boston?",
+  "must_call_tools": [
+    {
+      "name": "get_current_weather",
+      "input_parameters": { "location": "Boston" }
+    }
+  ],
+  "forbidden": ["I don't", "I'm not", "I can't", "Sun", "Snow", "Cloud"],
+  "semantic": {
+    "evaluation_steps": [
+      "Accurately retrieves the current weather information for Boston.",
+      "Gives information about temperature and conditions.",
+      "If it provides details or unnecessary information other than temperature and conditions, penalize the score."
+    ],
+    "min_score": 0.75
+  }
+}

--- a/tests/arduino/app_bricks/cloud_llm/conftest.py
+++ b/tests/arduino/app_bricks/cloud_llm/conftest.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
+import json
+import glob
+from typing import cast, Callable
+import os
+import time
+import threading
+import requests
+import uvicorn
+from logging import Logger
+
+
+from arduino.app_bricks.cloud_llm import CloudModelProvider, CloudModel
+from stubs.granular_mcp_server import granular_mcp_server_factory
+from stubs.object_mcp_server import object_mcp_server_factory
+
+from deepeval.dataset import EvaluationDataset, Golden
+from deepeval.test_case import LLMTestCase, ToolCall
+from fastapi import FastAPI
+
+
+logger = Logger("cloud_llm_tests")
+pytest_plugins = ["fixtures.judge_model", "fixtures.runners"]
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    name: CloudModel | str
+    provider: str
+    requires_api_key: bool = True
+    api_key: str | None = None
+
+
+models_to_test = [
+    ModelConfig(name="gemini-2.5-flash", provider=CloudModelProvider.GOOGLE, api_key=os.getenv("GEMINI_API_KEY")),
+    ModelConfig(name=CloudModel.OLLAMA, provider=CloudModelProvider.OLLAMA, requires_api_key=False),
+]
+
+
+def _load_cases() -> list[dict]:
+    cases: list[dict] = []
+    paths = sorted(p for p in glob.glob("tests/arduino/app_bricks/cloud_llm/cases/*.json") if not os.path.basename(p).startswith("_"))
+    for path in paths:
+        with open(path, "r", encoding="utf-8") as f:
+            c = json.load(f)
+            if isinstance(c, list):
+                cases.extend(c)
+            else:
+                cases.append(c)
+    return cases
+
+
+def load_dataset() -> EvaluationDataset:
+    goldens = [
+        Golden(
+            input=raw["prompt"],
+            multimodal=False,
+            expected_tools=[
+                ToolCall(name=tool["name"], input_parameters=tool.get("input_parameters", {})) for tool in raw.get("must_call_tools", [])
+            ],
+            additional_metadata={
+                "case_id": raw.get("id"),
+                "runners": raw.get("runners", []),
+                "semantic": raw.get("semantic", None),
+            },
+        )
+        for raw in _load_cases()
+    ]
+
+    dataset = EvaluationDataset(goldens=goldens)
+
+    for golden in dataset.goldens:
+        golden = cast(Golden, golden)
+        golden.additional_metadata = cast(dict, golden.additional_metadata)
+
+        case_id = golden.additional_metadata.get("case_id", None)
+        if case_id is None:
+            logger.warning("Golden missing case_id: %s", golden)
+            continue
+
+        semantic_test = golden.additional_metadata.get("semantic", None)
+
+        # Combinations of runners and models
+        for runner_name in golden.additional_metadata.get("runners", []):
+            for model in models_to_test:
+                test_case = LLMTestCase(
+                    name=(f"[bold]parent_case_id:[/bold] {case_id}\n[bold]runner:[/bold] {runner_name}\n[bold]model:[/bold] {model.name}"),
+                    input=golden.input,
+                    expected_tools=golden.expected_tools,
+                    additional_metadata={
+                        "runner_name": runner_name,
+                        "model": model,
+                        "semantic": semantic_test,
+                    },
+                )
+                dataset.add_test_case(test_case)
+
+    return dataset
+
+
+# MCP server management for tests
+def _is_worker() -> bool:
+    return os.environ.get("PYTEST_XDIST_WORKER") is not None
+
+
+def _is_mcp_srv_ready(port: int) -> bool:
+    try:
+        r = requests.get(f"http://127.0.0.1:{port}/health", timeout=0.3)
+        return r.status_code == 200
+    except requests.RequestException:
+        return False
+
+
+def _wait_mcp_srv_ready(port: int, timeout: float = 10.0) -> None:
+    start = time.time()
+    while time.time() - start < timeout:
+        if _is_mcp_srv_ready(port):
+            return
+        time.sleep(0.1)
+    raise TimeoutError(f"MCP server at 127.0.0.1:{port} not ready")
+
+
+def _wait_mcp_srvs_ready(ports: list[int], timeout: float = 10.0) -> None:
+    with ThreadPoolExecutor(max_workers=len(ports)) as executor:
+        futures = [executor.submit(_wait_mcp_srv_ready, port, timeout) for port in ports]
+        for future in futures:
+            future.result()
+
+
+def _start_mcp_srv(port: int, factory: Callable[[int], FastAPI]) -> None:
+    app = factory(port)
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    threading.Thread(target=server.run, daemon=True).start()
+
+
+def pytest_sessionstart(session):
+    mcp_srvs_port_factory_map = {
+        8000: granular_mcp_server_factory,
+        8001: object_mcp_server_factory,
+    }
+
+    if not _is_worker():
+        for port, factory in mcp_srvs_port_factory_map.items():
+            _start_mcp_srv(port, factory)
+
+    _wait_mcp_srvs_ready(list(mcp_srvs_port_factory_map))
+
+    logger.info("MCP servers are ready")

--- a/tests/arduino/app_bricks/cloud_llm/conftest.py
+++ b/tests/arduino/app_bricks/cloud_llm/conftest.py
@@ -25,7 +25,7 @@ from fastapi import FastAPI
 
 
 logger = Logger("cloud_llm_tests")
-pytest_plugins = ["fixtures.judge_model", "fixtures.runners"]
+pytest_plugins = ["fixtures.judge_model", "fixtures.runners", "fixtures.model_factory"]
 
 
 @dataclass(frozen=True)
@@ -34,11 +34,20 @@ class ModelConfig:
     provider: str
     requires_api_key: bool = True
     api_key: str | None = None
+    base_url: str | None = None
 
 
 models_to_test = [
-    ModelConfig(name="gemini-2.5-flash", provider=CloudModelProvider.GOOGLE, api_key=os.getenv("GEMINI_API_KEY")),
-    ModelConfig(name=CloudModel.OLLAMA, provider=CloudModelProvider.OLLAMA, requires_api_key=False),
+    ModelConfig(
+        name="gemini-2.5-flash",
+        provider=CloudModelProvider.GOOGLE,
+        api_key=os.getenv("GEMINI_API_KEY")
+    ),
+    ModelConfig(
+        name="ollama-qwen2.5:7b",
+        provider="ollama",
+        requires_api_key=False,
+    ),
 ]
 
 

--- a/tests/arduino/app_bricks/cloud_llm/conftest.py
+++ b/tests/arduino/app_bricks/cloud_llm/conftest.py
@@ -38,11 +38,7 @@ class ModelConfig:
 
 
 models_to_test = [
-    ModelConfig(
-        name="gemini-2.5-flash",
-        provider=CloudModelProvider.GOOGLE,
-        api_key=os.getenv("GEMINI_API_KEY")
-    ),
+    ModelConfig(name="gemini-2.5-flash", provider=CloudModelProvider.GOOGLE, api_key=os.getenv("GEMINI_API_KEY")),
     ModelConfig(
         name="ollama-qwen2.5:7b",
         provider="ollama",

--- a/tests/arduino/app_bricks/cloud_llm/fixtures/judge_model.py
+++ b/tests/arduino/app_bricks/cloud_llm/fixtures/judge_model.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import os
+import pytest
+
+from deepeval.models import GeminiModel
+
+
+@pytest.fixture(scope="session")
+def judge_model():
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise RuntimeError("GEMINI_API_KEY environment variable is not set for judge model")
+
+    return GeminiModel(
+        model=os.getenv("DEEPEVAL_JUDGE_MODEL", "gemini-3-pro-preview"),
+        api_key=api_key,
+    )

--- a/tests/arduino/app_bricks/cloud_llm/fixtures/model_factory.py
+++ b/tests/arduino/app_bricks/cloud_llm/fixtures/model_factory.py
@@ -1,5 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
 import pytest
 from langchain_ollama import ChatOllama
+
 
 @pytest.fixture(autouse=True)
 def model_factory_fixture(monkeypatch):
@@ -13,7 +18,7 @@ def model_factory_fixture(monkeypatch):
             name = model_name.split("-", 1)[1]
             return ChatOllama(base_url=base_url, model=name)
 
-        return real_model_factory(model_name, **kwargs) # type: ignore
+        return real_model_factory(model_name, **kwargs)  # type: ignore
 
     monkeypatch.setattr(cloud_llm, "model_factory", _model_factory)
     yield

--- a/tests/arduino/app_bricks/cloud_llm/fixtures/model_factory.py
+++ b/tests/arduino/app_bricks/cloud_llm/fixtures/model_factory.py
@@ -1,0 +1,19 @@
+import pytest
+from langchain_ollama import ChatOllama
+
+@pytest.fixture(autouse=True)
+def model_factory_fixture(monkeypatch):
+    import arduino.app_bricks.cloud_llm.cloud_llm as cloud_llm
+
+    real_model_factory = cloud_llm.model_factory
+
+    def _model_factory(model_name: str, **kwargs):
+        if model_name.startswith("ollama"):
+            base_url = kwargs.pop("base_url", "http://localhost:11434")
+            name = model_name.split("-", 1)[1]
+            return ChatOllama(base_url=base_url, model=name)
+
+        return real_model_factory(model_name, **kwargs) # type: ignore
+
+    monkeypatch.setattr(cloud_llm, "model_factory", _model_factory)
+    yield

--- a/tests/arduino/app_bricks/cloud_llm/fixtures/runners.py
+++ b/tests/arduino/app_bricks/cloud_llm/fixtures/runners.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import pytest
+import importlib
+import pkgutil
+from typing import Callable, Tuple, List, cast
+
+from arduino.app_bricks.cloud_llm import CloudLLM
+from runners.__init__ import ToolTrace
+from conftest import ModelConfig
+
+from deepeval.test_case import ToolCall
+
+
+Runner = Callable[[ModelConfig, str], Tuple[CloudLLM, str, ToolTrace]]
+ExecuteRunner = Callable[[str, ModelConfig, str], Tuple[str, List[ToolCall], List[ToolCall]]]
+
+
+@pytest.fixture(scope="session")
+def runners_registry():
+    registry: dict[str, Runner] = {}
+    package = "runners"
+    module = importlib.import_module(package)
+
+    for _, name, _ in pkgutil.iter_modules(module.__path__):
+        mod = importlib.import_module(f"{package}.{name}")
+        found = False
+        for attr_name in dir(mod):
+            attr = getattr(mod, attr_name)
+            if not callable(attr):
+                continue
+            if getattr(attr, "__module__", None) != mod.__name__:
+                continue
+            found = True
+            runner = cast(Runner, attr)
+            registry[f"{name}.{attr_name}"] = runner
+        if not found:
+            raise RuntimeError(f"Module {name} has no run* function")
+
+    return registry
+
+
+@pytest.fixture(scope="module")
+def runners_cache():
+    return {}
+
+
+@pytest.fixture
+def execute_runner(runners_registry, runners_cache) -> ExecuteRunner:
+    """
+    execute_runner(name, model, prompt) -> (response_text, available_tools, tools_called)
+    Caches executions to avoid redundant calls.
+    """
+
+    def _normalize_llm_response(response) -> str:
+        if response is None:
+            return ""
+        if isinstance(response, str):
+            return response
+        if isinstance(response, list):
+            if all(isinstance(x, str) for x in response):
+                return "\n".join(response)
+            return "\n".join(map(str, response))
+        return str(response)
+
+    def _execute_runner(name: str, model: ModelConfig, prompt: str) -> Tuple[str, List[ToolCall], List[ToolCall]]:
+        key = (name, model.name, model.provider, prompt)
+
+        if key not in runners_cache:
+            runner = cast(Runner, runners_registry[name])
+            llm, response_raw, tool_trace = runner(model, prompt)
+            tools = getattr(llm, "_tools", [])
+            available_tools = [ToolCall(name=tool.name, input_parameters={}) for tool in tools]
+            called_tools = [ToolCall(name=call.name, input_parameters=call.input_parameters) for call in tool_trace.tool_calls]
+            response_text = _normalize_llm_response(response_raw)
+            runners_cache[key] = (response_text, available_tools, called_tools)
+
+        return runners_cache[key]
+
+    return _execute_runner

--- a/tests/arduino/app_bricks/cloud_llm/runners/__init__.py
+++ b/tests/arduino/app_bricks/cloud_llm/runners/__init__.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import json
+import inspect
+from functools import wraps
+from typing import get_type_hints, cast
+from uuid import UUID
+
+from conftest import ModelConfig
+
+from deepeval.test_case import ToolCall
+from langchain_core.callbacks import BaseCallbackHandler
+
+
+class ToolCallWithRunId(ToolCall):
+    run_id: str | None = None
+
+
+class ToolTrace(BaseCallbackHandler):
+    def __init__(self):
+        self.tool_calls: list[ToolCallWithRunId] = []
+
+    def _serialize_run_id(self, run_id: UUID | str | None) -> str | None:
+        if run_id is None:
+            return None
+        if isinstance(run_id, UUID):
+            return str(run_id)
+        return run_id
+
+    def on_tool_start(self, serialized, input_str, *, run_id, **kwargs):
+        name = serialized.get("name", "unknown")
+        args = kwargs.get("inputs")
+        if args is None:
+            try:
+                args = json.loads(input_str)
+            except Exception:
+                args = input_str
+
+        self.tool_calls.append(ToolCallWithRunId(name=name, input_parameters=args, run_id=self._serialize_run_id(run_id)))
+
+    def on_tool_end(self, output, *, run_id, **_):
+        run_id = self._serialize_run_id(run_id)
+        for call in self.tool_calls:
+            if call.run_id == run_id:
+                call.output = output
+                break
+
+
+def runner(fn):
+    sig = inspect.signature(fn)
+    params = list(sig.parameters.values())
+    if len(params) != 3:
+        raise TypeError(f"{fn.__name__} must have exactly 3 parameters: (model, prompt, tool_trace)")
+
+    p_model, p_prompt, p_tool_trace = params
+    if p_model.name != "model" or p_prompt.name != "prompt" or p_tool_trace.name != "tool_trace":
+        raise TypeError(f"{fn.__name__} parameters must be named exactly (model, prompt, tool_trace)")
+
+    hints = get_type_hints(fn)
+    if hints.get("model") is not ModelConfig:
+        raise TypeError(f"{fn.__name__}: 'model' must be annotated as ModelConfig")
+    if hints.get("prompt") is not str:
+        raise TypeError(f"{fn.__name__}: 'prompt' must be annotated as str")
+    if hints.get("tool_trace") is not ToolTrace:
+        raise TypeError(f"{fn.__name__}: 'tool_trace' must be annotated as ToolTrace")
+
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        model = args[0] if args else kwargs.get("model")
+        model = cast(ModelConfig, model)
+
+        if model.requires_api_key and not model.api_key:
+            raise RuntimeError(f"{fn.__name__}: API key required but not provided for model {model}")
+
+        tool_trace = ToolTrace()
+        kwargs["tool_trace"] = tool_trace
+
+        result = fn(*args, **kwargs)
+        if not isinstance(result, tuple) or len(result) != 2:
+            raise TypeError(f"{fn.__name__} must return a Tuple[CloudLLM, str]")
+
+        return *result, tool_trace
+
+    return wrapper

--- a/tests/arduino/app_bricks/cloud_llm/runners/home_automation.py
+++ b/tests/arduino/app_bricks/cloud_llm/runners/home_automation.py
@@ -21,14 +21,12 @@ def _run(
     tool_trace: ToolTrace,
     tools: List[Any] = [],
 ) -> Tuple[CloudLLM, str]:
-    mcp_client = MultiServerMCPClient(
-        {
-            "home_automation": {
-                "transport": "streamable_http",
-                "url": f"http://localhost:{port}/mcp",
-            }
+    mcp_client = MultiServerMCPClient({
+        "home_automation": {
+            "transport": "streamable_http",
+            "url": f"http://localhost:{port}/mcp",
         }
-    )
+    })
 
     mcp_tools = asyncio.run(mcp_client.get_tools())
     tools.extend(mcp_tools)

--- a/tests/arduino/app_bricks/cloud_llm/runners/home_automation.py
+++ b/tests/arduino/app_bricks/cloud_llm/runners/home_automation.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from conftest import ModelConfig
+from arduino.app_bricks.cloud_llm import CloudLLM
+from stubs.weather_tool import get_current_weather
+from runners import runner, ToolTrace
+
+
+def _run(
+    model: ModelConfig,
+    prompt: str,
+    port: int,
+    tool_trace: ToolTrace,
+    tools: Optional[List[Any]] = None,
+) -> Tuple[CloudLLM, str]:
+    llm_kwargs: Dict[str, Any] = {
+        "model": model.name,
+        "temperature": 0,
+        "api_key": model.api_key,
+        "mcp_servers": [
+            {
+                "name": "home_automation",
+                "connection": {
+                    "transport": "streamable_http",
+                    "url": f"http://localhost:{port}/mcp",
+                },
+            }
+        ],
+        "callbacks": [tool_trace],
+    }
+
+    if tools:
+        llm_kwargs["tools"] = tools
+
+    llm = CloudLLM(**llm_kwargs)
+    llm_response = llm.chat(prompt)
+
+    return llm, llm_response
+
+
+@runner
+def run_granular(model: ModelConfig, prompt: str, tool_trace: ToolTrace) -> Tuple[CloudLLM, str]:
+    return _run(model=model, prompt=prompt, port=8000, tool_trace=tool_trace)
+
+
+@runner
+def run_granular_with_weather(model: ModelConfig, prompt: str, tool_trace: ToolTrace) -> Tuple[CloudLLM, str]:
+    return _run(model=model, prompt=prompt, port=8000, tools=[get_current_weather], tool_trace=tool_trace)
+
+
+@runner
+def run_object(model: ModelConfig, prompt: str, tool_trace: ToolTrace) -> Tuple[CloudLLM, str]:
+    return _run(model=model, prompt=prompt, port=8001, tool_trace=tool_trace)
+
+
+@runner
+def run_object_with_weather(model: ModelConfig, prompt: str, tool_trace: ToolTrace) -> Tuple[CloudLLM, str]:
+    return _run(model=model, prompt=prompt, port=8001, tools=[get_current_weather], tool_trace=tool_trace)

--- a/tests/arduino/app_bricks/cloud_llm/runners/home_automation.py
+++ b/tests/arduino/app_bricks/cloud_llm/runners/home_automation.py
@@ -3,13 +3,15 @@
 # SPDX-License-Identifier: MPL-2.0
 
 from __future__ import annotations
-
-from typing import Any, Dict, List, Optional, Tuple
+import asyncio
+from typing import Any, Dict, List, Tuple
 
 from conftest import ModelConfig
 from arduino.app_bricks.cloud_llm import CloudLLM
 from stubs.weather_tool import get_current_weather
 from runners import runner, ToolTrace
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
 
 
 def _run(
@@ -17,26 +19,28 @@ def _run(
     prompt: str,
     port: int,
     tool_trace: ToolTrace,
-    tools: Optional[List[Any]] = None,
+    tools: List[Any] = [],
 ) -> Tuple[CloudLLM, str]:
+    mcp_client = MultiServerMCPClient(
+        {
+            "home_automation": {
+                "transport": "streamable_http",
+                "url": f"http://localhost:{port}/mcp",
+            }
+        }
+    )
+
+    mcp_tools = asyncio.run(mcp_client.get_tools())
+    tools.extend(mcp_tools)
+
     llm_kwargs: Dict[str, Any] = {
         "model": model.name,
+        "base_url": model.base_url,
         "temperature": 0,
         "api_key": model.api_key,
-        "mcp_servers": [
-            {
-                "name": "home_automation",
-                "connection": {
-                    "transport": "streamable_http",
-                    "url": f"http://localhost:{port}/mcp",
-                },
-            }
-        ],
+        "tools": tools,
         "callbacks": [tool_trace],
     }
-
-    if tools:
-        llm_kwargs["tools"] = tools
 
     llm = CloudLLM(**llm_kwargs)
     llm_response = llm.chat(prompt)

--- a/tests/arduino/app_bricks/cloud_llm/runners/weather.py
+++ b/tests/arduino/app_bricks/cloud_llm/runners/weather.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from typing import Tuple
+
+from arduino.app_bricks.cloud_llm import CloudLLM
+from stubs.weather_tool import get_current_weather
+from conftest import ModelConfig
+from runners import runner, ToolTrace
+
+
+@runner
+def run(model: ModelConfig, prompt: str, tool_trace: ToolTrace) -> Tuple[CloudLLM, str]:
+    llm = CloudLLM(
+        model=model.name,
+        temperature=0,
+        api_key=model.api_key,
+        tools=[get_current_weather],  # pyright: ignore[reportArgumentType]
+        callbacks=[tool_trace],
+    )
+
+    llm_response = llm.chat(prompt)
+
+    return llm, llm_response

--- a/tests/arduino/app_bricks/cloud_llm/stubs/granular_mcp_server.py
+++ b/tests/arduino/app_bricks/cloud_llm/stubs/granular_mcp_server.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import random
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from mcp.server.fastmcp import FastMCP
+
+
+def granular_mcp_server_factory(port: int) -> FastAPI:
+    mcp = FastMCP("home_automation", port=port)
+
+    thermostat_temperatures = {}
+
+    @mcp.tool()
+    def turn_on_light(room: str) -> str:
+        """Turn on the light in the specified room."""
+        return f"The light in the {room} has been turned on."
+
+    @mcp.tool()
+    def turn_off_light(room: str) -> str:
+        """Turn off the light in the specified room."""
+        return f"The light in the {room} has been turned off."
+
+    @mcp.tool()
+    def set_thermostat(temperature: float, room: str) -> str:
+        """Set the thermostat of the air conditioner to the specified temperature in the specified room."""
+        thermostat_temperatures[room] = temperature
+        return f"The thermostat has been set to {temperature}°C in the {room}."
+
+    @mcp.tool()
+    def get_thermostat(room: str) -> int:
+        """Get the current thermostat temperature of the air conditioner in the specified room."""
+        return thermostat_temperatures.get(room, 22)
+
+    @mcp.tool()
+    def turn_on_ac(room: str) -> str:
+        """Turn on the air conditioner in the specified room."""
+        return f"The air conditioner in the {room} has been turned on."
+
+    @mcp.tool()
+    def turn_off_ac(room: str) -> str:
+        """Turn off the air conditioner in the specified room."""
+        return f"The air conditioner in the {room} has been turned off."
+
+    @mcp.tool()
+    def get_temperature(room: str) -> float:
+        """Get the current temperature in the specified room."""
+        return round(random.uniform(18.0, 30.0), 2)
+
+    mcp_app = mcp.streamable_http_app()
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        async with mcp.session_manager.run():
+            yield
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    app.mount("/", mcp_app)
+
+    return app

--- a/tests/arduino/app_bricks/cloud_llm/stubs/object_mcp_server.py
+++ b/tests/arduino/app_bricks/cloud_llm/stubs/object_mcp_server.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from contextlib import asynccontextmanager
+import random
+
+from fastapi import FastAPI
+from mcp.server.fastmcp import FastMCP
+
+
+def object_mcp_server_factory(port: int) -> FastAPI:
+    mcp = FastMCP("home_automation", port=port)
+
+    acStatuses = {}
+
+    @mcp.tool()
+    def light_control(state: bool, room: str) -> str:
+        action = "turned on" if state else "turned off"
+        return f"The light in the {room} has been {action}."
+
+    @mcp.tool()
+    def air_conditioner_control(state: bool, temperature: float, room: str) -> str:
+        acStatuses[room] = state
+        return (
+            f"The air conditioner in the {room} has been turned on and set to {temperature}°C."
+            if state
+            else f"The air conditioner in the {room} has been turned off."
+        )
+
+    @mcp.tool()
+    def get_room_temperature(room: str) -> int:
+        return random.randint(18, 30)
+
+    @mcp.tool()
+    def get_ac_status(room: str) -> str:
+        return "on" if acStatuses.get(room, False) else "off"
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        async with mcp.session_manager.run():
+            yield
+
+    app = FastAPI(lifespan=lifespan)
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok"}
+
+    app.mount("/", mcp.streamable_http_app())
+
+    return app

--- a/tests/arduino/app_bricks/cloud_llm/stubs/weather_tool.py
+++ b/tests/arduino/app_bricks/cloud_llm/stubs/weather_tool.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from arduino.app_bricks.cloud_llm import tool
+
+
+@tool
+def get_current_weather(location: str) -> str:
+    """
+    Get the current weather in a given location.
+    The output is a string with a summary of the weather.
+    """
+
+    if "boston" in location.lower():
+        return "The current weather in Boston is -5 C and rainy."
+    elif "paris" in location.lower():
+        return "The current weather in Paris is 8 C and rainy."
+    elif "turin" in location.lower():
+        return "The current weather in Turin is 8 C and rainy."
+    else:
+        return f"Sorry, I do not have real-time weather data for {location}. Assuming it's a sunny day!"

--- a/tests/arduino/app_bricks/cloud_llm/test_cloud_llm.py
+++ b/tests/arduino/app_bricks/cloud_llm/test_cloud_llm.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import pytest
+from typing import cast
+
+from conftest import load_dataset
+
+from deepeval import assert_test
+from deepeval.test_case import LLMTestCaseParams, ToolCallParams
+from deepeval.metrics import BaseMetric, GEval, ToolCorrectnessMetric
+
+
+dataset = load_dataset()
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    dataset.test_cases,
+)
+def test_cloud_llm(test_case, execute_runner, judge_model):
+    meta = cast(dict, test_case.additional_metadata)
+
+    response_text, available_tools, tools_called = execute_runner(
+        name=meta["runner_name"],
+        model=meta["model"],
+        prompt=test_case.input,
+    )
+
+    test_case.actual_output = response_text
+    test_case.tools_called = tools_called
+
+    metrics: list[BaseMetric] = []
+
+    if test_case.expected_tools:
+        metrics.append(
+            ToolCorrectnessMetric(
+                strict_mode=True,
+                available_tools=available_tools,
+                model=judge_model,
+                evaluation_params=[ToolCallParams.INPUT_PARAMETERS],
+                verbose_mode=True,
+            )
+        )
+
+    semantic_test = meta.get("semantic", None)
+    if semantic_test:
+        criteria = semantic_test.get("criteria", None)
+        evaluation_steps = semantic_test.get("evaluation_steps", [])
+        min_score = semantic_test.get("min_score", 0.75)
+        metrics.append(
+            GEval(
+                name="semantic evaluation",
+                model=judge_model,
+                evaluation_params=[LLMTestCaseParams.ACTUAL_OUTPUT],
+                criteria=criteria,
+                evaluation_steps=evaluation_steps,
+                threshold=min_score,
+                verbose_mode=True,
+            )
+        )
+
+    assert_test(test_case, metrics)


### PR DESCRIPTION
- Introduces integration tests between LLMs and external resources, using the `cloud_llm` brick and [DeepEval](https://deepeval.com/) to run the tests. The tests cover both single-step and multi-step function calling, including MCP servers.
- Fixes a bug that caused history messages to be shared across different instances of the cloud_llm brick.
- Adds support for multi-step function calling.