### PR TITLE
Add loop support for SoundGenerator.play_composition()

### DIFF
--- a/src/arduino/app_bricks/sound_generator/README.md
+++ b/src/arduino/app_bricks/sound_generator/README.md
@@ -8,9 +8,9 @@ Sound Generator is a lightweight and expressive audio generation brick that lets
 
 - Generate tones and melodies from notes or frequencies
 - Choose your waveform — sine, square, triangle, sawtooth
-- Add sound effects such as chorus, overdrive, delay, vibrato, or distortion
+- Add sound effects such as ADSR, bitcrusher, chorus, tremolo, vibrato, or overdrive
 - Compose procedural music directly from code
-- Real-time playback over speaker
+- Playback over speaker
 
 ## Code example and usage
 

--- a/src/arduino/app_bricks/sound_generator/__init__.py
+++ b/src/arduino/app_bricks/sound_generator/__init__.py
@@ -628,6 +628,52 @@ class SoundGenerator(SoundGeneratorStreamer):
             self._output_device.start()
             self._sync_sample_rate()
 
+    def _estimate_output_drain_time(self) -> float:
+        """Estimate a small drain time so blocking playback does not cut the tail."""
+        sample_rate = getattr(self._output_device, "sample_rate", 0)
+        buffer_size = getattr(self._output_device, "buffer_size", 0)
+        if not sample_rate or not buffer_size:
+            return 0.0
+        return min((float(buffer_size) / float(sample_rate)) * 2.0, 0.25)
+
+    def _wait_for_playback_session_end(self, session_id: int):
+        """Wait until the given playback session is no longer active."""
+        while True:
+            with self._sequence_lock:
+                current_session_id = self._playback_session_id
+                current_thread = self._sequence_thread
+            if current_session_id != session_id or current_thread is None or not current_thread.is_alive():
+                return
+            time.sleep(0.01)
+
+    def _schedule_sequence_stop(self, session_id: int, delay: float) -> threading.Event:
+        """Schedule a timed stop for the currently running playback session."""
+        stop_done = threading.Event()
+
+        def stop_after_delay():
+            deadline = time.monotonic() + delay
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0.0:
+                    break
+                time.sleep(min(0.1, remaining))
+                with self._sequence_lock:
+                    current_session_id = self._playback_session_id
+                    current_thread = self._sequence_thread
+                if current_session_id != session_id or current_thread is None or not current_thread.is_alive():
+                    stop_done.set()
+                    return
+
+            with self._sequence_lock:
+                current_session_id = self._playback_session_id
+                current_thread = self._sequence_thread
+            if current_session_id == session_id and current_thread is not None and current_thread.is_alive():
+                self.stop_sequence()
+            stop_done.set()
+
+        threading.Thread(target=stop_after_delay, daemon=True, name="SoundGen-CompStopTimer").start()
+        return stop_done
+
     def set_master_volume(self, volume: float):
         """
         Set the master volume level.
@@ -662,7 +708,13 @@ class SoundGenerator(SoundGeneratorStreamer):
         if block and duration > 0.0:
             time.sleep(duration)
 
-    def play_composition(self, composition: "MusicComposition", block: bool = False):
+    def play_composition(
+        self,
+        composition: "MusicComposition",
+        loop: bool = False,
+        play_for: float | None = None,
+        block: bool | None = None,
+    ):
         """
         Play a MusicComposition object.
 
@@ -674,8 +726,32 @@ class SoundGenerator(SoundGeneratorStreamer):
 
         Args:
             composition (MusicComposition): The composition to play.
-            block (bool): If True, block until the entire composition has been played.
+            loop (bool): If True, loop the composition until ``stop_sequence()``
+                is called or until ``play_for`` expires.
+            play_for (float | None): When looping, stop automatically after the
+                given number of seconds. Requires ``loop=True``.
+            block (bool | None): Controls whether this call waits for playback.
+                - True: wait until the current playback session ends. When
+                  ``loop=True`` and ``play_for`` is not set, this may block
+                  indefinitely until ``stop_sequence()`` or ``stop()`` is called
+                  from another thread.
+                - False: start playback and return immediately.
+                - None: choose automatically based on the playback mode. Finite
+                  playback blocks, infinite looping returns immediately, and
+                  timed looping (``loop=True`` with ``play_for`` set) blocks
+                  until the timed stop completes. This is the recommended
+                  default for most scripts and examples.
         """
+        if play_for is not None:
+            play_for = float(play_for)
+            if play_for <= 0.0:
+                raise ValueError("play_for must be greater than 0.")
+            if not loop:
+                raise ValueError("play_for requires loop=True.")
+
+        if block is None:
+            block = (not loop) or (play_for is not None)
+
         # Configure the generator with composition settings
         self.set_bpm(composition.bpm)
         self.set_wave_form(composition.waveform)
@@ -697,27 +773,45 @@ class SoundGenerator(SoundGeneratorStreamer):
         if step_duration is None:
             step_duration = 1 / 16  # Default fallback
 
-        if block:
-            # Use threading to wait for completion
-            playback_done = threading.Event()
+        playback_done = threading.Event()
+        on_complete_callback = None
+        if not loop:
 
             def on_complete():
                 playback_done.set()
 
-            self.play_step_sequence(
-                sequence=sequence,
-                note_duration=step_duration,
-                bpm=composition.bpm,
-                loop=False,
-                on_complete_callback=on_complete,
-                volume=composition.volume,
-            )
+            on_complete_callback = on_complete
 
+        self.play_step_sequence(
+            sequence=sequence,
+            note_duration=step_duration,
+            bpm=composition.bpm,
+            loop=loop,
+            on_complete_callback=on_complete_callback,
+            volume=composition.volume,
+        )
+
+        with self._sequence_lock:
+            session_id = self._playback_session_id
+
+        timed_stop_done = None
+        if loop and play_for is not None:
+            timed_stop_done = self._schedule_sequence_stop(session_id, play_for)
+
+        if not block:
+            return
+
+        if not loop:
             playback_done.wait()
-            # Buffer time for audio queue to drain
-            time.sleep(2.0)
-        else:
-            self.play_step_sequence(sequence=sequence, note_duration=step_duration, bpm=composition.bpm, loop=False, volume=composition.volume)
+            self._wait_for_playback_session_end(session_id)
+            drain_time = self._estimate_output_drain_time()
+            if drain_time > 0.0:
+                time.sleep(drain_time)
+            return
+
+        if timed_stop_done is not None:
+            timed_stop_done.wait()
+        self._wait_for_playback_session_end(session_id)
 
     def play_chord(self, notes: list[str], note_duration: float | str = 1 / 4, volume: float = None, block: bool = False):
         """
@@ -867,14 +961,15 @@ class SoundGenerator(SoundGeneratorStreamer):
         # Ensure speaker is ready before starting the sequence thread
         self._ensure_speaker_ready()
 
-        # Start playback thread with new session ID
+        # Start a non-daemon thread so queued playback can keep the process
+        # alive until the sequence finishes or is explicitly stopped.
         self._sequence_stop_event.clear()
         self._playback_session_id += 1
         session_id = self._playback_session_id
         self._sequence_thread = threading.Thread(
             target=self._playback_sequence_thread,
             args=(sequence, note_duration, bpm, loop, on_step_callback, on_complete_callback, volume, session_id),
-            daemon=True,
+            daemon=False,
             name="SoundGen-StepSeq",
         )
         self._sequence_thread.start()

--- a/src/arduino/app_bricks/sound_generator/__init__.py
+++ b/src/arduino/app_bricks/sound_generator/__init__.py
@@ -987,7 +987,7 @@ class SoundGenerator(SoundGeneratorStreamer):
         immediately drop any pending audio in the ALSA buffer.  The speaker is
         transparently restarted on the next play call via _ensure_speaker_ready.
         """
-        logger.info("stop_sequence() called")
+        logger.debug("stop_sequence() called")
         should_stop_speaker = False
         with self._sequence_lock:
             if self._sequence_thread and self._sequence_thread.is_alive():

--- a/src/arduino/app_bricks/sound_generator/__init__.py
+++ b/src/arduino/app_bricks/sound_generator/__init__.py
@@ -10,6 +10,7 @@ import numpy as np
 import time
 from pathlib import Path
 from collections import OrderedDict
+import math
 
 from .generator import WaveSamplesBuilder
 from .effects import *
@@ -544,6 +545,8 @@ class SoundGenerator(SoundGeneratorStreamer):
 
         Args:
             output_device (Speaker, optional): The output device to play sound through.
+                When omitted, SoundGenerator creates an internal shared speaker so
+                multiple instances can overlap playback on the same device.
             bpm (int): The tempo in beats per minute for note duration calculations.
             time_signature (tuple): The time signature as (numerator, denominator).
             octaves (int): Number of octaves to generate notes for (starting from octave
@@ -567,8 +570,9 @@ class SoundGenerator(SoundGeneratorStreamer):
         self._started = threading.Event()
         if output_device is None:
             self.external_speaker = False
-            # Request 16 kHz, float32, small buffer for low-latency playback.
-            self._output_device = Speaker(sample_rate=Speaker.RATE_16K, format=np.float32, buffer_size=Speaker.BUFFER_SIZE_REALTIME, shared=False)
+            # Use shared mode by default so multiple SoundGenerator instances can
+            # overlap playback on the same speaker.
+            self._output_device = Speaker(sample_rate=Speaker.RATE_32K, format=np.float32, buffer_size=Speaker.BUFFER_SIZE_SAFE, shared=True)
         else:
             self.external_speaker = True
             self._output_device = output_device
@@ -630,8 +634,8 @@ class SoundGenerator(SoundGeneratorStreamer):
 
     def _estimate_output_drain_time(self) -> float:
         """Estimate a small drain time so blocking playback does not cut the tail."""
-        sample_rate = getattr(self._output_device, "sample_rate", 0)
-        buffer_size = getattr(self._output_device, "buffer_size", 0)
+        sample_rate = self._output_device.sample_rate
+        buffer_size = self._output_device.buffer_size
         if not sample_rate or not buffer_size:
             return 0.0
         return min((float(buffer_size) / float(sample_rate)) * 2.0, 0.25)
@@ -1012,6 +1016,14 @@ class SoundGenerator(SoundGeneratorStreamer):
         with self._sequence_lock:
             return self._sequence_thread is not None and self._sequence_thread.is_alive()
 
+    def _render_sequence_step(self, notes: list[str], note_duration: float | str, volume: float):
+        """Render a single sequence step to a float32 audio buffer."""
+        if notes and len(notes) > 0:
+            if len(notes) == 1:
+                return super(SoundGenerator, self).play(notes[0], note_duration, volume)
+            return super(SoundGenerator, self).play_chord(notes, note_duration, volume)
+        return super(SoundGenerator, self).play("REST", note_duration, volume)
+
     def _playback_sequence_thread(
         self,
         sequence: list[list[str]],
@@ -1040,30 +1052,36 @@ class SoundGenerator(SoundGeneratorStreamer):
             total_steps = len(sequence)
 
             logger.info(f"Starting sequence: {total_steps} steps at {bpm} BPM")
+            speaker_buffer = float(self._output_device.buffer_size or 0)
+            speaker_rate = float(self._sample_rate or self._output_device.sample_rate or 0)
+            shared_prequeue_lead = (
+                (speaker_buffer / speaker_rate) if self._output_device.shared and speaker_buffer > 0.0 and speaker_rate > 0.0 else 0.0
+            )
+            prequeue_future_steps = max(1, int(math.ceil(shared_prequeue_lead / duration))) if shared_prequeue_lead > 0.0 and duration > 0.0 else 0
+            render_ahead_steps = max(1, prequeue_future_steps)
 
             step_iterator = cycle(enumerate(sequence)) if loop else enumerate(sequence)
+            current_step = next(step_iterator, None)
+            if current_step is None:
+                return
 
-            step_count = 0
-            for step_index, notes in step_iterator:
+            current_step_index, current_notes = current_step
+            current_data = self._render_sequence_step(current_notes, note_duration, volume)
+            current_data_prequeued = False
+            future_steps = []
+
+            processed_steps = 0
+            while current_step is not None:
                 step_start = time.monotonic()
 
                 if self._sequence_stop_event.is_set():
-                    logger.debug(f"Sequence stopped at step {step_index}")
+                    logger.debug(f"Sequence stopped at step {current_step_index}")
                     break
 
-                # --- Generate audio for this step ---
-                if notes and len(notes) > 0:
-                    if len(notes) == 1:
-                        data = super(SoundGenerator, self).play(notes[0], note_duration, volume)
-                    else:
-                        data = super(SoundGenerator, self).play_chord(notes, note_duration, volume)
-                else:
-                    data = super(SoundGenerator, self).play("REST", note_duration, volume)
-
                 # --- Send audio to speaker ---
-                if data is not None:
+                if current_data is not None and not current_data_prequeued:
                     try:
-                        self._output_device.play(data)
+                        self._output_device.play(current_data)
                     except Exception:
                         # Speaker was closed by stop_sequence() — exit gracefully
                         if self._sequence_stop_event.is_set():
@@ -1073,14 +1091,34 @@ class SoundGenerator(SoundGeneratorStreamer):
                 # --- Step callback ---
                 if on_step_callback:
                     try:
-                        on_step_callback(step_index, total_steps)
+                        on_step_callback(current_step_index, total_steps)
                     except Exception as e:
                         logger.error(f"Error in step callback: {e}")
 
+                processed_steps += 1
+
+                while not self._sequence_stop_event.is_set() and len(future_steps) < render_ahead_steps:
+                    if not loop and processed_steps + len(future_steps) >= total_steps:
+                        break
+                    next_step = next(step_iterator, None)
+                    if next_step is None:
+                        break
+
+                    next_step_index, next_notes = next_step
+                    next_data = self._render_sequence_step(next_notes, note_duration, volume)
+                    next_data_prequeued = len(future_steps) < prequeue_future_steps
+                    if next_data is not None and next_data_prequeued:
+                        try:
+                            self._output_device.play(next_data)
+                        except Exception:
+                            if self._sequence_stop_event.is_set():
+                                break
+                            raise
+                    future_steps.append((next_step_index, next_notes, next_data, next_data_prequeued))
+
                 # --- Wait for the remaining step duration ----
-                # speaker.play() may have already consumed part of the step time
-                # via ALSA back-pressure; sleep only the remainder so timing is
-                # correct regardless of the speaker's buffer size.
+                # Rendering the next step happens before this sleep so the next
+                # write can be issued immediately at the step boundary.
                 elapsed = time.monotonic() - step_start
                 remaining = duration - elapsed
                 if remaining > 0.0:
@@ -1093,10 +1131,10 @@ class SoundGenerator(SoundGeneratorStreamer):
                             break
                         time.sleep(min(0.01, left))
 
-                step_count += 1
-                if not loop and step_count >= total_steps:
+                if not future_steps:
                     break
 
+                current_step_index, current_notes, current_data, current_data_prequeued = future_steps.pop(0)
             logger.info("Sequence playback ended")
 
             if not self._sequence_stop_event.is_set() and not loop and on_complete_callback:

--- a/src/arduino/app_bricks/sound_generator/__init__.py
+++ b/src/arduino/app_bricks/sound_generator/__init__.py
@@ -715,9 +715,9 @@ class SoundGenerator(SoundGeneratorStreamer):
     def play_composition(
         self,
         composition: "MusicComposition",
+        block: bool | None = None,
         loop: bool = False,
         play_for: float | None = None,
-        block: bool | None = None,
     ):
         """
         Play a MusicComposition object.
@@ -730,10 +730,6 @@ class SoundGenerator(SoundGeneratorStreamer):
 
         Args:
             composition (MusicComposition): The composition to play.
-            loop (bool): If True, loop the composition until ``stop_sequence()``
-                is called or until ``play_for`` expires.
-            play_for (float | None): When looping, stop automatically after the
-                given number of seconds. Requires ``loop=True``.
             block (bool | None): Controls whether this call waits for playback.
                 - True: wait until the current playback session ends. When
                   ``loop=True`` and ``play_for`` is not set, this may block
@@ -745,6 +741,10 @@ class SoundGenerator(SoundGeneratorStreamer):
                   timed looping (``loop=True`` with ``play_for`` set) blocks
                   until the timed stop completes. This is the recommended
                   default for most scripts and examples.
+            loop (bool): If True, loop the composition until ``stop_sequence()``
+                is called or until ``play_for`` expires.
+            play_for (float | None): When looping, stop automatically after the
+                given number of seconds. Requires ``loop=True``.
         """
         if play_for is not None:
             play_for = float(play_for)

--- a/src/arduino/app_bricks/sound_generator/composition.py
+++ b/src/arduino/app_bricks/sound_generator/composition.py
@@ -45,8 +45,10 @@ class MusicComposition:
 
         # Configure and play with SoundGenerator
         gen = SoundGenerator()
-        gen.start()
-        gen.play_composition(comp, block=True)
+        gen.play_composition(comp)  # Plays once and waits for completion
+
+        # Loop for a fixed time
+        gen.play_composition(comp, loop=True, play_for=10.0)
 
         # Alternatively, set parameters manually and play
         gen = SoundGenerator()

--- a/src/arduino/app_bricks/sound_generator/examples/8_play_composition.py
+++ b/src/arduino/app_bricks/sound_generator/examples/8_play_composition.py
@@ -29,6 +29,21 @@ comp = MusicComposition(
 )
 
 player = SoundGenerator()
-player.play_composition(comp, block=True)
+
+# Choose how to play the composition:
+# - "once": play it once and wait automatically until it finishes
+# - "timed_loop": loop it for a fixed duration and wait automatically
+# - "loop": loop forever until the app is stopped
+PLAY_MODE = "timed_loop"
+LOOP_DURATION_SECONDS = 10.0
+
+if PLAY_MODE == "once":
+    player.play_composition(comp)
+elif PLAY_MODE == "timed_loop":
+    player.play_composition(comp, loop=True, play_for=LOOP_DURATION_SECONDS)
+elif PLAY_MODE == "loop":
+    player.play_composition(comp, loop=True)
+else:
+    raise ValueError(f"Unsupported PLAY_MODE: {PLAY_MODE}")
 
 App.run()

--- a/src/arduino/app_peripherals/speaker/alsa_speaker.py
+++ b/src/arduino/app_peripherals/speaker/alsa_speaker.py
@@ -67,8 +67,8 @@ class ALSASpeaker(BaseSpeaker):
             auto_reconnect (bool): Enable automatic reconnection on failure.
                 Default: True.
 
-            Note: When shared=True, only higher buffer size values are supported due to
-                ALSA limitations (~2000).
+            Note: When shared=True, buffer size is auto-negotiated due to
+                ALSA limitations to reach 125ms of latency.
 
         Raises:
             SpeakerConfigError: If the format is not supported.

--- a/tests/arduino/app_bricks/sound_generator/test_play_composition.py
+++ b/tests/arduino/app_bricks/sound_generator/test_play_composition.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
 import threading
 
 import pytest

--- a/tests/arduino/app_bricks/sound_generator/test_play_composition.py
+++ b/tests/arduino/app_bricks/sound_generator/test_play_composition.py
@@ -4,6 +4,7 @@
 
 import threading
 
+import numpy as np
 import pytest
 
 from arduino.app_bricks.sound_generator import MusicComposition, SoundGenerator
@@ -11,7 +12,86 @@ import arduino.app_bricks.sound_generator as sound_generator_module
 
 
 class DummySpeaker:
-    sample_rate = 16000
+    sample_rate = 32000
+    buffer_size = 4096
+    shared = True
+
+
+def test_playback_sequence_thread_prequeues_enough_future_steps_to_cover_speaker_period(monkeypatch):
+    events = []
+    current_time = {"value": 0.0}
+
+    class SequencerSpeaker:
+        sample_rate = 10
+        buffer_size = 1
+        shared = True
+
+        def play(self, data):
+            events.append(("play", round(current_time["value"], 3), len(data)))
+
+    generator = SoundGenerator(output_device=SequencerSpeaker(), bpm=180)
+
+    def fake_render(notes, note_duration, volume):
+        events.append(("render", round(current_time["value"], 3), tuple(notes)))
+        current_time["value"] += 0.01
+        return np.ones(8, dtype=np.float32)
+
+    def fake_sleep(delay):
+        events.append(("sleep", round(current_time["value"], 3), round(delay, 3)))
+        current_time["value"] += delay
+
+    monkeypatch.setattr(generator, "_render_sequence_step", fake_render)
+    monkeypatch.setattr(sound_generator_module.time, "monotonic", lambda: current_time["value"])
+    monkeypatch.setattr(sound_generator_module.time, "sleep", fake_sleep)
+
+    generator._playback_sequence_thread(
+        sequence=[["C4"], ["D4"], ["E4"]],
+        note_duration=1 / 16,
+        bpm=180,
+        loop=False,
+        on_step_callback=None,
+        on_complete_callback=None,
+        volume=None,
+        session_id=1,
+    )
+
+    non_sleep_events = [event for event in events if event[0] != "sleep"]
+    assert non_sleep_events[:6] == [
+        ("render", 0.0, ("C4",)),
+        ("play", 0.01, 8),
+        ("render", 0.01, ("D4",)),
+        ("play", 0.02, 8),
+        ("render", 0.02, ("E4",)),
+        ("play", 0.03, 8),
+    ]
+
+
+def test_sound_generator_default_speaker_is_shared(monkeypatch):
+    captured = {}
+
+    class FakeInternalSpeaker:
+        sample_rate = 32000
+
+    class FakeSpeakerFactory:
+        RATE_32K = 32000
+        BUFFER_SIZE_SAFE = 4096
+
+        def __new__(cls, **kwargs):
+            captured.update(kwargs)
+            return FakeInternalSpeaker()
+
+    monkeypatch.setattr(sound_generator_module, "Speaker", FakeSpeakerFactory)
+
+    generator = SoundGenerator()
+
+    assert generator.external_speaker is False
+    assert isinstance(generator._output_device, FakeInternalSpeaker)
+    assert captured == {
+        "sample_rate": 32000,
+        "format": np.float32,
+        "buffer_size": 4096,
+        "shared": True,
+    }
 
 
 def test_play_composition_passes_loop_to_step_sequence():

--- a/tests/arduino/app_bricks/sound_generator/test_play_composition.py
+++ b/tests/arduino/app_bricks/sound_generator/test_play_composition.py
@@ -1,0 +1,157 @@
+import threading
+
+import pytest
+
+from arduino.app_bricks.sound_generator import MusicComposition, SoundGenerator
+import arduino.app_bricks.sound_generator as sound_generator_module
+
+
+class DummySpeaker:
+    sample_rate = 16000
+
+
+def test_play_composition_passes_loop_to_step_sequence():
+    generator = SoundGenerator(output_device=DummySpeaker())
+    composition = MusicComposition(
+        composition=[
+            [("C4", 1 / 16)],
+            [("REST", 1 / 16)],
+            [("E4", 1 / 16), ("G4", 1 / 16)],
+        ],
+        bpm=140,
+        waveform="square",
+        volume=0.7,
+        effects=[],
+    )
+
+    captured = {}
+
+    def fake_play_step_sequence(*, sequence, note_duration, bpm, loop, volume, on_complete_callback=None, **kwargs):
+        captured["sequence"] = sequence
+        captured["note_duration"] = note_duration
+        captured["bpm"] = bpm
+        captured["loop"] = loop
+        captured["volume"] = volume
+        captured["on_complete_callback"] = on_complete_callback
+
+    generator.play_step_sequence = fake_play_step_sequence
+
+    generator.play_composition(composition, loop=True)
+
+    assert captured == {
+        "sequence": [["C4"], [], ["E4", "G4"]],
+        "note_duration": 1 / 16,
+        "bpm": 140,
+        "loop": True,
+        "volume": 0.7,
+        "on_complete_callback": None,
+    }
+
+
+def test_play_composition_defaults_to_blocking_for_one_shot(monkeypatch):
+    generator = SoundGenerator(output_device=DummySpeaker())
+    composition = MusicComposition(
+        composition=[[("C4", 1 / 16)]],
+        effects=[],
+    )
+    captured = {}
+
+    monkeypatch.setattr(sound_generator_module.time, "sleep", lambda _: None)
+
+    def fake_play_step_sequence(*, on_complete_callback=None, **kwargs):
+        captured["on_complete_callback"] = on_complete_callback
+        if on_complete_callback is not None:
+            on_complete_callback()
+
+    generator.play_step_sequence = fake_play_step_sequence
+
+    generator.play_composition(composition)
+
+    assert captured["on_complete_callback"] is not None
+
+
+def test_play_composition_defaults_to_blocking_for_timed_loop(monkeypatch):
+    generator = SoundGenerator(output_device=DummySpeaker())
+    composition = MusicComposition(
+        composition=[[("C4", 1 / 16)]],
+        effects=[],
+    )
+    captured = {}
+    stop_done = threading.Event()
+    stop_done.set()
+
+    def fake_play_step_sequence(**kwargs):
+        generator._playback_session_id = 7
+        generator._sequence_thread = None
+        captured["loop"] = kwargs["loop"]
+        captured["on_complete_callback"] = kwargs.get("on_complete_callback")
+
+    def fake_schedule_sequence_stop(session_id: int, delay: float):
+        captured["scheduled_session_id"] = session_id
+        captured["scheduled_delay"] = delay
+        return stop_done
+
+    def fake_wait_for_playback_session_end(session_id: int):
+        captured["waited_session_id"] = session_id
+
+    monkeypatch.setattr(generator, "play_step_sequence", fake_play_step_sequence)
+    monkeypatch.setattr(generator, "_schedule_sequence_stop", fake_schedule_sequence_stop)
+    monkeypatch.setattr(generator, "_wait_for_playback_session_end", fake_wait_for_playback_session_end)
+
+    generator.play_composition(composition, loop=True, play_for=5.0)
+
+    assert captured == {
+        "loop": True,
+        "on_complete_callback": None,
+        "scheduled_session_id": 7,
+        "scheduled_delay": 5.0,
+        "waited_session_id": 7,
+    }
+
+
+def test_play_composition_rejects_invalid_play_for_without_loop():
+    generator = SoundGenerator(output_device=DummySpeaker())
+    composition = MusicComposition(
+        composition=[[("C4", 1 / 16)]],
+        effects=[],
+    )
+
+    with pytest.raises(ValueError, match="play_for requires loop=True"):
+        generator.play_composition(composition, play_for=5.0)
+
+
+def test_play_composition_rejects_non_positive_play_for():
+    generator = SoundGenerator(output_device=DummySpeaker())
+    composition = MusicComposition(
+        composition=[[("C4", 1 / 16)]],
+        effects=[],
+    )
+
+    with pytest.raises(ValueError, match="play_for must be greater than 0"):
+        generator.play_composition(composition, loop=True, play_for=0.0)
+
+
+def test_play_step_sequence_uses_non_daemon_thread(monkeypatch):
+    generator = SoundGenerator(output_device=DummySpeaker())
+    captured = {}
+
+    class FakeThread:
+        def __init__(self, *, target, args, daemon, name):
+            captured["target"] = target
+            captured["args"] = args
+            captured["daemon"] = daemon
+            captured["name"] = name
+            self._alive = False
+
+        def start(self):
+            self._alive = True
+
+        def is_alive(self):
+            return self._alive
+
+    monkeypatch.setattr(sound_generator_module.threading, "Thread", FakeThread)
+
+    generator.play_step_sequence(sequence=[["C4"]], loop=False)
+
+    assert captured["daemon"] is False
+    assert captured["name"] == "SoundGen-StepSeq"


### PR DESCRIPTION
This PR adds play-in-loop support for `SoundGenerator.play_composition()`.

Method's signature has changed to add:
- play in loop support
- play in loop for a definite time interval
- handle blocking or non blocking in every mode

Minimal example has also changed to show all playback modes.

> It is also tested the overlapping playback of two `SoundGenerator.play_composition()` to overlap and mix many sequences with different starting point or playback modes.