### PR TITLE
Add clear method to WindowedChatMessageHistory of CloudLLM brick

### DIFF
--- a/src/arduino/app_bricks/cloud_llm/memory.py
+++ b/src/arduino/app_bricks/cloud_llm/memory.py
@@ -43,3 +43,7 @@ class WindowedChatMessageHistory:
             return [self._system_message] + self.messages
         else:
             return self.messages
+
+    def clear(self) -> None:
+        """Clear the message history."""
+        self.messages = []


### PR DESCRIPTION
The clear method of the the `WindowedChatMessageHistory` was not implemented causing errors when calling the `CloudLLM.clear_memory()` method