### PR TITLE
fix(peripherals): use ALSA card indexes instead of sequential enumeration

### DIFF
--- a/src/arduino/app_peripherals/microphone/alsa_microphone.py
+++ b/src/arduino/app_peripherals/microphone/alsa_microphone.py
@@ -248,7 +248,7 @@ class ALSAMicrophone(BaseMicrophone):
             try:
                 card_name = match.group(2)
                 device_index = int(match.group(3))
-                for card_idx, curr_card_name in enumerate(alsaaudio.cards()):  # Look for the card index
+                for card_idx, curr_card_name in zip(card_indexes, alsaaudio.cards()):
                     if curr_card_name == card_name:
                         return card_idx, device_index
 

--- a/src/arduino/app_peripherals/speaker/alsa_speaker.py
+++ b/src/arduino/app_peripherals/speaker/alsa_speaker.py
@@ -249,7 +249,7 @@ class ALSASpeaker(BaseSpeaker):
             try:
                 card_name = match.group(2)
                 device_index = int(match.group(3))
-                for card_idx, curr_card_name in enumerate(alsaaudio.cards()):  # Look for the card index
+                for card_idx, curr_card_name in zip(card_indexes, alsaaudio.cards()):
                     if curr_card_name == card_name:
                         return card_idx, device_index
 


### PR DESCRIPTION
`_resolve_runtime_ref()` in `ALSAMicrophone` and `ALSASpeaker` used `enumerate(alsaaudio.cards())` which produces sequential Python indexes (0, 1, 2...) instead of actual ALSA card indexes that can be non-contiguous (e.g. 0, 2) when a USB device is removed.

This caused the wrong plug_card_X_dev_Y PCM name to be opened after a device was disconnected and the app restarted.

This PR fix: replace `enumerate()` with` zip(card_indexes(), cards())`, matching the pattern already used in `_list_usb_devices()`.