### PR TITLE
Fix alternate of AI conversation roles when using system prompt

### DIFF
--- a/src/arduino/app_bricks/cloud_llm/cloud_llm.py
+++ b/src/arduino/app_bricks/cloud_llm/cloud_llm.py
@@ -154,7 +154,7 @@ class CloudLLM:
             message = HumanMessage(content=content)
         else:
             message = HumanMessage(content=user_input)
-        
+
         if message is not None:
             messages.append(message)
             self._history.add_messages([message])

--- a/src/arduino/app_bricks/cloud_llm/cloud_llm.py
+++ b/src/arduino/app_bricks/cloud_llm/cloud_llm.py
@@ -143,6 +143,7 @@ class CloudLLM:
                 including system prompt if set.
         """
         messages = self._history.get_messages()
+        message = None
         if images is not None and len(images) > 0:
             content = []
             content.append({"type": "text", "text": user_input})
@@ -150,9 +151,13 @@ class CloudLLM:
                 image_b64 = self._image_to_base64(img)
                 content.append({"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"}})
 
-            messages.append(HumanMessage(content=content))
+            message = HumanMessage(content=content)
         else:
-            messages.append(HumanMessage(content=user_input))
+            message = HumanMessage(content=user_input)
+        
+        if message is not None:
+            messages.append(message)
+            self._history.add_messages([message])
 
         return messages
 
@@ -298,12 +303,12 @@ class CloudLLM:
             raise RuntimeError("CloudLLM brick is not started. Please call start() before generating text.")
         if self._keep_streaming.is_set():
             raise AlreadyGenerating("A streaming response is already in progress. Please stop it before starting a new one.")
+        assistant_chunks: list[str] = []
 
         try:
             self._keep_streaming.set()
             input_messages = self._get_message_with_history(message, images)
 
-            assistant_chunks: list[str] = []
             tool_calls = []
             for token in self._model.stream(input_messages):
                 if not self._keep_streaming.is_set():

--- a/src/arduino/app_bricks/cloud_llm/memory.py
+++ b/src/arduino/app_bricks/cloud_llm/memory.py
@@ -54,7 +54,7 @@ class WindowedChatMessageHistory:
         if self._system_message:
             return [self._system_message] + self._messages
         else:
-            return self._messages
+            return self._messages.copy()
 
     def clear(self) -> None:
         """Clear the message history."""


### PR DESCRIPTION
This PR solves the error with Google based LLM when a system prompt is added to the message thread.
The logged error:
 `Conversation roles must alternate user/assistant/user/assistant/...`

The fix: return a copy of the messages thread array to the `get_messages` and not the pointer of the array; add the new user prompt using the proper method `add_messages` instead of appending elements to the pointer
