### PR TITLE
fix: make group id dynamic

### DIFF
--- a/containers/ei-models-runner/Dockerfile
+++ b/containers/ei-models-runner/Dockerfile
@@ -6,11 +6,8 @@ FROM public.ecr.aws/g7a8t7v6/inference-container-qc-adreno-702:v1.86.2
 
 # Create the user and group needed to run the container as non-root
 RUN set -ex; \
-    groupadd -g 44 video || true; \
-    groupadd -g 29 audio || true; \
-    groupadd -g 991 render || true; \
     groupadd -g 1000 arduino || true; \
-    useradd -u 1000 -g arduino -G audio,video,render -ms /bin/bash arduino
+    useradd -u 1000 -g arduino -ms /bin/bash arduino
 
 # Add all EI OOTB models to the container with specific ownership
 COPY --chown=arduino:arduino ./models/ei-ootb-models/arm64/* /models/ootb/ei/

--- a/containers/python-base/Dockerfile
+++ b/containers/python-base/Dockerfile
@@ -29,13 +29,8 @@ COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/pytho
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 RUN set -ex; \
-    groupadd -g 44 video || true; \
-    groupadd -g 29 audio || true; \
-    groupadd -g 20 dialout || true; \
-    groupadd -g 991 render || true; \
     groupadd -g 1000 arduino || true; \
-    groupadd -g 1001 gpiod || true; \
-    useradd -u 1000 -g arduino -G audio,video,dialout,render,gpiod -ms /bin/bash arduino; \
+    useradd -u 1000 -g arduino -ms /bin/bash arduino; \
     apt-get update -y; \
     apt-get upgrade -y; \
     apt-get install --no-install-recommends -y libglib2.0-0 alsa-utils inotify-tools wget libzbar0 portaudio19-dev; \

--- a/src/arduino/app_bricks/audio_classification/brick_compose.yaml
+++ b/src/arduino/app_bricks/audio_classification/brick_compose.yaml
@@ -8,8 +8,6 @@ services:
         max-file: "2"     
     devices:
       - "/dev/dri:/dev/dri"
-    group_add:
-      - "render"      
     ports:
       - ${BIND_ADDRESS:-127.0.0.1}:1339:1337
     volumes:

--- a/src/arduino/app_bricks/image_classification/brick_compose.yaml
+++ b/src/arduino/app_bricks/image_classification/brick_compose.yaml
@@ -8,8 +8,6 @@ services:
         max-file: "2"     
     devices:
       - "/dev/dri:/dev/dri"
-    group_add:
-      - "render"
     ports:
       - ${BIND_ADDRESS:-127.0.0.1}:1338:1337
     volumes:

--- a/src/arduino/app_bricks/keyword_spotting/brick_compose.yaml
+++ b/src/arduino/app_bricks/keyword_spotting/brick_compose.yaml
@@ -8,8 +8,6 @@ services:
         max-file: "2"     
     devices:
       - "/dev/dri:/dev/dri"
-    group_add:
-      - "render"      
     ports:
       - ${BIND_ADDRESS:-127.0.0.1}:1340:1337
     volumes:

--- a/src/arduino/app_bricks/motion_detection/brick_compose.yaml
+++ b/src/arduino/app_bricks/motion_detection/brick_compose.yaml
@@ -8,8 +8,6 @@ services:
         max-file: "2"     
     devices:
       - "/dev/dri:/dev/dri"
-    group_add:
-      - "render"    
     ports:
       - ${BIND_ADDRESS:-127.0.0.1}:1341:1337
     volumes:

--- a/src/arduino/app_bricks/object_detection/brick_compose.yaml
+++ b/src/arduino/app_bricks/object_detection/brick_compose.yaml
@@ -8,8 +8,6 @@ services:
         max-file: "2"     
     devices:
       - "/dev/dri:/dev/dri"
-    group_add:
-      - "render"
     ports:
       - ${BIND_ADDRESS:-127.0.0.1}:1337:1337
     volumes:

--- a/src/arduino/app_bricks/vibration_anomaly_detection/brick_compose.yaml
+++ b/src/arduino/app_bricks/vibration_anomaly_detection/brick_compose.yaml
@@ -10,8 +10,6 @@ services:
         max-file: "2"     
     devices:
       - "/dev/dri:/dev/dri"
-    group_add:
-      - "render"    
     ports:
       - ${BIND_ADDRESS:-127.0.0.1}:1342:1337
     volumes:

--- a/src/arduino/app_bricks/visual_anomaly_detection/brick_compose.yaml
+++ b/src/arduino/app_bricks/visual_anomaly_detection/brick_compose.yaml
@@ -8,8 +8,6 @@ services:
         max-file: "2"    
     devices:
       - "/dev/dri:/dev/dri"
-    group_add:
-      - "render"      
     ports:
       - ${BIND_ADDRESS:-127.0.0.1}:1343:1337
     volumes:


### PR DESCRIPTION
Remove group definition in bricks and Dockerfile. After [this pr](https://github.com/arduino/arduino-app-cli/pull/242), groups will be injected during the provisioning phase. This prevents conflicts if the host has a different id for the same group name.