### PR TITLE
WebUI brick missing on import

### DIFF
--- a/src/arduino/app_bricks/web_ui/README.md
+++ b/src/arduino/app_bricks/web_ui/README.md
@@ -25,7 +25,7 @@ Once started, your application will be accessible via a web browser at `http://<
 ## Code example and usage
 
 ```python
-from app_bricks.web_ui import WebUI
+from arduino.app_bricks.web_ui import WebUI
 
 # Initialize the Web UI server
 web_ui = WebUI()


### PR DESCRIPTION
The brick instructions was missing the `arduino.` on the first line.