### PR TITLE
feat: Add message size error code to Bridge

### DIFF
--- a/src/arduino/app_utils/bridge.py
+++ b/src/arduino/app_utils/bridge.py
@@ -627,11 +627,7 @@ class ClientServer(metaclass=SingletonMeta):
         try:
             packed_data = msgpack.packb(msg)
             if len(packed_data) > _max_message_size:
-                logger.error(
-                    f"Response for msgid {msgid} exceeds maximum message size "
-                    f"({len(packed_data)} > {_max_message_size} bytes). Sending error response instead."
-                )
-                # Send a minimal error response instead
+                logger.error(f"Response for msgid {msgid} exceeds maximum message size ({len(packed_data)} > {_max_message_size} bytes).")
                 error_msg = [1, msgid, [GENERIC_ERR, "Response too large"], None]
                 packed_data = msgpack.packb(error_msg)
             self._send_bytes(packed_data)

--- a/src/arduino/app_utils/bridge.py
+++ b/src/arduino/app_utils/bridge.py
@@ -20,6 +20,7 @@ _reconnect_delay = 3.0  # seconds
 
 # Error codes for RPC messages received from the RPC router. These are defined in the RPC router itself.
 ROUTE_ALREADY_EXISTS_ERR = 0x05
+BUFFER_LIMIT_EXCEEDED_ERR = 0x06
 
 # Error codes for RPC messages sent to Arduino_RPClite. These are defined in the lib itself.
 MALFORMED_CALL_ERR = 0xFD

--- a/src/arduino/app_utils/bridge.py
+++ b/src/arduino/app_utils/bridge.py
@@ -627,7 +627,11 @@ class ClientServer(metaclass=SingletonMeta):
         try:
             packed_data = msgpack.packb(msg)
             if len(packed_data) > _max_message_size:
-                logger.error(f"Response for msgid {msgid} exceeds maximum message size ({len(packed_data)} > {_max_message_size} bytes).")
+                logger.error(
+                    f"Response for msgid {msgid} exceeds maximum message size "
+                    f"({len(packed_data)} > {_max_message_size} bytes). Sending error response instead."
+                )
+                # Send a minimal error response instead
                 error_msg = [1, msgid, [GENERIC_ERR, "Response too large"], None]
                 packed_data = msgpack.packb(error_msg)
             self._send_bytes(packed_data)

--- a/src/arduino/app_utils/bridge.py
+++ b/src/arduino/app_utils/bridge.py
@@ -17,7 +17,6 @@ logger = Logger("Bridge")
 
 
 _reconnect_delay = 3.0  # seconds
-_max_message_size = 256  # Maximum message size supported by Arduino router (bytes)
 
 # Error codes for RPC messages received from the RPC router. These are defined in the RPC router itself.
 ROUTE_ALREADY_EXISTS_ERR = 0x05
@@ -304,13 +303,7 @@ class ClientServer(metaclass=SingletonMeta):
         """Sends a notification to the server without waiting for a response."""
         request = [2, method_name, params]
         try:
-            packed_data = msgpack.packb(request)
-            if len(packed_data) > _max_message_size:
-                logger.error(
-                    f"Notification '{method_name}' exceeds maximum message size ({len(packed_data)} > {_max_message_size} bytes). Message dropped."
-                )
-                return
-            self._send_bytes(packed_data)
+            self._send_bytes(msgpack.packb(request))
         except ConnectionError:
             # Fire-and-forget semantics
             pass
@@ -334,14 +327,7 @@ class ClientServer(metaclass=SingletonMeta):
             self.callbacks[msgid] = (on_result, on_error)
 
         try:
-            packed_data = msgpack.packb(request)
-            if len(packed_data) > _max_message_size:
-                with self.callbacks_lock:
-                    self.callbacks.pop(msgid, None)
-                raise ValueError(
-                    f"Request '{method_name}' exceeds maximum message size ({len(packed_data)} > {_max_message_size} bytes). Call aborted."
-                )
-            self._send_bytes(packed_data)
+            self._send_bytes(msgpack.packb(request))
         except Exception as e:
             with self.callbacks_lock:
                 self.callbacks.pop(msgid, None)
@@ -625,16 +611,7 @@ class ClientServer(metaclass=SingletonMeta):
 
         msg = [1, msgid, err, response]
         try:
-            packed_data = msgpack.packb(msg)
-            if len(packed_data) > _max_message_size:
-                logger.error(
-                    f"Response for msgid {msgid} exceeds maximum message size "
-                    f"({len(packed_data)} > {_max_message_size} bytes). Sending error response instead."
-                )
-                # Send a minimal error response instead
-                error_msg = [1, msgid, [GENERIC_ERR, "Response too large"], None]
-                packed_data = msgpack.packb(error_msg)
-            self._send_bytes(packed_data)
+            self._send_bytes(msgpack.packb(msg))
         except ConnectionError:
             pass  # Response sending is best-effort if connection drops while handling request.
         except Exception as e:  # e.g., msgpack encoding error

--- a/tests/arduino/app_utils/bridge/test_integration.py
+++ b/tests/arduino/app_utils/bridge/test_integration.py
@@ -14,6 +14,7 @@ import queue
 from unittest.mock import MagicMock, patch
 
 from arduino.app_utils.bridge import ClientServer
+from arduino.app_utils.bridge import BUFFER_LIMIT_EXCEEDED_ERR
 
 
 class TestIntegration(unittest.TestCase):
@@ -221,3 +222,38 @@ class TestIntegration(unittest.TestCase):
                 time_waited += 0.1
 
             self.assertEqual(len(connections), 2, "Client did not reconnect in time")
+
+    def test_router_returns_buffer_limit_error(self):
+        """Simulate router rejecting a request due to buffer limit and verify ClientServer propagates the error."""
+        server_ready = threading.Event()
+
+        def server_logic():
+            server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server_sock.bind(self.socket_path)
+            server_sock.listen(1)
+            server_ready.set()
+            conn, _ = server_sock.accept()
+            unpacker = msgpack.Unpacker(raw=False)
+            data = conn.recv(4096)
+            unpacker.feed(data)
+            req = next(unpacker)
+
+            # Send a response containing the buffer-limit error
+            resp = [1, req[1], [BUFFER_LIMIT_EXCEEDED_ERR, f"message size exceeds the limit of {128} bytes"], None]
+            conn.sendall(msgpack.packb(resp))
+
+            self.stop_server.wait()
+            conn.close()
+            server_sock.close()
+
+        self.server_thread = threading.Thread(target=server_logic, daemon=True)
+        self.server_thread.start()
+        self.assertTrue(server_ready.wait(timeout=2), "Server did not become ready")
+
+        client = ClientServer(address=f"unix://{self.socket_path}")
+        client._is_connected_flag.wait(timeout=2)
+
+        with self.assertRaises(ValueError) as cm:
+            client.call("some_method")
+
+        self.assertIn("message size exceeds the limit", str(cm.exception))

--- a/tests/arduino/app_utils/bridge/test_unit_errors.py
+++ b/tests/arduino/app_utils/bridge/test_unit_errors.py
@@ -4,7 +4,7 @@
 
 from unittest.mock import MagicMock
 
-from arduino.app_utils.bridge import ClientServer, GENERIC_ERR
+from arduino.app_utils.bridge import ClientServer, GENERIC_ERR, BUFFER_LIMIT_EXCEEDED_ERR
 from test_unit_common import UnitTest
 
 
@@ -76,3 +76,23 @@ class TestErrors(UnitTest):
         on_error_1.assert_called_once_with(reason)
         on_error_2.assert_called_once_with(reason)
         self.assertEqual(len(client.callbacks), 0)
+
+    def test_buffer_limit_error_propagates(self):
+        """Test that a BUFFER_LIMIT_EXCEEDED_ERR response is propagated to the registered callback."""
+        client = ClientServer()
+        client._send_bytes = MagicMock()
+
+        method_name = "test_buffer_limit"
+        error_response = [BUFFER_LIMIT_EXCEEDED_ERR, "message size exceeds limit of 128 bytes"]
+        msgid = client.next_msgid + 1
+
+        def side_effect(*args, **kwargs):
+            _, on_error = client.callbacks[msgid]
+            on_error(error_response)
+
+        client._send_bytes.side_effect = side_effect
+
+        with self.assertRaises(ValueError) as cm:
+            client.call(method_name)
+
+        self.assertIn("message size exceeds limit", str(cm.exception))


### PR DESCRIPTION
## Add message size error code to Bridge
The [Arduino router bridge](https://github.com/arduino/arduino-router) has a message size limitation of 256 bytes. When messages exceeding this limit are sent, the application crashes or blocks threads/processes instead of handling the error gracefully.

This PR adds a proper error code for this error in the already existing error handling and tests.

### Changes
- **Added** `BUFFER_LIMIT_EXCEEDED_ERR` error code according to the [new error code](https://github.com/arduino/arduino-router/blob/387994f4ccbe8a6f7616245ba04273697199816b/internal/msgpackrouter/errors.go#L27)
- **Added** unit and integration tests

### References
#### Code
- Arduino router: https://github.com/arduino/arduino-router
- Arduino_RPClite library buffer size definition: 
  - https://github.com/arduino-libraries/Arduino_RPClite/blob/main/src/request.h#L15
  - https://github.com/arduino-libraries/Arduino_RPClite/blob/main/src/Arduino_RPClite.h#L17
#### Issues
- https://github.com/arduino-libraries/Arduino_RouterBridge/issues/54
- https://github.com/arduino/arduino-router/issues/26
#### PRs
- https://github.com/arduino-libraries/Arduino_RouterBridge/pull/55
- https://github.com/arduino/arduino-router/pull/30