### PR TITLE
Remove BPP for plain mode

### DIFF
--- a/src/arduino/app_peripherals/camera/camera.py
+++ b/src/arduino/app_peripherals/camera/camera.py
@@ -82,6 +82,8 @@ class Camera:
                         disables security. Default: "".
                     encrypt (bool): Enable encryption (only effective if secret is provided).
                         Default: False.
+                    auto_reconnect (bool): Whether to automatically attempt to reconnect
+                        if the camera connection is lost. Default: True.
 
         Returns:
             BaseCamera: Appropriate camera implementation instance
@@ -108,8 +110,8 @@ class Camera:
             IP Camera:
 
             ```python
-            camera = Camera("rtsp://192.168.1.100:554/stream", username="admin", password="secret", timeout=15.0)
-            camera = Camera("http://192.168.1.100:8080/video.mp4")
+            camera = Camera("rtsp://192.168.1.100:554/stream")
+            camera = Camera("http://192.168.1.100:8080/video.mp4", username="admin", password="secret")
             ```
 
             WebSocket Camera:

--- a/src/arduino/app_peripherals/camera/websocket_camera.py
+++ b/src/arduino/app_peripherals/camera/websocket_camera.py
@@ -57,7 +57,7 @@ class WebSocketCamera(BaseCamera):
         timeout: int = 3,
         certs_dir_path: str = "/app/certs",
         use_tls: bool = False,
-        secret: str = "",
+        secret: str | None = None,
         encrypt: bool = False,
         resolution: tuple[int, int] = (640, 480),
         fps: int = 10,
@@ -74,17 +74,21 @@ class WebSocketCamera(BaseCamera):
             use_tls (bool): Enable TLS for secure connections. If True, 'encrypt' will
                 be ignored. Use this for transport-level security with clients that can
                 accept self-signed certificates or when supplying your own certificates.
-            secret (str): Pre-shared secret key. When empty (default), security is
-                disabled and clients send raw bytes without BPP wrapping. When set,
-                enables HMAC-SHA256 authentication via BPP.
+            secret (str | None): Pre-shared secret key. When None (default), security
+                is disabled and clients send raw bytes directly. When set to a
+                non-empty string, enables HMAC-SHA256 authentication via BPP protocol.
+                An empty string is not a valid secret and raises RuntimeError.
             encrypt (bool): Enable ChaCha20-Poly1305 encryption via BPP. Requires a
-                non-empty secret; raises RuntimeError otherwise.
+                secret, raises RuntimeError otherwise.
             resolution (tuple[int, int]): Resolution as (width, height)
             fps (int): Frames per second to capture
             adjustments (Callable[[np.ndarray], np.ndarray] | None): Function to adjust frames
             auto_reconnect (bool): Enable automatic reconnection on failure
         """
         super().__init__(resolution, fps, adjustments, auto_reconnect)
+
+        if secret is not None and not secret:
+            raise RuntimeError("Secret must be a non-empty string or None.")
 
         if encrypt and not secret:
             raise RuntimeError("Encryption requires a secret key.")

--- a/src/arduino/app_peripherals/camera/websocket_camera.py
+++ b/src/arduino/app_peripherals/camera/websocket_camera.py
@@ -28,21 +28,23 @@ class WebSocketCamera(BaseCamera):
     """
     WebSocket Camera implementation that hosts a WebSocket server.
 
-    This camera acts as a WebSocket server that receives frames from connected clients.
-    Only one client can be connected at a time.
+    This camera acts as a WebSocket server that receives frames from a connected
+    client. Only one client can be connected at a time.
 
-    Clients must encode video frames in one of these formats:
+    The client must encode video frames in one of these formats:
     - JPEG
     - PNG
     - WebP
     - BMP
     - TIFF
-    The video frames must then be serialized in the binary format supported by BPPCodec.
 
-    Secure communication with the WebSocket server is supported in three security modes:
+    Communication with the WebSocket server is supported in three security modes:
     - Security disabled (empty secret)
     - Authenticated (secret + encrypt=False) - HMAC-SHA256
     - Authenticated + Encrypted (secret + encrypt=True) - ChaCha20-Poly1305
+
+    In security-disabled mode, clients must send raw image bytes directly.
+    In other security modes, data must be serialized using the BPP protocol.
 
     When connecting, clients can specify a "client_name" parameter in the URL query string
     to identify themselves. This name will be sanitized to allow only alphanumeric chars,
@@ -85,7 +87,7 @@ class WebSocketCamera(BaseCamera):
             logger.warning("Encryption is redundant over TLS connections, disabling encryption.")
             encrypt = False
 
-        self.codec = BPPCodec(secret, encrypt)
+        self.codec = BPPCodec(secret, encrypt) if secret else None
         self.secret = secret
         self.encrypt = encrypt
         self.logger = logger
@@ -290,12 +292,14 @@ class WebSocketCamera(BaseCamera):
                 self.logger.warning(f"Failed to decode string message using base64: {e}")
                 return None
 
-        decoded = self.codec.decode(message)
-        if decoded is None:
-            self.logger.warning("Failed to decode message")
-            return None
+        if self.codec:
+            decoded = self.codec.decode(message)
+            if decoded is None:
+                self.logger.warning("Failed to decode message")
+                return None
+            message = decoded
 
-        nparr = np.frombuffer(decoded, np.uint8)
+        nparr = np.frombuffer(message, np.uint8)
         frame = cv2.imdecode(nparr, cv2.IMREAD_UNCHANGED)
         return frame
 
@@ -353,7 +357,7 @@ class WebSocketCamera(BaseCamera):
         if isinstance(message, str):
             message = message.encode()
 
-        encoded = self.codec.encode(message)
+        data = self.codec.encode(message) if self.codec else message
 
         # Keep a ref to current client to avoid locking
         client = client or self._client
@@ -361,7 +365,7 @@ class WebSocketCamera(BaseCamera):
             raise ConnectionError("No client connected")
 
         try:
-            await client.send(encoded)
+            await client.send(data)
         except websockets.ConnectionClosedOK:
             self.logger.warning("Client has already closed the connection")
         except websockets.ConnectionClosedError as e:

--- a/src/arduino/app_peripherals/camera/websocket_camera.py
+++ b/src/arduino/app_peripherals/camera/websocket_camera.py
@@ -74,12 +74,10 @@ class WebSocketCamera(BaseCamera):
             use_tls (bool): Enable TLS for secure connections. If True, 'encrypt' will
                 be ignored. Use this for transport-level security with clients that can
                 accept self-signed certificates or when supplying your own certificates.
-            secret (str | None): Pre-shared secret key. When None (default), security
-                is disabled and clients send raw bytes directly. When set to a
-                non-empty string, enables HMAC-SHA256 authentication via BPP protocol.
-                An empty string is not a valid secret and raises RuntimeError.
-            encrypt (bool): Enable ChaCha20-Poly1305 encryption via BPP. Requires a
-                secret, raises RuntimeError otherwise.
+            secret (str | None): Pre-shared secret key. None disables security.
+                Default: None.
+            encrypt (bool): Enable encryption. Requires a secret, raises
+                RuntimeError otherwise. Default: False.
             resolution (tuple[int, int]): Resolution as (width, height)
             fps (int): Frames per second to capture
             adjustments (Callable[[np.ndarray], np.ndarray] | None): Function to adjust frames
@@ -87,17 +85,14 @@ class WebSocketCamera(BaseCamera):
         """
         super().__init__(resolution, fps, adjustments, auto_reconnect)
 
-        if secret is not None and not secret:
-            raise RuntimeError("Secret must be a non-empty string or None.")
-
-        if encrypt and not secret:
+        if encrypt and secret is None:
             raise RuntimeError("Encryption requires a secret key.")
 
         if use_tls and encrypt:
             logger.warning("Encryption is redundant over TLS connections, disabling encryption.")
             encrypt = False
 
-        self.codec = BPPCodec(secret, encrypt) if secret else None
+        self.codec = BPPCodec(secret, encrypt) if secret is not None else None
         self.secret = secret
         self.encrypt = encrypt
         self.logger = logger
@@ -145,7 +140,7 @@ class WebSocketCamera(BaseCamera):
     @property
     def security_mode(self) -> str:
         """Return current security mode for logging/debugging."""
-        if not self.secret:
+        if self.secret is None:
             return "none"
         elif self.encrypt:
             return "encrypted (ChaCha20-Poly1305)"

--- a/src/arduino/app_peripherals/camera/websocket_camera.py
+++ b/src/arduino/app_peripherals/camera/websocket_camera.py
@@ -74,10 +74,11 @@ class WebSocketCamera(BaseCamera):
             use_tls (bool): Enable TLS for secure connections. If True, 'encrypt' will
                 be ignored. Use this for transport-level security with clients that can
                 accept self-signed certificates or when supplying your own certificates.
-            secret (str | None): Pre-shared secret key. None disables security.
-                Default: None.
-            encrypt (bool): Enable encryption. Requires a secret, raises
-                RuntimeError otherwise. Default: False.
+            secret (str | None): Pre-shared secret key used for HMAC-SHA256
+                authentication, or to derive the ChaCha20-Poly1305 key when
+                encrypt is True. None disables security. Default: None.
+            encrypt (bool): Enable ChaCha20-Poly1305 encryption. Requires a
+                non-None secret; raises RuntimeError otherwise. Default: False.
             resolution (tuple[int, int]): Resolution as (width, height)
             fps (int): Frames per second to capture
             adjustments (Callable[[np.ndarray], np.ndarray] | None): Function to adjust frames

--- a/src/arduino/app_peripherals/camera/websocket_camera.py
+++ b/src/arduino/app_peripherals/camera/websocket_camera.py
@@ -227,7 +227,7 @@ class WebSocketCamera(BaseCamera):
                     if sanitized:
                         client_name = sanitized
                 # Allow raw (no BPP) mode only when security is disabled
-                if "raw" in query_params and query_params["raw"][0].lower() == "true":
+                if "raw" in query_params and (not query_params["raw"] or query_params["raw"][0].lower() != "false"):
                     if self.secret is None:
                         client_raw = True
                     else:

--- a/src/arduino/app_peripherals/camera/websocket_camera.py
+++ b/src/arduino/app_peripherals/camera/websocket_camera.py
@@ -38,13 +38,15 @@ class WebSocketCamera(BaseCamera):
     - BMP
     - TIFF
 
-    Communication with the WebSocket server is supported in three security modes:
-    - Security disabled (empty secret)
-    - Authenticated (secret + encrypt=False) - HMAC-SHA256
-    - Authenticated + Encrypted (secret + encrypt=True) - ChaCha20-Poly1305
+    Communication uses the BPP (Binary Peripheral Protocol) in three security modes:
+    - Security disabled (secret=None) - BPP with no authentication
+    - Authenticated (secret + encrypt=False) - BPP with HMAC-SHA256
+    - Authenticated + Encrypted (secret + encrypt=True) - BPP with ChaCha20-Poly1305
 
-    In security-disabled mode, clients must send raw image bytes directly.
-    In other security modes, data must be serialized using the BPP protocol.
+    By default, all modes use BPP framing. When security is disabled (secret=None),
+    clients can opt out of BPP by connecting with the "raw=true" URL query parameter,
+    allowing them to send raw image bytes directly without BPP wrapping. This parameter
+    is silently ignored when security is enabled.
 
     When connecting, clients can specify a "client_name" parameter in the URL query string
     to identify themselves. This name will be sanitized to allow only alphanumeric chars,
@@ -93,9 +95,10 @@ class WebSocketCamera(BaseCamera):
             logger.warning("Encryption is redundant over TLS connections, disabling encryption.")
             encrypt = False
 
-        self.codec = BPPCodec(secret, encrypt) if secret is not None else None
+        self.codec = BPPCodec(secret or "", encrypt)
         self.secret = secret
         self.encrypt = encrypt
+        self._client_raw = False
         self.logger = logger
         self.name = self.__class__.__name__
 
@@ -210,8 +213,9 @@ class WebSocketCamera(BaseCamera):
 
     async def _ws_handler(self, conn: websockets.ServerConnection) -> None:
         """Handle a connected WebSocket client. Only one client allowed at a time."""
-        # Extract and sanitize client_name from URL parameters
+        # Extract URL parameters: client_name and raw mode opt-in
         client_name = "Unknown"
+        client_raw = False
         if conn.request:
             try:
                 parsed_path = urlparse(conn.request.path)
@@ -222,10 +226,17 @@ class WebSocketCamera(BaseCamera):
                     sanitized = "".join(c for c in raw_name if c.isalnum() or c in " -_")[:64]
                     if sanitized:
                         client_name = sanitized
+                # Allow raw (no BPP) mode only when security is disabled
+                if "raw" in query_params and query_params["raw"][0].lower() == "true":
+                    if self.secret is None:
+                        client_raw = True
+                    else:
+                        self.logger.warning("Client requested raw mode but security is enabled, ignoring.")
             except Exception as e:
-                self.logger.debug(f"Failed to extract client_name from URL parameters: {e}")
+                self.logger.debug(f"Failed to extract URL parameters: {e}")
             finally:
                 self.name = client_name
+                self._client_raw = client_raw
 
         client_addr = f"{conn.remote_address[0]}:{conn.remote_address[1]}"
 
@@ -287,6 +298,7 @@ class WebSocketCamera(BaseCamera):
             async with self._client_lock:
                 if self._client == conn:
                     self._client = None
+                    self._client_raw = False
                     self._set_status("disconnected", {"client_address": client_addr, "client_name": client_name})
                     self.logger.debug(f"Client removed: {client_addr}")
 
@@ -299,7 +311,7 @@ class WebSocketCamera(BaseCamera):
                 self.logger.warning(f"Failed to decode string message using base64: {e}")
                 return None
 
-        if self.codec:
+        if not self._client_raw:
             decoded = self.codec.decode(message)
             if decoded is None:
                 self.logger.warning("Failed to decode message")
@@ -364,7 +376,7 @@ class WebSocketCamera(BaseCamera):
         if isinstance(message, str):
             message = message.encode()
 
-        data = self.codec.encode(message) if self.codec else message
+        data = message if self._client_raw else self.codec.encode(message)
 
         # Keep a ref to current client to avoid locking
         client = client or self._client

--- a/src/arduino/app_peripherals/camera/websocket_camera.py
+++ b/src/arduino/app_peripherals/camera/websocket_camera.py
@@ -74,14 +74,20 @@ class WebSocketCamera(BaseCamera):
             use_tls (bool): Enable TLS for secure connections. If True, 'encrypt' will
                 be ignored. Use this for transport-level security with clients that can
                 accept self-signed certificates or when supplying your own certificates.
-            secret (str): Secret key for authentication/encryption (empty = security disabled)
-            encrypt (bool): Enable encryption (only effective if secret is provided)
+            secret (str): Pre-shared secret key. When empty (default), security is
+                disabled and clients send raw bytes without BPP wrapping. When set,
+                enables HMAC-SHA256 authentication via BPP.
+            encrypt (bool): Enable ChaCha20-Poly1305 encryption via BPP. Requires a
+                non-empty secret; raises RuntimeError otherwise.
             resolution (tuple[int, int]): Resolution as (width, height)
             fps (int): Frames per second to capture
             adjustments (Callable[[np.ndarray], np.ndarray] | None): Function to adjust frames
             auto_reconnect (bool): Enable automatic reconnection on failure
         """
         super().__init__(resolution, fps, adjustments, auto_reconnect)
+
+        if encrypt and not secret:
+            raise RuntimeError("Encryption requires a secret key.")
 
         if use_tls and encrypt:
             logger.warning("Encryption is redundant over TLS connections, disabling encryption.")

--- a/src/arduino/app_peripherals/camera/websocket_camera.py
+++ b/src/arduino/app_peripherals/camera/websocket_camera.py
@@ -228,6 +228,7 @@ class WebSocketCamera(BaseCamera):
                 self.name = client_name
 
         client_addr = f"{conn.remote_address[0]}:{conn.remote_address[1]}"
+
         async with self._client_lock:
             if self._client is not None:
                 # Reject the new client

--- a/src/arduino/app_peripherals/microphone/microphone.py
+++ b/src/arduino/app_peripherals/microphone/microphone.py
@@ -137,8 +137,10 @@ class Microphone:
                     use_tls (bool): Enable TLS for secure connections. If True, 'encrypt' will
                         be ignored. Use this for transport-level security with clients that can
                         accept self-signed certificates or when supplying your own certificates.
-                    secret (str): Secret key for authentication/encryption (empty = security disabled)
-                    encrypt (bool): Enable encryption (only effective if secret is provided)
+                    secret (str | None): Pre-shared secret key. None disables security.
+                        An empty string raises RuntimeError. Default: None.
+                    encrypt (bool): Enable encryption. Requires a secret, raises
+                        RuntimeError otherwise. Default: False.
                     auto_reconnect (bool): Whether to automatically attempt to reconnect
                         if the microphone connection is lost. Default: True.
 
@@ -164,8 +166,8 @@ class Microphone:
             WebSocket Microphone:
 
             ```python
-            microphone = Microphone("ws://0.0.0.0:8080", audio_format="json")
-            microphone = Microphone("ws://192.168.1.100:8080", sample_rate=48000)
+            microphone = Microphone("ws://0.0.0.0:8080", sample_rate=48000)
+            microphone = Microphone("ws://0.0.0.0:8080", secret="topsecret", encrypt=True)
             ```
         """
         if isinstance(device, str):

--- a/src/arduino/app_peripherals/microphone/microphone.py
+++ b/src/arduino/app_peripherals/microphone/microphone.py
@@ -138,7 +138,7 @@ class Microphone:
                         be ignored. Use this for transport-level security with clients that can
                         accept self-signed certificates or when supplying your own certificates.
                     secret (str | None): Pre-shared secret key. None disables security.
-                        An empty string raises RuntimeError. Default: None.
+                        Default: None.
                     encrypt (bool): Enable encryption. Requires a secret, raises
                         RuntimeError otherwise. Default: False.
                     auto_reconnect (bool): Whether to automatically attempt to reconnect

--- a/src/arduino/app_peripherals/microphone/websocket_microphone.py
+++ b/src/arduino/app_peripherals/microphone/websocket_microphone.py
@@ -48,7 +48,7 @@ class WebSocketMicrophone(BaseMicrophone):
         timeout: int = 3,
         certs_dir_path: str = "/app/certs",
         use_tls: bool = False,
-        secret: str = "",
+        secret: str | None = None,
         encrypt: bool = False,
         sample_rate: int = Microphone.RATE_16K,
         channels: int = Microphone.CHANNELS_MONO,
@@ -68,11 +68,12 @@ class WebSocketMicrophone(BaseMicrophone):
                 be ignored. Use this for transport-level security with clients that can
                 accept self-signed certificates or when supplying your own certificates.
                 Default: False.
-            secret (str): Pre-shared secret key. When empty (default), security is
-                disabled and clients send raw PCM bytes without BPP wrapping. When
-                set, enables HMAC-SHA256 authentication via BPP.
+            secret (str | None): Pre-shared secret key. When None (default), security
+                is disabled and clients send raw PCM bytes without BPP wrapping. When
+                set to a non-empty string, enables HMAC-SHA256 authentication via BPP.
+                An empty string is not a valid secret and raises RuntimeError.
             encrypt (bool): Enable ChaCha20-Poly1305 encryption via BPP. Requires a
-                non-empty secret; raises RuntimeError otherwise. Default: False.
+                secret; raises RuntimeError otherwise. Default: False.
             sample_rate (int): Sample rate in Hz. Default: 16000.
             channels (int): Number of audio channels. Default: Microphone.CHANNELS_MONO - 1.
             format (FormatPlain | FormatPacked): Audio format as one of:
@@ -87,6 +88,9 @@ class WebSocketMicrophone(BaseMicrophone):
             auto_reconnect (bool): Enable automatic reconnection on failure.
         """
         super().__init__(sample_rate, channels, format, buffer_size, auto_reconnect)
+
+        if secret is not None and not secret:
+            raise RuntimeError("Secret must be a non-empty string or None.")
 
         if encrypt and not secret:
             raise RuntimeError("Encryption requires a secret key.")

--- a/src/arduino/app_peripherals/microphone/websocket_microphone.py
+++ b/src/arduino/app_peripherals/microphone/websocket_microphone.py
@@ -68,12 +68,10 @@ class WebSocketMicrophone(BaseMicrophone):
                 be ignored. Use this for transport-level security with clients that can
                 accept self-signed certificates or when supplying your own certificates.
                 Default: False.
-            secret (str | None): Pre-shared secret key. When None (default), security
-                is disabled and clients send raw PCM bytes without BPP wrapping. When
-                set to a non-empty string, enables HMAC-SHA256 authentication via BPP.
-                An empty string is not a valid secret and raises RuntimeError.
-            encrypt (bool): Enable ChaCha20-Poly1305 encryption via BPP. Requires a
-                secret; raises RuntimeError otherwise. Default: False.
+            secret (str | None): Pre-shared secret key. None disables security.
+                Default: None.
+            encrypt (bool): Enable encryption. Requires a secret, raises
+                RuntimeError otherwise. Default: False.
             sample_rate (int): Sample rate in Hz. Default: 16000.
             channels (int): Number of audio channels. Default: Microphone.CHANNELS_MONO - 1.
             format (FormatPlain | FormatPacked): Audio format as one of:
@@ -89,17 +87,14 @@ class WebSocketMicrophone(BaseMicrophone):
         """
         super().__init__(sample_rate, channels, format, buffer_size, auto_reconnect)
 
-        if secret is not None and not secret:
-            raise RuntimeError("Secret must be a non-empty string or None.")
-
-        if encrypt and not secret:
+        if encrypt and secret is None:
             raise RuntimeError("Encryption requires a secret key.")
 
         if use_tls and encrypt:
             logger.warning("Encryption is redundant over TLS connections, disabling encryption.")
             encrypt = False
 
-        self.codec = BPPCodec(secret, encrypt) if secret else None
+        self.codec = BPPCodec(secret, encrypt) if secret is not None else None
         self.secret = secret
         self.encrypt = encrypt
         self.logger = logger
@@ -147,7 +142,7 @@ class WebSocketMicrophone(BaseMicrophone):
     @property
     def security_mode(self) -> str:
         """Return current security mode for logging/debugging."""
-        if not self.secret:
+        if self.secret is None:
             return "none"
         elif self.encrypt:
             return "encrypted (ChaCha20-Poly1305)"

--- a/src/arduino/app_peripherals/microphone/websocket_microphone.py
+++ b/src/arduino/app_peripherals/microphone/websocket_microphone.py
@@ -68,10 +68,11 @@ class WebSocketMicrophone(BaseMicrophone):
                 be ignored. Use this for transport-level security with clients that can
                 accept self-signed certificates or when supplying your own certificates.
                 Default: False.
-            secret (str | None): Pre-shared secret key. None disables security.
-                Default: None.
-            encrypt (bool): Enable encryption. Requires a secret, raises
-                RuntimeError otherwise. Default: False.
+            secret (str | None): Pre-shared secret key used for HMAC-SHA256
+                authentication, or to derive the ChaCha20-Poly1305 key when
+                encrypt is True. None disables security. Default: None.
+            encrypt (bool): Enable ChaCha20-Poly1305 encryption. Requires a
+                non-None secret; raises RuntimeError otherwise. Default: False.
             sample_rate (int): Sample rate in Hz. Default: 16000.
             channels (int): Number of audio channels. Default: Microphone.CHANNELS_MONO - 1.
             format (FormatPlain | FormatPacked): Audio format as one of:

--- a/src/arduino/app_peripherals/microphone/websocket_microphone.py
+++ b/src/arduino/app_peripherals/microphone/websocket_microphone.py
@@ -32,13 +32,15 @@ class WebSocketMicrophone(BaseMicrophone):
     The client must encode the audio data in PCM format and must respect the
     sample rate, channels, format, and chunk size specified during initialization.
 
-    Communication with the WebSocket server is supported in three security modes:
-    - Security disabled (empty secret)
-    - Authenticated (secret + encrypt=False) - HMAC-SHA256
-    - Authenticated + Encrypted (secret + encrypt=True) - ChaCha20-Poly1305
+    Communication uses the BPP (Binary Peripheral Protocol) in three security modes:
+    - Security disabled (secret=None) - BPP with no authentication
+    - Authenticated (secret + encrypt=False) - BPP with HMAC-SHA256
+    - Authenticated + Encrypted (secret + encrypt=True) - BPP with ChaCha20-Poly1305
 
-    In security-disabled mode, clients must send raw PCM bytes directly.
-    In other security modes, data must be serialized using the BPP protocol.
+    By default, all modes use BPP framing. When security is disabled (secret=None),
+    clients can opt out of BPP by connecting with the "raw=true" URL query parameter,
+    allowing them to send raw PCM bytes directly without BPP wrapping. This parameter
+    is silently ignored when security is enabled.
 
     When connecting, clients can specify a "client_name" parameter in the URL query string
     to identify themselves. This name will be sanitized to allow only alphanumeric chars,
@@ -100,9 +102,10 @@ class WebSocketMicrophone(BaseMicrophone):
             logger.warning("Encryption is redundant over TLS connections, disabling encryption.")
             encrypt = False
 
-        self.codec = BPPCodec(secret, encrypt) if secret is not None else None
+        self.codec = BPPCodec(secret or "", encrypt)
         self.secret = secret
         self.encrypt = encrypt
+        self._client_raw = False
         self.logger = logger
         self.name = self.__class__.__name__
 
@@ -217,8 +220,9 @@ class WebSocketMicrophone(BaseMicrophone):
 
     async def _ws_handler(self, conn: websockets.ServerConnection) -> None:
         """Handle a connected WebSocket client. Only one client allowed at a time."""
-        # Extract and sanitize client_name from URL parameters
+        # Extract URL parameters: client_name and raw mode opt-in
         client_name = "Unknown"
+        client_raw = False
         if conn.request:
             try:
                 parsed_path = urlparse(conn.request.path)
@@ -229,10 +233,17 @@ class WebSocketMicrophone(BaseMicrophone):
                     sanitized = "".join(c for c in raw_name if c.isalnum() or c in " -_")[:64]
                     if sanitized:
                         client_name = sanitized
+                # Allow raw (no BPP) mode only when security is disabled
+                if "raw" in query_params and query_params["raw"][0].lower() == "true":
+                    if self.secret is None:
+                        client_raw = True
+                    else:
+                        self.logger.warning("Client requested raw mode but security is enabled, ignoring.")
             except Exception as e:
-                self.logger.debug(f"Failed to extract client_name from URL parameters: {e}")
+                self.logger.debug(f"Failed to extract URL parameters: {e}")
             finally:
                 self.name = client_name
+                self._client_raw = client_raw
 
         client_addr = f"{conn.remote_address[0]}:{conn.remote_address[1]}"
 
@@ -301,6 +312,7 @@ class WebSocketMicrophone(BaseMicrophone):
             async with self._client_lock:
                 if self._client == conn:
                     self._client = None
+                    self._client_raw = False
                     self._set_status("disconnected", {"client_address": client_addr, "client_name": client_name})
                     self.logger.debug(f"Client removed: {client_addr}")
 
@@ -313,7 +325,7 @@ class WebSocketMicrophone(BaseMicrophone):
                 self.logger.warning(f"Failed to decode string message using base64: {e}")
                 return None
 
-        if self.codec:
+        if not self._client_raw:
             decoded = self.codec.decode(message)
             if decoded is None:
                 self.logger.warning("Failed to decode message")
@@ -376,7 +388,7 @@ class WebSocketMicrophone(BaseMicrophone):
         if isinstance(message, str):
             message = message.encode()
 
-        data = self.codec.encode(message) if self.codec else message
+        data = message if self._client_raw else self.codec.encode(message)
 
         # Keep a ref to current client to avoid locking
         client = client or self._client

--- a/src/arduino/app_peripherals/microphone/websocket_microphone.py
+++ b/src/arduino/app_peripherals/microphone/websocket_microphone.py
@@ -11,6 +11,7 @@ import numpy as np
 import websockets
 import asyncio
 from concurrent.futures import CancelledError, TimeoutError, Future
+from urllib.parse import urlparse, parse_qs
 
 from arduino.app_internal.core.peripherals import BPPCodec
 from arduino.app_utils import Logger
@@ -38,6 +39,10 @@ class WebSocketMicrophone(BaseMicrophone):
 
     In security-disabled mode, clients must send raw PCM bytes directly.
     In other security modes, data must be serialized using the BPP protocol.
+
+    When connecting, clients can specify a "client_name" parameter in the URL query string
+    to identify themselves. This name will be sanitized to allow only alphanumeric chars,
+    whitespace, hyphens, and underscores, and limit its length to 64 characters.
     """
 
     from .microphone import Microphone
@@ -212,6 +217,23 @@ class WebSocketMicrophone(BaseMicrophone):
 
     async def _ws_handler(self, conn: websockets.ServerConnection) -> None:
         """Handle a connected WebSocket client. Only one client allowed at a time."""
+        # Extract and sanitize client_name from URL parameters
+        client_name = "Unknown"
+        if conn.request:
+            try:
+                parsed_path = urlparse(conn.request.path)
+                query_params = parse_qs(parsed_path.query)
+                if "client_name" in query_params:
+                    raw_name = query_params["client_name"][0]
+                    # Sanitize: only allow alphanumeric, spaces, hyphens, underscores, and limit length
+                    sanitized = "".join(c for c in raw_name if c.isalnum() or c in " -_")[:64]
+                    if sanitized:
+                        client_name = sanitized
+            except Exception as e:
+                self.logger.debug(f"Failed to extract client_name from URL parameters: {e}")
+            finally:
+                self.name = client_name
+
         client_addr = f"{conn.remote_address[0]}:{conn.remote_address[1]}"
 
         async with self._client_lock:
@@ -229,7 +251,7 @@ class WebSocketMicrophone(BaseMicrophone):
             # Accept the client
             self._client = conn
 
-        self._set_status("connected", {"client_address": client_addr})
+        self._set_status("connected", {"client_address": client_addr, "client_name": client_name})
         self.logger.debug(f"Client connected: {client_addr}")
 
         try:
@@ -279,7 +301,7 @@ class WebSocketMicrophone(BaseMicrophone):
             async with self._client_lock:
                 if self._client == conn:
                     self._client = None
-                    self._set_status("disconnected", {"client_address": client_addr})
+                    self._set_status("disconnected", {"client_address": client_addr, "client_name": client_name})
                     self.logger.debug(f"Client removed: {client_addr}")
 
     def _parse_message(self, message: str | bytes) -> np.ndarray | None:

--- a/src/arduino/app_peripherals/microphone/websocket_microphone.py
+++ b/src/arduino/app_peripherals/microphone/websocket_microphone.py
@@ -68,10 +68,11 @@ class WebSocketMicrophone(BaseMicrophone):
                 be ignored. Use this for transport-level security with clients that can
                 accept self-signed certificates or when supplying your own certificates.
                 Default: False.
-            secret (str): Secret key for authentication/encryption (empty = security disabled).
-                Default: empty.
-            encrypt (bool): Enable encryption (only effective if secret is provided).
-                Default: False.
+            secret (str): Pre-shared secret key. When empty (default), security is
+                disabled and clients send raw PCM bytes without BPP wrapping. When
+                set, enables HMAC-SHA256 authentication via BPP.
+            encrypt (bool): Enable ChaCha20-Poly1305 encryption via BPP. Requires a
+                non-empty secret; raises RuntimeError otherwise. Default: False.
             sample_rate (int): Sample rate in Hz. Default: 16000.
             channels (int): Number of audio channels. Default: Microphone.CHANNELS_MONO - 1.
             format (FormatPlain | FormatPacked): Audio format as one of:
@@ -86,6 +87,9 @@ class WebSocketMicrophone(BaseMicrophone):
             auto_reconnect (bool): Enable automatic reconnection on failure.
         """
         super().__init__(sample_rate, channels, format, buffer_size, auto_reconnect)
+
+        if encrypt and not secret:
+            raise RuntimeError("Encryption requires a secret key.")
 
         if use_tls and encrypt:
             logger.warning("Encryption is redundant over TLS connections, disabling encryption.")

--- a/src/arduino/app_peripherals/microphone/websocket_microphone.py
+++ b/src/arduino/app_peripherals/microphone/websocket_microphone.py
@@ -25,19 +25,19 @@ class WebSocketMicrophone(BaseMicrophone):
     """
     WebSocket Microphone implementation that hosts a WebSocket server.
 
-    This microphone exposes a WebSocket server that receives audio chunks from connected
-    clients. Only one client can be connected at a time.
+    This microphone exposes a WebSocket server that receives audio chunks from
+    a connected client. Only one client can be connected at a time.
 
-    Clients must encode the audio data in PCM format and serialize the content in the
-    binary format supported by BPPCodec.
+    The client must encode the audio data in PCM format and must respect the
+    sample rate, channels, format, and chunk size specified during initialization.
 
-    Secure communication with the WebSocket server is supported in three security modes:
+    Communication with the WebSocket server is supported in three security modes:
     - Security disabled (empty secret)
     - Authenticated (secret + encrypt=False) - HMAC-SHA256
     - Authenticated + Encrypted (secret + encrypt=True) - ChaCha20-Poly1305
 
-    Also, clients are expected to respect the sample rate, channels, format, and chunk
-    size specified during initialization.
+    In security-disabled mode, clients must send raw PCM bytes directly.
+    In other security modes, data must be serialized using the BPP protocol.
     """
 
     from .microphone import Microphone
@@ -91,7 +91,7 @@ class WebSocketMicrophone(BaseMicrophone):
             logger.warning("Encryption is redundant over TLS connections, disabling encryption.")
             encrypt = False
 
-        self.codec = BPPCodec(secret, encrypt)
+        self.codec = BPPCodec(secret, encrypt) if secret else None
         self.secret = secret
         self.encrypt = encrypt
         self.logger = logger
@@ -287,12 +287,14 @@ class WebSocketMicrophone(BaseMicrophone):
                 self.logger.warning(f"Failed to decode string message using base64: {e}")
                 return None
 
-        decoded = self.codec.decode(message)
-        if decoded is None:
-            self.logger.warning("Failed to decode message")
-            return None
+        if self.codec:
+            decoded = self.codec.decode(message)
+            if decoded is None:
+                self.logger.warning("Failed to decode message")
+                return None
+            message = decoded
 
-        return np.frombuffer(decoded, dtype=self.format)
+        return np.frombuffer(message, dtype=self.format)
 
     def _close_microphone(self) -> None:
         """Stop the WebSocket server."""
@@ -348,7 +350,7 @@ class WebSocketMicrophone(BaseMicrophone):
         if isinstance(message, str):
             message = message.encode()
 
-        encoded = self.codec.encode(message)
+        data = self.codec.encode(message) if self.codec else message
 
         # Keep a ref to current client to avoid locking
         client = client or self._client
@@ -356,7 +358,7 @@ class WebSocketMicrophone(BaseMicrophone):
             raise ConnectionError("No client connected")
 
         try:
-            await client.send(encoded)
+            await client.send(data)
         except websockets.ConnectionClosedOK:
             self.logger.warning("Client has already closed the connection")
         except websockets.ConnectionClosedError as e:

--- a/src/arduino/app_peripherals/microphone/websocket_microphone.py
+++ b/src/arduino/app_peripherals/microphone/websocket_microphone.py
@@ -234,7 +234,7 @@ class WebSocketMicrophone(BaseMicrophone):
                     if sanitized:
                         client_name = sanitized
                 # Allow raw (no BPP) mode only when security is disabled
-                if "raw" in query_params and query_params["raw"][0].lower() == "true":
+                if "raw" in query_params and (not query_params["raw"] or query_params["raw"][0].lower() != "false"):
                     if self.secret is None:
                         client_raw = True
                     else:

--- a/tests/arduino/app_peripherals/camera/test_websocket_camera.py
+++ b/tests/arduino/app_peripherals/camera/test_websocket_camera.py
@@ -10,14 +10,7 @@ import numpy as np
 import cv2
 import websockets
 
-from arduino.app_internal.core.peripherals.bpp_codec import BPPCodec
 from arduino.app_peripherals.camera import WebSocketCamera
-
-
-@pytest.fixture
-def codec() -> BPPCodec:
-    """Create codec for encoding/decoding in tests."""
-    return BPPCodec()
 
 
 @pytest.fixture
@@ -28,16 +21,16 @@ def sample_frame() -> np.ndarray:
 
 
 @pytest.fixture
-def encoded_frame_binary(codec, sample_frame) -> bytes:
-    """Encode frame as binary."""
+def raw_frame_binary(sample_frame) -> bytes:
+    """Encode frame as raw JPEG bytes (no BPP wrapping in plain mode)."""
     _, buffer = cv2.imencode(".jpg", sample_frame)
-    return codec.encode(buffer.tobytes())
+    return buffer.tobytes()
 
 
 @pytest.fixture
-def encoded_frame_string(encoded_frame_binary) -> str:
-    """Encode frame as base64 string."""
-    return base64.b64encode(encoded_frame_binary).decode()
+def raw_frame_string(raw_frame_binary) -> str:
+    """Encode raw frame bytes as base64 string."""
+    return base64.b64encode(raw_frame_binary).decode()
 
 
 def test_websocket_camera_init_default():
@@ -86,22 +79,22 @@ def test_websocket_camera_start_stop():
     assert camera.status == "disconnected"
 
 
-def test_websocket_camera_handle_binary_message(sample_frame, encoded_frame_binary):
+def test_websocket_camera_handle_binary_message(sample_frame, raw_frame_binary):
     """Test parsing binary frame message."""
     camera = WebSocketCamera()
 
-    frame = camera._parse_message(encoded_frame_binary)
+    frame = camera._parse_message(raw_frame_binary)
 
     assert frame is not None
     assert isinstance(frame, np.ndarray)
     assert frame.shape == sample_frame.shape
 
 
-def test_websocket_camera_handle_base64_message(sample_frame, encoded_frame_string):
+def test_websocket_camera_handle_base64_message(sample_frame, raw_frame_string):
     """Test parsing binary message received as string using base64 encoding."""
     camera = WebSocketCamera()
 
-    frame = camera._parse_message(encoded_frame_string)
+    frame = camera._parse_message(raw_frame_string)
 
     assert frame is not None
     assert isinstance(frame, np.ndarray)
@@ -125,14 +118,14 @@ def test_websocket_camera_read_frame_empty_queue():
 
 
 @pytest.mark.asyncio
-async def test_websocket_camera_capture_frame(encoded_frame_binary):
+async def test_websocket_camera_capture_frame(raw_frame_binary):
     """Test capturing frame from WebSocket camera."""
     with WebSocketCamera(port=0) as camera:
         async with websockets.connect(camera.url) as ws:
             # Skip welcome message
             await ws.recv()
 
-            await ws.send(encoded_frame_binary)
+            await ws.send(raw_frame_binary)
 
             await asyncio.sleep(0.1)
 
@@ -143,7 +136,7 @@ async def test_websocket_camera_capture_frame(encoded_frame_binary):
 
 
 @pytest.mark.asyncio
-async def test_websocket_camera_single_client(codec):
+async def test_websocket_camera_single_client():
     """Test WebSocket server accepts only one client at a time."""
     camera = WebSocketCamera(port=0)
     camera.start()
@@ -153,8 +146,7 @@ async def test_websocket_camera_single_client(codec):
         async with websockets.connect(camera.url) as ws1:
             # First client should receive welcome message
             welcome = await ws1.recv()
-            decoded_welcome = codec.decode(welcome)
-            welcome_message = json.loads(decoded_welcome)
+            welcome_message = json.loads(welcome)
             assert welcome_message["status"] == "connected"
 
             # Try to connect second client while first is connected
@@ -162,8 +154,7 @@ async def test_websocket_camera_single_client(codec):
                 async with websockets.connect(camera.url) as ws2:
                     # Second client should receive rejection message
                     rejection = await asyncio.wait_for(ws2.recv(), timeout=1.0)
-                    decoded_rejection = codec.decode(rejection)
-                    rejection_message = json.loads(decoded_rejection)
+                    rejection_message = json.loads(rejection)
                     assert "error" in rejection_message
             except websockets.exceptions.ConnectionClosed:
                 # Connection closed immediately - also acceptable
@@ -173,14 +164,13 @@ async def test_websocket_camera_single_client(codec):
 
 
 @pytest.mark.asyncio
-async def test_websocket_camera_welcome_message(codec):
+async def test_websocket_camera_welcome_message():
     """Test that welcome message is sent to connected client."""
     with WebSocketCamera(port=0) as camera:
         async with websockets.connect(camera.url) as ws:
             # Should receive welcome message
             welcome = await asyncio.wait_for(ws.recv(), timeout=1.0)
-            decoded_welcome = codec.decode(welcome)
-            welcome_message = json.loads(decoded_welcome)
+            welcome_message = json.loads(welcome)
             assert "message" in welcome_message
             assert welcome_message["status"] == "connected"
             assert tuple(welcome_message["resolution"]) == camera.resolution
@@ -189,7 +179,7 @@ async def test_websocket_camera_welcome_message(codec):
 
 
 @pytest.mark.asyncio
-async def test_websocket_camera_receives_frames(encoded_frame_binary):
+async def test_websocket_camera_receives_frames(raw_frame_binary):
     """Test that server receives and queues frames from client."""
     with WebSocketCamera(port=0) as camera:
         async with websockets.connect(camera.url) as ws:
@@ -197,7 +187,7 @@ async def test_websocket_camera_receives_frames(encoded_frame_binary):
             await ws.recv()
 
             # Send a frame
-            await ws.send(encoded_frame_binary)
+            await ws.send(raw_frame_binary)
 
             # Give time for frame to be processed
             await asyncio.sleep(0.2)
@@ -207,7 +197,7 @@ async def test_websocket_camera_receives_frames(encoded_frame_binary):
 
 
 @pytest.mark.asyncio
-async def test_websocket_camera_disconnects_client_on_stop(codec):
+async def test_websocket_camera_disconnects_client_on_stop():
     """Test that connected client is disconnected when camera stops."""
     camera = WebSocketCamera(port=0)
     camera.start()
@@ -216,8 +206,7 @@ async def test_websocket_camera_disconnects_client_on_stop(codec):
         async with websockets.connect(camera.url) as ws:
             # Client connected, receive welcome message
             welcome = await ws.recv()
-            decoded_welcome = codec.decode(welcome)
-            welcome_message = json.loads(decoded_welcome)
+            welcome_message = json.loads(welcome)
             assert welcome_message["status"] == "connected"
 
             # Stop the camera (runs in background thread via to_thread)
@@ -227,8 +216,7 @@ async def test_websocket_camera_disconnects_client_on_stop(codec):
                 # Keep receiving until connection is closed
                 while True:
                     goodbye = await asyncio.wait_for(ws.recv(), timeout=1.0)
-                    decoded_goodbye = codec.decode(goodbye)
-                    goodbye_message = json.loads(decoded_goodbye)
+                    goodbye_message = json.loads(goodbye)
                     if goodbye_message.get("status") == "disconnecting":
                         # Got goodbye message, connection should close soon
                         continue
@@ -251,7 +239,7 @@ def test_websocket_camera_stop_without_client():
 
 
 @pytest.mark.asyncio
-async def test_websocket_camera_backpressure(codec):
+async def test_websocket_camera_backpressure():
     """Test that old frames are dropped when new frames arrive faster than they're consumed."""
     with WebSocketCamera(port=0) as camera:
         async with websockets.connect(camera.url) as ws:
@@ -261,9 +249,9 @@ async def test_websocket_camera_backpressure(codec):
             _, buffer2 = cv2.imencode(".jpg", np.ones((480, 640, 3), dtype=np.uint8) * 2)
             _, buffer3 = cv2.imencode(".jpg", np.ones((480, 640, 3), dtype=np.uint8) * 3)
 
-            await ws.send(codec.encode(buffer1.tobytes()))
-            await ws.send(codec.encode(buffer2.tobytes()))
-            await ws.send(codec.encode(buffer3.tobytes()))
+            await ws.send(buffer1.tobytes())
+            await ws.send(buffer2.tobytes())
+            await ws.send(buffer3.tobytes())
 
             await asyncio.sleep(0.1)
 

--- a/tests/arduino/app_peripherals/camera/test_websocket_camera.py
+++ b/tests/arduino/app_peripherals/camera/test_websocket_camera.py
@@ -22,16 +22,22 @@ def sample_frame() -> np.ndarray:
 
 
 @pytest.fixture
-def raw_frame_binary(sample_frame) -> bytes:
-    """Encode frame as raw JPEG bytes (no BPP wrapping in plain mode)."""
-    _, buffer = cv2.imencode(".jpg", sample_frame)
-    return buffer.tobytes()
+def plain_codec() -> BPPCodec:
+    """BPPCodec for MODE_NONE (no secret, no encryption)."""
+    return BPPCodec("", enable_encryption=False)
 
 
 @pytest.fixture
-def raw_frame_string(raw_frame_binary) -> str:
-    """Encode raw frame bytes as base64 string."""
-    return base64.b64encode(raw_frame_binary).decode()
+def bpp_frame_binary(sample_frame, plain_codec) -> bytes:
+    """Encode frame as JPEG bytes wrapped in BPP MODE_NONE."""
+    _, buffer = cv2.imencode(".jpg", sample_frame)
+    return plain_codec.encode(buffer.tobytes())
+
+
+@pytest.fixture
+def bpp_frame_string(bpp_frame_binary) -> str:
+    """Encode BPP-wrapped frame as base64 string."""
+    return base64.b64encode(bpp_frame_binary).decode()
 
 
 def test_websocket_camera_init_default():
@@ -93,22 +99,22 @@ def test_websocket_camera_start_stop():
     assert camera.status == "disconnected"
 
 
-def test_websocket_camera_handle_binary_message(sample_frame, raw_frame_binary):
-    """Test parsing binary frame message."""
+def test_websocket_camera_handle_binary_message(sample_frame, bpp_frame_binary):
+    """Test parsing BPP-wrapped binary frame message."""
     camera = WebSocketCamera()
 
-    frame = camera._parse_message(raw_frame_binary)
+    frame = camera._parse_message(bpp_frame_binary)
 
     assert frame is not None
     assert isinstance(frame, np.ndarray)
     assert frame.shape == sample_frame.shape
 
 
-def test_websocket_camera_handle_base64_message(sample_frame, raw_frame_string):
-    """Test parsing binary message received as string using base64 encoding."""
+def test_websocket_camera_handle_base64_message(sample_frame, bpp_frame_string):
+    """Test parsing BPP-wrapped message received as base64 string."""
     camera = WebSocketCamera()
 
-    frame = camera._parse_message(raw_frame_string)
+    frame = camera._parse_message(bpp_frame_string)
 
     assert frame is not None
     assert isinstance(frame, np.ndarray)
@@ -132,14 +138,14 @@ def test_websocket_camera_read_frame_empty_queue():
 
 
 @pytest.mark.asyncio
-async def test_websocket_camera_capture_frame(raw_frame_binary):
-    """Test capturing frame from WebSocket camera."""
+async def test_websocket_camera_capture_frame(bpp_frame_binary):
+    """Test capturing frame from WebSocket camera (BPP MODE_NONE)."""
     with WebSocketCamera(port=0) as camera:
         async with websockets.connect(camera.url) as ws:
             # Skip welcome message
             await ws.recv()
 
-            await ws.send(raw_frame_binary)
+            await ws.send(bpp_frame_binary)
 
             await asyncio.sleep(0.1)
 
@@ -152,23 +158,24 @@ async def test_websocket_camera_capture_frame(raw_frame_binary):
 @pytest.mark.asyncio
 async def test_websocket_camera_single_client():
     """Test WebSocket server accepts only one client at a time."""
+    codec = BPPCodec("", enable_encryption=False)
     camera = WebSocketCamera(port=0)
     camera.start()
 
     try:
         # Connect first client
         async with websockets.connect(camera.url) as ws1:
-            # First client should receive welcome message
-            welcome = await ws1.recv()
-            welcome_message = json.loads(welcome)
+            # First client should receive BPP-wrapped welcome message
+            welcome_raw = await ws1.recv()
+            welcome_message = json.loads(codec.decode(welcome_raw))
             assert welcome_message["status"] == "connected"
 
             # Try to connect second client while first is connected
             try:
                 async with websockets.connect(camera.url) as ws2:
-                    # Second client should receive rejection message
-                    rejection = await asyncio.wait_for(ws2.recv(), timeout=1.0)
-                    rejection_message = json.loads(rejection)
+                    # Second client should receive BPP-wrapped rejection message
+                    rejection_raw = await asyncio.wait_for(ws2.recv(), timeout=1.0)
+                    rejection_message = json.loads(codec.decode(rejection_raw))
                     assert "error" in rejection_message
             except websockets.exceptions.ConnectionClosed:
                 # Connection closed immediately - also acceptable
@@ -179,12 +186,15 @@ async def test_websocket_camera_single_client():
 
 @pytest.mark.asyncio
 async def test_websocket_camera_welcome_message():
-    """Test that welcome message is sent to connected client."""
+    """Test that welcome message is sent to connected client (BPP-wrapped)."""
+    codec = BPPCodec("", enable_encryption=False)
     with WebSocketCamera(port=0) as camera:
         async with websockets.connect(camera.url) as ws:
-            # Should receive welcome message
-            welcome = await asyncio.wait_for(ws.recv(), timeout=1.0)
-            welcome_message = json.loads(welcome)
+            # Should receive BPP-wrapped welcome message
+            welcome_raw = await asyncio.wait_for(ws.recv(), timeout=1.0)
+            welcome_payload = codec.decode(welcome_raw)
+            assert welcome_payload is not None
+            welcome_message = json.loads(welcome_payload)
             assert "message" in welcome_message
             assert welcome_message["status"] == "connected"
             assert tuple(welcome_message["resolution"]) == camera.resolution
@@ -193,15 +203,15 @@ async def test_websocket_camera_welcome_message():
 
 
 @pytest.mark.asyncio
-async def test_websocket_camera_receives_frames(raw_frame_binary):
-    """Test that server receives and queues frames from client."""
+async def test_websocket_camera_receives_frames(bpp_frame_binary):
+    """Test that server receives and queues BPP-wrapped frames from client."""
     with WebSocketCamera(port=0) as camera:
         async with websockets.connect(camera.url) as ws:
             # Skip welcome message
             await ws.recv()
 
-            # Send a frame
-            await ws.send(raw_frame_binary)
+            # Send a BPP-wrapped frame
+            await ws.send(bpp_frame_binary)
 
             # Give time for frame to be processed
             await asyncio.sleep(0.2)
@@ -213,14 +223,15 @@ async def test_websocket_camera_receives_frames(raw_frame_binary):
 @pytest.mark.asyncio
 async def test_websocket_camera_disconnects_client_on_stop():
     """Test that connected client is disconnected when camera stops."""
+    codec = BPPCodec("", enable_encryption=False)
     camera = WebSocketCamera(port=0)
     camera.start()
 
     try:
         async with websockets.connect(camera.url) as ws:
-            # Client connected, receive welcome message
-            welcome = await ws.recv()
-            welcome_message = json.loads(welcome)
+            # Client connected, receive BPP-wrapped welcome message
+            welcome_raw = await ws.recv()
+            welcome_message = json.loads(codec.decode(welcome_raw))
             assert welcome_message["status"] == "connected"
 
             # Stop the camera (runs in background thread via to_thread)
@@ -229,8 +240,8 @@ async def test_websocket_camera_disconnects_client_on_stop():
             with pytest.raises(websockets.exceptions.ConnectionClosed):
                 # Keep receiving until connection is closed
                 while True:
-                    goodbye = await asyncio.wait_for(ws.recv(), timeout=1.0)
-                    goodbye_message = json.loads(goodbye)
+                    goodbye_raw = await asyncio.wait_for(ws.recv(), timeout=1.0)
+                    goodbye_message = json.loads(codec.decode(goodbye_raw))
                     if goodbye_message.get("status") == "disconnecting":
                         # Got goodbye message, connection should close soon
                         continue
@@ -255,6 +266,7 @@ def test_websocket_camera_stop_without_client():
 @pytest.mark.asyncio
 async def test_websocket_camera_backpressure():
     """Test that old frames are dropped when new frames arrive faster than they're consumed."""
+    codec = BPPCodec("", enable_encryption=False)
     with WebSocketCamera(port=0) as camera:
         async with websockets.connect(camera.url) as ws:
             await ws.recv()  # Skip welcome message
@@ -263,9 +275,9 @@ async def test_websocket_camera_backpressure():
             _, buffer2 = cv2.imencode(".jpg", np.ones((480, 640, 3), dtype=np.uint8) * 2)
             _, buffer3 = cv2.imencode(".jpg", np.ones((480, 640, 3), dtype=np.uint8) * 3)
 
-            await ws.send(buffer1.tobytes())
-            await ws.send(buffer2.tobytes())
-            await ws.send(buffer3.tobytes())
+            await ws.send(codec.encode(buffer1.tobytes()))
+            await ws.send(codec.encode(buffer2.tobytes()))
+            await ws.send(codec.encode(buffer3.tobytes()))
 
             await asyncio.sleep(0.1)
 
@@ -532,6 +544,64 @@ async def test_websocket_camera_encrypted_rejects_raw():
             await ws.recv()  # Skip welcome
 
             # Send raw bytes — should be rejected
+            frame = np.ones((480, 640, 3), dtype=np.uint8) * 42
+            _, buffer = cv2.imencode(".jpg", frame)
+            await ws.send(buffer.tobytes())
+
+            await asyncio.sleep(0.2)
+
+            captured = camera.capture()
+            assert captured is None
+    finally:
+        camera.stop()
+
+
+@pytest.mark.asyncio
+async def test_websocket_camera_raw_mode():
+    """Test that clients can bypass BPP with ?raw=true when security is disabled."""
+    camera = WebSocketCamera(port=0)
+    camera.start()
+
+    try:
+        # Connect with raw=true query parameter
+        async with websockets.connect(camera.url + "?raw=true") as ws:
+            # Welcome should be plain JSON (not BPP-wrapped)
+            welcome = await asyncio.wait_for(ws.recv(), timeout=1.0)
+            welcome_message = json.loads(welcome)
+            assert welcome_message["status"] == "connected"
+
+            # Send raw JPEG bytes (no BPP wrapping)
+            frame = np.ones((480, 640, 3), dtype=np.uint8) * 77
+            _, buffer = cv2.imencode(".jpg", frame)
+            await ws.send(buffer.tobytes())
+
+            await asyncio.sleep(0.2)
+
+            captured = camera.capture()
+            assert captured is not None
+            assert np.mean(captured) == pytest.approx(77, abs=1)
+    finally:
+        camera.stop()
+
+
+@pytest.mark.asyncio
+async def test_websocket_camera_raw_mode_ignored_with_secret():
+    """Test that ?raw=true is ignored when security is enabled."""
+    codec = BPPCodec(TEST_SECRET, enable_encryption=False)
+    camera = WebSocketCamera(port=0, secret=TEST_SECRET)
+    camera.start()
+
+    try:
+        # Connect with raw=true — should be ignored since secret is set
+        async with websockets.connect(camera.url + "?raw=true") as ws:
+            # Welcome should still be BPP-wrapped
+            welcome_raw = await ws.recv()
+            welcome_payload = codec.decode(welcome_raw)
+            assert welcome_payload is not None
+            welcome = json.loads(welcome_payload)
+            assert welcome["status"] == "connected"
+
+            # Sending raw bytes should be rejected (BPP is enforced)
             frame = np.ones((480, 640, 3), dtype=np.uint8) * 42
             _, buffer = cv2.imencode(".jpg", frame)
             await ws.send(buffer.tobytes())

--- a/tests/arduino/app_peripherals/camera/test_websocket_camera.py
+++ b/tests/arduino/app_peripherals/camera/test_websocket_camera.py
@@ -10,6 +10,7 @@ import numpy as np
 import cv2
 import websockets
 
+from arduino.app_internal.core.peripherals.bpp_codec import BPPCodec
 from arduino.app_peripherals.camera import WebSocketCamera
 
 
@@ -415,3 +416,116 @@ async def test_websocket_camera_stop_event():
     assert len(events) == 2
     assert "connected" in events[0][0]
     assert "disconnected" in events[1][0]
+
+
+TEST_SECRET = "test-secret-key"
+
+
+@pytest.mark.asyncio
+async def test_websocket_camera_authenticated_mode():
+    """Test sending and receiving frames with HMAC-SHA256 authentication (secret, no encryption)."""
+    codec = BPPCodec(TEST_SECRET, enable_encryption=False)
+    camera = WebSocketCamera(port=0, secret=TEST_SECRET, encrypt=False)
+    camera.start()
+
+    try:
+        async with websockets.connect(camera.url) as ws:
+            # Welcome message should be BPP-encoded
+            welcome_raw = await ws.recv()
+            welcome_payload = codec.decode(welcome_raw)
+            assert welcome_payload is not None
+            welcome = json.loads(welcome_payload)
+            assert welcome["status"] == "connected"
+            assert "authenticated" in welcome["security_mode"]
+
+            # Send a BPP-encoded frame
+            frame = np.ones((480, 640, 3), dtype=np.uint8) * 42
+            _, buffer = cv2.imencode(".jpg", frame)
+            await ws.send(codec.encode(buffer.tobytes()))
+
+            await asyncio.sleep(0.2)
+
+            captured = camera.capture()
+            assert captured is not None
+            assert isinstance(captured, np.ndarray)
+            assert np.mean(captured) == pytest.approx(42, abs=1)
+    finally:
+        camera.stop()
+
+
+@pytest.mark.asyncio
+async def test_websocket_camera_authenticated_rejects_raw():
+    """Test that authenticated mode rejects raw (non-BPP) messages."""
+    camera = WebSocketCamera(port=0, secret=TEST_SECRET, encrypt=False)
+    camera.start()
+
+    try:
+        async with websockets.connect(camera.url) as ws:
+            await ws.recv()  # Skip welcome
+
+            # Send raw bytes (not BPP-encoded) — should be rejected
+            frame = np.ones((480, 640, 3), dtype=np.uint8) * 42
+            _, buffer = cv2.imencode(".jpg", frame)
+            await ws.send(buffer.tobytes())
+
+            await asyncio.sleep(0.2)
+
+            captured = camera.capture()
+            assert captured is None
+    finally:
+        camera.stop()
+
+
+@pytest.mark.asyncio
+async def test_websocket_camera_encrypted_mode():
+    """Test sending and receiving frames with ChaCha20-Poly1305 encryption."""
+    codec = BPPCodec(TEST_SECRET, enable_encryption=True)
+    camera = WebSocketCamera(port=0, secret=TEST_SECRET, encrypt=True)
+    camera.start()
+
+    try:
+        async with websockets.connect(camera.url) as ws:
+            # Welcome message should be BPP-encoded with encryption
+            welcome_raw = await ws.recv()
+            welcome_payload = codec.decode(welcome_raw)
+            assert welcome_payload is not None
+            welcome = json.loads(welcome_payload)
+            assert welcome["status"] == "connected"
+            assert "encrypted" in welcome["security_mode"]
+
+            # Send a BPP-encrypted frame
+            frame = np.ones((480, 640, 3), dtype=np.uint8) * 99
+            _, buffer = cv2.imencode(".jpg", frame)
+            await ws.send(codec.encode(buffer.tobytes()))
+
+            await asyncio.sleep(0.2)
+
+            captured = camera.capture()
+            assert captured is not None
+            assert isinstance(captured, np.ndarray)
+            assert np.mean(captured) == pytest.approx(99, abs=1)
+    finally:
+        camera.stop()
+
+
+@pytest.mark.asyncio
+async def test_websocket_camera_encrypted_rejects_raw():
+    """Test that encrypted mode rejects raw (non-BPP) messages."""
+    camera = WebSocketCamera(port=0, secret=TEST_SECRET, encrypt=True)
+    camera.start()
+
+    try:
+        async with websockets.connect(camera.url) as ws:
+            await ws.recv()  # Skip welcome
+
+            # Send raw bytes — should be rejected
+            frame = np.ones((480, 640, 3), dtype=np.uint8) * 42
+            _, buffer = cv2.imencode(".jpg", frame)
+            await ws.send(buffer.tobytes())
+
+            await asyncio.sleep(0.2)
+
+            captured = camera.capture()
+            assert captured is None
+    finally:
+        camera.stop()

--- a/tests/arduino/app_peripherals/camera/test_websocket_camera.py
+++ b/tests/arduino/app_peripherals/camera/test_websocket_camera.py
@@ -62,10 +62,11 @@ def test_websocket_camera_encrypt_without_secret_fails():
         WebSocketCamera(encrypt=True)
 
 
-def test_websocket_camera_empty_string_secret_fails():
-    """Test that secret="" raises RuntimeError."""
-    with pytest.raises(RuntimeError, match="Secret must be a non-empty string or None"):
-        WebSocketCamera(secret="")
+def test_websocket_camera_empty_string_secret_enables_bpp():
+    """Test that secret="" is valid and enables BPP authentication."""
+    camera = WebSocketCamera(port=0, secret="")
+    assert camera.codec is not None
+    assert camera.secret == ""
 
 
 def test_websocket_camera_start_stop():

--- a/tests/arduino/app_peripherals/camera/test_websocket_camera.py
+++ b/tests/arduino/app_peripherals/camera/test_websocket_camera.py
@@ -56,6 +56,18 @@ def test_websocket_camera_init_custom():
     assert camera.status == "disconnected"
 
 
+def test_websocket_camera_encrypt_without_secret_fails():
+    """Test that encrypt=True without a secret raises RuntimeError."""
+    with pytest.raises(RuntimeError, match="Encryption requires a secret key"):
+        WebSocketCamera(encrypt=True)
+
+
+def test_websocket_camera_empty_string_secret_fails():
+    """Test that secret="" raises RuntimeError."""
+    with pytest.raises(RuntimeError, match="Secret must be a non-empty string or None"):
+        WebSocketCamera(secret="")
+
+
 def test_websocket_camera_start_stop():
     """Test start/stop WebSocket camera server."""
     camera = WebSocketCamera(port=0)

--- a/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
+++ b/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
@@ -66,6 +66,7 @@ class TestWebSocketPCMBinaryFormat:
     @pytest.mark.asyncio
     async def test_receive_binary_pcm_int16(self):
         """Test receiving binary PCM data as int16."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone()
 
         mic.start()
@@ -77,8 +78,8 @@ class TestWebSocketPCMBinaryFormat:
         async with websockets.connect(mic.url) as ws:
             await ws.recv()  # Welcome message
 
-            # Send raw PCM bytes directly (no BPP in plain mode)
-            await ws.send(pcm_bytes)
+            # Send BPP-encoded PCM bytes
+            await ws.send(codec.encode(pcm_bytes))
 
             # Capture and validate
             received = mic.capture()
@@ -94,6 +95,7 @@ class TestWebSocketPCMBinaryFormat:
     @pytest.mark.asyncio
     async def test_receive_binary_pcm_int32(self):
         """Test receiving binary PCM data as int32."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0, format=np.int32)
 
         mic.start()
@@ -104,7 +106,7 @@ class TestWebSocketPCMBinaryFormat:
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
 
-            await ws.send(pcm_bytes)
+            await ws.send(codec.encode(pcm_bytes))
 
             received = mic.capture()
 
@@ -118,6 +120,7 @@ class TestWebSocketPCMBinaryFormat:
     @pytest.mark.asyncio
     async def test_receive_binary_pcm_float32(self):
         """Test receiving binary PCM data as float32."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0, format=np.float32)
 
         mic.start()
@@ -128,7 +131,7 @@ class TestWebSocketPCMBinaryFormat:
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
 
-            await ws.send(pcm_bytes)
+            await ws.send(codec.encode(pcm_bytes))
 
             received = mic.capture()
 
@@ -145,15 +148,16 @@ class TestWebSocketPCMBase64Format:
 
     @pytest.mark.asyncio
     async def test_receive_base64_encoded_pcm(self):
-        """Test receiving base64-encoded PCM data."""
+        """Test receiving base64-encoded BPP data."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
 
-        # Create and encode test PCM data
+        # Create test PCM data, wrap in BPP, then base64-encode
         test_audio = np.arange(512, dtype=np.int16)
-        pcm_bytes = test_audio.tobytes()
-        base64_encoded = base64.b64encode(pcm_bytes).decode()
+        bpp_encoded = codec.encode(test_audio.tobytes())
+        base64_encoded = base64.b64encode(bpp_encoded).decode()
 
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
@@ -172,15 +176,16 @@ class TestWebSocketPCMBase64Format:
 
     @pytest.mark.asyncio
     async def test_receive_base64_with_padding(self):
-        """Test receiving base64 data with padding."""
+        """Test receiving base64-encoded BPP data with padding."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
 
         # Use size that requires padding in base64
         test_audio = np.arange(100, dtype=np.int16)
-        pcm_bytes = test_audio.tobytes()
-        base64_encoded = base64.b64encode(pcm_bytes).decode()
+        bpp_encoded = codec.encode(test_audio.tobytes())
+        base64_encoded = base64.b64encode(bpp_encoded).decode()
 
         # Verify it has padding
         assert "=" in base64_encoded or len(base64_encoded) % 4 == 0
@@ -204,6 +209,7 @@ class TestWebSocketMultipleChunks:
     @pytest.mark.asyncio
     async def test_receive_multiple_sequential_chunks(self):
         """Test receiving correctly multiple PCM chunks in sequence."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
@@ -216,7 +222,7 @@ class TestWebSocketMultipleChunks:
             for i in range(5):  # Internal queue holds up to 10 chunks
                 chunk = np.full(128, i, dtype=np.int16)
                 sent_chunks.append(chunk)
-                await ws.send(chunk.tobytes())
+                await ws.send(codec.encode(chunk.tobytes()))
 
             received_chunks = []
             for _ in range(5):
@@ -235,6 +241,7 @@ class TestWebSocketMultipleChunks:
     @pytest.mark.asyncio
     async def test_receive_rapid_fire_chunks(self):
         """Test receiving chunks sent in rapid succession."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
@@ -245,7 +252,7 @@ class TestWebSocketMultipleChunks:
             # Send chunks rapidly without delay
             for i in range(10):  # Internal queue holds up to 10 chunks
                 chunk = np.full(64, i, dtype=np.int16)
-                await ws.send(chunk.tobytes())
+                await ws.send(codec.encode(chunk.tobytes()))
 
             # Should handle rapid chunks
             for i in range(10):
@@ -261,6 +268,7 @@ class TestWebSocketPCMDataIntegrity:
     @pytest.mark.asyncio
     async def test_pcm_values_preserved_exactly(self):
         """Test that PCM values are preserved exactly through transmission."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
@@ -271,7 +279,7 @@ class TestWebSocketPCMDataIntegrity:
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
 
-            await ws.send(test_audio.tobytes())
+            await ws.send(codec.encode(test_audio.tobytes()))
 
             received = mic.capture()
 
@@ -283,6 +291,7 @@ class TestWebSocketPCMDataIntegrity:
     @pytest.mark.asyncio
     async def test_pcm_byte_order_preserved(self):
         """Test that byte order is preserved in PCM transmission."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
@@ -293,7 +302,7 @@ class TestWebSocketPCMDataIntegrity:
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
 
-            await ws.send(test_audio.tobytes())
+            await ws.send(codec.encode(test_audio.tobytes()))
 
             received = mic.capture()
 
@@ -308,14 +317,15 @@ class TestWebSocketClientConnection:
     @pytest.mark.asyncio
     async def test_client_receives_welcome_message(self):
         """Test that client receives welcome message on connection."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
 
         async with websockets.connect(mic.url) as ws:
-            welcome = await ws.recv()
+            welcome_raw = await ws.recv()
 
-            welcome_data = json.loads(welcome)
+            welcome_data = json.loads(codec.decode(welcome_raw))
 
             assert "status" in welcome_data
             assert welcome_data["status"] == "connected"
@@ -327,22 +337,23 @@ class TestWebSocketClientConnection:
     @pytest.mark.asyncio
     async def test_single_client_enforcement(self):
         """Test that only one client can connect at a time."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
 
         # Connect first client
         async with websockets.connect(mic.url) as client1:
-            welcome = await client1.recv()  # Welcome
-            welcome_data = json.loads(welcome)
+            welcome_raw = await client1.recv()  # Welcome
+            welcome_data = json.loads(codec.decode(welcome_raw))
             assert "status" in welcome_data
             assert welcome_data["status"] == "connected"
 
             # Try to connect second client
             async with websockets.connect(mic.url) as client2:
                 # Should receive rejection
-                rejection = await client2.recv()
-                rejection_data = json.loads(rejection)
+                rejection_raw = await client2.recv()
+                rejection_data = json.loads(codec.decode(rejection_raw))
                 assert "error" in rejection_data
 
         mic.stop()
@@ -350,6 +361,7 @@ class TestWebSocketClientConnection:
     @pytest.mark.asyncio
     async def test_client_disconnection_handled(self):
         """Test that client disconnection is handled gracefully."""
+        codec = BPPCodec("", enable_encryption=False)
         loop = asyncio.get_running_loop()
         test_done = asyncio.Event()
 
@@ -370,7 +382,7 @@ class TestWebSocketClientConnection:
         # Connect and disconnect
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
-            await ws.send(test_audio)
+            await ws.send(codec.encode(test_audio))
 
         await asyncio.wait_for(test_done.wait(), timeout=2)
         mic.stop()
@@ -490,6 +502,7 @@ class TestWebSocketClientDisconnection:
     @pytest.mark.asyncio
     async def test_client_reconnect_after_disconnect(self):
         """Test that client can reconnect after disconnecting."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
@@ -500,8 +513,8 @@ class TestWebSocketClientDisconnection:
 
         # Second connection should work
         async with websockets.connect(mic.url) as ws:
-            welcome = await ws.recv()
-            assert "connected" in welcome.decode()
+            welcome_raw = await ws.recv()
+            assert b"connected" in codec.decode(welcome_raw)
 
         mic.stop()
 
@@ -562,6 +575,7 @@ class TestWebSocketPCMStreaming:
     @pytest.mark.asyncio
     async def test_continuous_pcm_stream(self):
         """Test continuous PCM streaming from client."""
+        codec = BPPCodec("", enable_encryption=False)
         mic = WebSocketMicrophone(port=0)
 
         mic.start()
@@ -573,7 +587,7 @@ class TestWebSocketPCMStreaming:
                 # Stream 10 chunks then stop
                 for i in range(10):
                     chunk = np.full(128, i, dtype=np.int16)
-                    await ws.send(chunk.tobytes())
+                    await ws.send(codec.encode(chunk.tobytes()))
 
         # Start streaming
         stream_task = asyncio.create_task(stream_audio())
@@ -596,6 +610,58 @@ class TestWebSocketPCMStreaming:
         for chunk in chunks:
             assert isinstance(chunk, np.ndarray)
             assert chunk.dtype == np.int16
+
+        mic.stop()
+
+
+class TestWebSocketRawMode:
+    """Test raw mode that bypasses BPP framing."""
+
+    @pytest.mark.asyncio
+    async def test_raw_mode_bypasses_bpp(self):
+        """Test that ?raw=true allows sending raw PCM bytes without BPP wrapping."""
+        mic = WebSocketMicrophone(port=0)
+
+        mic.start()
+
+        test_audio = np.arange(256, dtype=np.int16)
+        pcm_bytes = test_audio.tobytes()
+
+        async with websockets.connect(mic.url + "?raw=true") as ws:
+            await ws.recv()  # Welcome message
+
+            # Send raw PCM bytes directly (no BPP wrapping)
+            await ws.send(pcm_bytes)
+
+            received = mic.capture()
+
+            assert received is not None
+            assert isinstance(received, np.ndarray)
+            assert received.dtype == np.int16
+            assert len(received) == 256
+            np.testing.assert_array_equal(received, test_audio)
+
+        mic.stop()
+
+    @pytest.mark.asyncio
+    async def test_raw_mode_ignored_with_secret(self):
+        """Test that ?raw=true is ignored when a secret is set (BPP still enforced)."""
+        mic = WebSocketMicrophone(port=0, secret="my-secret", encrypt=False)
+
+        mic.start()
+
+        test_audio = np.arange(256, dtype=np.int16)
+
+        async with websockets.connect(mic.url + "?raw=true") as ws:
+            await ws.recv()  # Welcome message
+
+            # Send raw PCM bytes — should be rejected because BPP is enforced
+            await ws.send(test_audio.tobytes())
+
+            await asyncio.sleep(0.1)
+
+            received = mic.capture()
+            assert received is None
 
         mic.stop()
 

--- a/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
+++ b/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
@@ -30,6 +30,16 @@ class TestWebSocketMicrophoneInit:
         assert not mic.is_started()
         assert mic._server is None
 
+    def test_encrypt_without_secret_fails(self):
+        """Test that encrypt=True without a secret raises RuntimeError."""
+        with pytest.raises(RuntimeError, match="Encryption requires a secret key"):
+            WebSocketMicrophone(encrypt=True)
+
+    def test_empty_string_secret_fails(self):
+        """Test that secret="" raises RuntimeError."""
+        with pytest.raises(RuntimeError, match="Secret must be a non-empty string or None"):
+            WebSocketMicrophone(secret="")
+
     @pytest.mark.asyncio
     async def test_start_on_unavailable_port_fails(self):
         """Test that starting on an unavailable port fails gracefully."""

--- a/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
+++ b/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
@@ -35,10 +35,11 @@ class TestWebSocketMicrophoneInit:
         with pytest.raises(RuntimeError, match="Encryption requires a secret key"):
             WebSocketMicrophone(encrypt=True)
 
-    def test_empty_string_secret_fails(self):
-        """Test that secret="" raises RuntimeError."""
-        with pytest.raises(RuntimeError, match="Secret must be a non-empty string or None"):
-            WebSocketMicrophone(secret="")
+    def test_empty_string_secret_enables_bpp(self):
+        """Test that secret="" is valid and enables BPP authentication."""
+        mic = WebSocketMicrophone(port=0, secret="")
+        assert mic.codec is not None
+        assert mic.secret == ""
 
     @pytest.mark.asyncio
     async def test_start_on_unavailable_port_fails(self):

--- a/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
+++ b/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
@@ -376,6 +376,78 @@ class TestWebSocketClientConnection:
         mic.stop()
 
 
+class TestWebSocketClientEvents:
+    """Test WebSocket client event emission with client_name."""
+
+    @pytest.mark.asyncio
+    async def test_client_events(self):
+        """
+        Test that WebSocket microphone emits connection and disconnection events
+        with client_name extracted from URL query parameters.
+        """
+        events = []
+        main_loop = asyncio.get_running_loop()
+
+        connected = asyncio.Event()
+        disconnected = asyncio.Event()
+
+        mic = WebSocketMicrophone(port=0)
+
+        def event_listener(event_type, data):
+            if event_type == "connected":
+                main_loop.call_soon_threadsafe(connected.set)
+                assert "client_address" in data
+                assert "client_name" in data
+                assert data["client_name"] == "test_client"
+                assert mic.name == "test_client"
+            if event_type == "disconnected":
+                main_loop.call_soon_threadsafe(disconnected.set)
+                assert "client_address" in data
+                assert "client_name" in data
+                assert data["client_name"] == "test_client"
+                assert mic.name == "test_client"
+            events.append((event_type, data))
+
+        mic.on_status_changed(event_listener)
+        mic.start()
+
+        # This should emit connection and disconnection events
+        async def client_task():
+            async with websockets.connect(mic.url + "?client_name=test_client"):
+                pass
+
+        # Run client concurrently to properly test event handling
+        client = asyncio.create_task(client_task())
+
+        try:
+            await asyncio.wait_for(connected.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            pytest.fail("Connection event was not emitted within timeout")
+        try:
+            await asyncio.wait_for(disconnected.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            pytest.fail("Disconnection event was not emitted within timeout")
+
+        await client  # Ensure client task is finished and check for errors
+
+        # The events list is modified from another thread, so a brief sleep
+        # helps ensure the main thread sees the appended items before asserting.
+        await asyncio.sleep(0.1)
+
+        assert len(events) == 2
+        assert "connected" in events[0][0]
+        assert "disconnected" in events[1][0]
+
+        mic.stop()  # This should not emit a disconnection
+
+        await asyncio.sleep(0.1)
+
+        # Check that stop() didn't emit additional events
+        assert len(events) == 2
+        assert "connected" in events[0][0]
+        assert "disconnected" in events[1][0]
+
+
 class TestWebSocketClientDisconnection:
     """Test WebSocket client disconnection handling."""
 

--- a/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
+++ b/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
@@ -11,6 +11,7 @@ import json
 import base64
 import numpy as np
 
+from arduino.app_internal.core.peripherals.bpp_codec import BPPCodec
 from arduino.app_peripherals.microphone import WebSocketMicrophone, MicrophoneOpenError
 
 
@@ -512,5 +513,112 @@ class TestWebSocketPCMStreaming:
         for chunk in chunks:
             assert isinstance(chunk, np.ndarray)
             assert chunk.dtype == np.int16
+
+        mic.stop()
+
+
+TEST_SECRET = "test-secret-key"
+
+
+class TestWebSocketMicrophoneAuthenticated:
+    """Test WebSocket microphone with HMAC-SHA256 authentication (secret, no encryption)."""
+
+    @pytest.mark.asyncio
+    async def test_receive_authenticated_pcm(self):
+        """Test receiving BPP-authenticated PCM data."""
+        codec = BPPCodec(TEST_SECRET, enable_encryption=False)
+        mic = WebSocketMicrophone(port=0, secret=TEST_SECRET, encrypt=False)
+        mic.start()
+
+        test_audio = np.arange(512, dtype=np.int16)
+
+        async with websockets.connect(mic.url) as ws:
+            # Welcome should be BPP-encoded
+            welcome_raw = await ws.recv()
+            welcome_payload = codec.decode(welcome_raw)
+            assert welcome_payload is not None
+            welcome = json.loads(welcome_payload)
+            assert welcome["status"] == "connected"
+            assert "authenticated" in welcome["security_mode"]
+
+            # Send BPP-encoded audio
+            await ws.send(codec.encode(test_audio.tobytes()))
+
+            received = mic.capture()
+            assert received is not None
+            np.testing.assert_array_equal(received, test_audio)
+
+        mic.stop()
+
+    @pytest.mark.asyncio
+    async def test_authenticated_rejects_raw(self):
+        """Test that authenticated mode rejects raw (non-BPP) messages."""
+        mic = WebSocketMicrophone(port=0, secret=TEST_SECRET, encrypt=False)
+        mic.start()
+
+        test_audio = np.arange(512, dtype=np.int16)
+
+        async with websockets.connect(mic.url) as ws:
+            await ws.recv()  # Skip welcome
+
+            # Send raw bytes — should be rejected
+            await ws.send(test_audio.tobytes())
+
+            await asyncio.sleep(0.1)
+
+            received = mic.capture()
+            assert received is None
+
+        mic.stop()
+
+
+class TestWebSocketMicrophoneEncrypted:
+    """Test WebSocket microphone with ChaCha20-Poly1305 encryption."""
+
+    @pytest.mark.asyncio
+    async def test_receive_encrypted_pcm(self):
+        """Test receiving BPP-encrypted PCM data."""
+        codec = BPPCodec(TEST_SECRET, enable_encryption=True)
+        mic = WebSocketMicrophone(port=0, secret=TEST_SECRET, encrypt=True)
+        mic.start()
+
+        test_audio = np.arange(256, dtype=np.int16)
+
+        async with websockets.connect(mic.url) as ws:
+            # Welcome should be BPP-encoded with encryption
+            welcome_raw = await ws.recv()
+            welcome_payload = codec.decode(welcome_raw)
+            assert welcome_payload is not None
+            welcome = json.loads(welcome_payload)
+            assert welcome["status"] == "connected"
+            assert "encrypted" in welcome["security_mode"]
+
+            # Send BPP-encrypted audio
+            await ws.send(codec.encode(test_audio.tobytes()))
+
+            received = mic.capture()
+            assert received is not None
+            np.testing.assert_array_equal(received, test_audio)
+
+        mic.stop()
+
+    @pytest.mark.asyncio
+    async def test_encrypted_rejects_raw(self):
+        """Test that encrypted mode rejects raw (non-BPP) messages."""
+        mic = WebSocketMicrophone(port=0, secret=TEST_SECRET, encrypt=True)
+        mic.start()
+
+        test_audio = np.arange(256, dtype=np.int16)
+
+        async with websockets.connect(mic.url) as ws:
+            await ws.recv()  # Skip welcome
+
+            # Send raw bytes — should be rejected
+            await ws.send(test_audio.tobytes())
+
+            await asyncio.sleep(0.1)
+
+            received = mic.capture()
+            assert received is None
 
         mic.stop()

--- a/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
+++ b/tests/arduino/app_peripherals/microphone/test_websocket_microphone.py
@@ -11,14 +11,7 @@ import json
 import base64
 import numpy as np
 
-from arduino.app_internal.core.peripherals import BPPCodec
 from arduino.app_peripherals.microphone import WebSocketMicrophone, MicrophoneOpenError
-
-
-@pytest.fixture
-def codec() -> BPPCodec:
-    """Fixture to provide a codec if needed in future tests."""
-    return BPPCodec()
 
 
 class TestWebSocketMicrophoneInit:
@@ -59,7 +52,7 @@ class TestWebSocketPCMBinaryFormat:
     """Test receiving binary PCM streams."""
 
     @pytest.mark.asyncio
-    async def test_receive_binary_pcm_int16(self, codec):
+    async def test_receive_binary_pcm_int16(self):
         """Test receiving binary PCM data as int16."""
         mic = WebSocketMicrophone()
 
@@ -72,9 +65,8 @@ class TestWebSocketPCMBinaryFormat:
         async with websockets.connect(mic.url) as ws:
             await ws.recv()  # Welcome message
 
-            # Send binary PCM data
-            encoded = codec.encode(pcm_bytes)
-            await ws.send(encoded)
+            # Send raw PCM bytes directly (no BPP in plain mode)
+            await ws.send(pcm_bytes)
 
             # Capture and validate
             received = mic.capture()
@@ -88,7 +80,7 @@ class TestWebSocketPCMBinaryFormat:
         mic.stop()
 
     @pytest.mark.asyncio
-    async def test_receive_binary_pcm_int32(self, codec):
+    async def test_receive_binary_pcm_int32(self):
         """Test receiving binary PCM data as int32."""
         mic = WebSocketMicrophone(port=0, format=np.int32)
 
@@ -96,12 +88,11 @@ class TestWebSocketPCMBinaryFormat:
 
         test_audio = np.arange(512, dtype=np.int32)
         pcm_bytes = test_audio.tobytes()
-        encoded = codec.encode(pcm_bytes)
 
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
 
-            await ws.send(encoded)
+            await ws.send(pcm_bytes)
 
             received = mic.capture()
 
@@ -113,7 +104,7 @@ class TestWebSocketPCMBinaryFormat:
         mic.stop()
 
     @pytest.mark.asyncio
-    async def test_receive_binary_pcm_float32(self, codec):
+    async def test_receive_binary_pcm_float32(self):
         """Test receiving binary PCM data as float32."""
         mic = WebSocketMicrophone(port=0, format=np.float32)
 
@@ -125,8 +116,7 @@ class TestWebSocketPCMBinaryFormat:
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
 
-            encoded = codec.encode(pcm_bytes)
-            await ws.send(encoded)
+            await ws.send(pcm_bytes)
 
             received = mic.capture()
 
@@ -142,7 +132,7 @@ class TestWebSocketPCMBase64Format:
     """Test receiving base64-encoded PCM streams."""
 
     @pytest.mark.asyncio
-    async def test_receive_base64_encoded_pcm(self, codec):
+    async def test_receive_base64_encoded_pcm(self):
         """Test receiving base64-encoded PCM data."""
         mic = WebSocketMicrophone(port=0)
 
@@ -151,8 +141,7 @@ class TestWebSocketPCMBase64Format:
         # Create and encode test PCM data
         test_audio = np.arange(512, dtype=np.int16)
         pcm_bytes = test_audio.tobytes()
-        encoded = codec.encode(pcm_bytes)
-        base64_encoded = base64.b64encode(encoded).decode()
+        base64_encoded = base64.b64encode(pcm_bytes).decode()
 
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
@@ -170,7 +159,7 @@ class TestWebSocketPCMBase64Format:
         mic.stop()
 
     @pytest.mark.asyncio
-    async def test_receive_base64_with_padding(self, codec):
+    async def test_receive_base64_with_padding(self):
         """Test receiving base64 data with padding."""
         mic = WebSocketMicrophone(port=0)
 
@@ -179,8 +168,7 @@ class TestWebSocketPCMBase64Format:
         # Use size that requires padding in base64
         test_audio = np.arange(100, dtype=np.int16)
         pcm_bytes = test_audio.tobytes()
-        encoded = codec.encode(pcm_bytes)
-        base64_encoded = base64.b64encode(encoded).decode()
+        base64_encoded = base64.b64encode(pcm_bytes).decode()
 
         # Verify it has padding
         assert "=" in base64_encoded or len(base64_encoded) % 4 == 0
@@ -202,7 +190,7 @@ class TestWebSocketMultipleChunks:
     """Test receiving multiple PCM chunks sequentially."""
 
     @pytest.mark.asyncio
-    async def test_receive_multiple_sequential_chunks(self, codec):
+    async def test_receive_multiple_sequential_chunks(self):
         """Test receiving correctly multiple PCM chunks in sequence."""
         mic = WebSocketMicrophone(port=0)
 
@@ -216,8 +204,7 @@ class TestWebSocketMultipleChunks:
             for i in range(5):  # Internal queue holds up to 10 chunks
                 chunk = np.full(128, i, dtype=np.int16)
                 sent_chunks.append(chunk)
-                encoded = codec.encode(chunk.tobytes())
-                await ws.send(encoded)
+                await ws.send(chunk.tobytes())
 
             received_chunks = []
             for _ in range(5):
@@ -234,7 +221,7 @@ class TestWebSocketMultipleChunks:
         mic.stop()
 
     @pytest.mark.asyncio
-    async def test_receive_rapid_fire_chunks(self, codec):
+    async def test_receive_rapid_fire_chunks(self):
         """Test receiving chunks sent in rapid succession."""
         mic = WebSocketMicrophone(port=0)
 
@@ -246,8 +233,7 @@ class TestWebSocketMultipleChunks:
             # Send chunks rapidly without delay
             for i in range(10):  # Internal queue holds up to 10 chunks
                 chunk = np.full(64, i, dtype=np.int16)
-                encoded = codec.encode(chunk.tobytes())
-                await ws.send(encoded)
+                await ws.send(chunk.tobytes())
 
             # Should handle rapid chunks
             for i in range(10):
@@ -261,7 +247,7 @@ class TestWebSocketPCMDataIntegrity:
     """Test data integrity of received PCM streams."""
 
     @pytest.mark.asyncio
-    async def test_pcm_values_preserved_exactly(self, codec):
+    async def test_pcm_values_preserved_exactly(self):
         """Test that PCM values are preserved exactly through transmission."""
         mic = WebSocketMicrophone(port=0)
 
@@ -269,12 +255,11 @@ class TestWebSocketPCMDataIntegrity:
 
         # Create test pattern with known values
         test_audio = np.array([0, 100, -100, 32000, -32000, 1, -1], dtype=np.int16)
-        encoded = codec.encode(test_audio.tobytes())
 
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
 
-            await ws.send(encoded)
+            await ws.send(test_audio.tobytes())
 
             received = mic.capture()
 
@@ -284,7 +269,7 @@ class TestWebSocketPCMDataIntegrity:
         mic.stop()
 
     @pytest.mark.asyncio
-    async def test_pcm_byte_order_preserved(self, codec):
+    async def test_pcm_byte_order_preserved(self):
         """Test that byte order is preserved in PCM transmission."""
         mic = WebSocketMicrophone(port=0)
 
@@ -292,12 +277,11 @@ class TestWebSocketPCMDataIntegrity:
 
         # Test with values that would differ if byte order is wrong
         test_audio = np.array([256, 257, 258], dtype=np.int16)
-        encoded = codec.encode(test_audio.tobytes())
 
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
 
-            await ws.send(encoded)
+            await ws.send(test_audio.tobytes())
 
             received = mic.capture()
 
@@ -310,7 +294,7 @@ class TestWebSocketClientConnection:
     """Test WebSocket client connection handling."""
 
     @pytest.mark.asyncio
-    async def test_client_receives_welcome_message(self, codec):
+    async def test_client_receives_welcome_message(self):
         """Test that client receives welcome message on connection."""
         mic = WebSocketMicrophone(port=0)
 
@@ -319,8 +303,7 @@ class TestWebSocketClientConnection:
         async with websockets.connect(mic.url) as ws:
             welcome = await ws.recv()
 
-            decoded = codec.decode(welcome)
-            welcome_data = json.loads(decoded)
+            welcome_data = json.loads(welcome)
 
             assert "status" in welcome_data
             assert welcome_data["status"] == "connected"
@@ -330,7 +313,7 @@ class TestWebSocketClientConnection:
         mic.stop()
 
     @pytest.mark.asyncio
-    async def test_single_client_enforcement(self, codec):
+    async def test_single_client_enforcement(self):
         """Test that only one client can connect at a time."""
         mic = WebSocketMicrophone(port=0)
 
@@ -339,8 +322,7 @@ class TestWebSocketClientConnection:
         # Connect first client
         async with websockets.connect(mic.url) as client1:
             welcome = await client1.recv()  # Welcome
-            decoded = codec.decode(welcome)
-            welcome_data = json.loads(decoded)
+            welcome_data = json.loads(welcome)
             assert "status" in welcome_data
             assert welcome_data["status"] == "connected"
 
@@ -348,14 +330,13 @@ class TestWebSocketClientConnection:
             async with websockets.connect(mic.url) as client2:
                 # Should receive rejection
                 rejection = await client2.recv()
-                decoded = codec.decode(rejection)
-                rejection_data = json.loads(decoded)
+                rejection_data = json.loads(rejection)
                 assert "error" in rejection_data
 
         mic.stop()
 
     @pytest.mark.asyncio
-    async def test_client_disconnection_handled(self, codec):
+    async def test_client_disconnection_handled(self):
         """Test that client disconnection is handled gracefully."""
         loop = asyncio.get_running_loop()
         test_done = asyncio.Event()
@@ -373,12 +354,11 @@ class TestWebSocketClientConnection:
         mic.start()
 
         test_audio = np.zeros(128, dtype=np.int16).tobytes()
-        encoded = codec.encode(test_audio)
 
         # Connect and disconnect
         async with websockets.connect(mic.url) as ws:
             await ws.recv()
-            await ws.send(encoded)
+            await ws.send(test_audio)
 
         await asyncio.wait_for(test_done.wait(), timeout=2)
         mic.stop()
@@ -424,7 +404,7 @@ class TestWebSocketClientDisconnection:
         assert mic._client is None
 
     @pytest.mark.asyncio
-    async def test_client_reconnect_after_disconnect(self, codec):
+    async def test_client_reconnect_after_disconnect(self):
         """Test that client can reconnect after disconnecting."""
         mic = WebSocketMicrophone(port=0)
 
@@ -437,8 +417,7 @@ class TestWebSocketClientDisconnection:
         # Second connection should work
         async with websockets.connect(mic.url) as ws:
             welcome = await ws.recv()
-            decoded = codec.decode(welcome)
-            assert "connected" in decoded.decode()
+            assert "connected" in welcome.decode()
 
         mic.stop()
 
@@ -497,7 +476,7 @@ class TestWebSocketPCMStreaming:
     """Test continuous PCM streaming from WebSocket."""
 
     @pytest.mark.asyncio
-    async def test_continuous_pcm_stream(self, codec):
+    async def test_continuous_pcm_stream(self):
         """Test continuous PCM streaming from client."""
         mic = WebSocketMicrophone(port=0)
 
@@ -510,8 +489,7 @@ class TestWebSocketPCMStreaming:
                 # Stream 10 chunks then stop
                 for i in range(10):
                     chunk = np.full(128, i, dtype=np.int16)
-                    encoded = codec.encode(chunk.tobytes())
-                    await ws.send(encoded)
+                    await ws.send(chunk.tobytes())
 
         # Start streaming
         stream_task = asyncio.create_task(stream_audio())


### PR DESCRIPTION
This PR removes the need to use the BPP protocol for plaintext communication with the WebSocketCamera and WebSocketMicrophone endpoints.