### PR TITLE
fix camera code detection brick

### DIFF
--- a/src/arduino/app_bricks/camera_code_detection/detection.py
+++ b/src/arduino/app_bricks/camera_code_detection/detection.py
@@ -8,10 +8,10 @@ from typing import Callable
 
 from pyzbar.pyzbar import decode, ZBarSymbol, PyZbarError
 import numpy as np
-from PIL.Image import Image, fromarray
+from PIL.Image import Image
 
 from arduino.app_peripherals.camera import Camera, BaseCamera
-from arduino.app_utils.image import greyscale
+from arduino.app_utils.image import greyscale, numpy_to_pil
 from arduino.app_utils import brick, Logger
 
 logger = Logger("CameraCodeDetection")
@@ -154,7 +154,7 @@ class CameraCodeDetection:
             self._on_error(e)
             return
 
-        pil_frame = fromarray(frame)
+        pil_frame = numpy_to_pil(frame)
         self._on_frame(pil_frame)
 
         # Use grayscale for barcode/QR code detection

--- a/src/arduino/app_peripherals/usb_camera/__init__.py
+++ b/src/arduino/app_peripherals/usb_camera/__init__.py
@@ -7,7 +7,7 @@ import warnings
 from PIL import Image
 from arduino.app_peripherals.camera import Camera as Camera, CameraReadError as CRE, CameraOpenError as COE
 from arduino.app_peripherals.camera.v4l_camera import V4LCamera
-from arduino.app_utils.image import letterboxed, compressed_to_png
+from arduino.app_utils.image import letterboxed, compressed_to_png, numpy_to_pil
 from arduino.app_utils import Logger
 
 logger = Logger("USB Camera")
@@ -64,7 +64,7 @@ class USBCamera:
                 # If compression is enabled, we expect image_bytes to be in PNG format
                 return Image.open(io.BytesIO(image_bytes))
             else:
-                return Image.fromarray(image_bytes)
+                return numpy_to_pil(image_bytes)
         except Exception as e:
             logger.exception(f"Error converting captured bytes to PIL Image: {e}")
             return None


### PR DESCRIPTION
## Fix Camera Code Detection Brick

This PR fixes issues in the Camera Code Detection brick and improves the image handling utilities.

### Changes

#### 1. Fix Camera Code Detection Brick

- **Replace `Image.fromarray()` with `numpy_to_pil()`**: Updated image conversion calls in both `camera_code_detection/detection.py` and `usb_camera/__init__.py` to use the centralized `numpy_to_pil()` utility function instead of directly calling `Image.fromarray()`. This ensures consistent image handling across the codebase and proper RGB/BGR conversion when needed.

- **Remove unused import**: Removed the `fromarray` import from `PIL.Image` in `camera_code_detection/detection.py` since it's no longer needed.

**Files changed:**
- `src/arduino/app_bricks/camera_code_detection/detection.py`
- `src/arduino/app_peripherals/usb_camera/__init__.py`

#### 2. Export `draw_bounding_box` Utility for Code Detector Brick

- **Make `draw_bounding_box` publicly available**: Added `draw_bounding_box` to the public API of the `camera_code_detection` module by exporting it in `__init__.py`. This allows users to access this utility function for drawing bounding boxes around detected codes in their applications with this brick.

**Files changed:**
- `src/arduino/app_bricks/camera_code_detection/__init__.py`