### PR TITLE
fix: do not crash if FPS capability is not correctyl readable

### DIFF
--- a/src/arduino/app_peripherals/camera/v4l_camera.py
+++ b/src/arduino/app_peripherals/camera/v4l_camera.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+import math
 import os
 import time
 from typing import Literal, Optional
@@ -221,10 +222,14 @@ class V4LCamera(BaseCamera):
             if self.fps:
                 self._cap.set(cv2.CAP_PROP_FPS, self.fps)
 
-                actual_fps = int(self._cap.get(cv2.CAP_PROP_FPS))
-                if actual_fps != self.fps:
-                    logger.warning(f"Camera {self.name} FPS set to {actual_fps} instead of requested {self.fps}")
-                    self.fps = actual_fps
+                configured_fps = self._cap.get(cv2.CAP_PROP_FPS)
+                if math.isnan(configured_fps) or configured_fps <= 0:
+                    logger.warning(f"Camera {self.name} returned invalid FPS value: {configured_fps}. Cannot verify FPS setting.")
+                else:
+                    actual_fps = int(configured_fps)
+                    if actual_fps != self.fps:
+                        logger.warning(f"Camera {self.name} FPS set to {actual_fps} instead of requested {self.fps}")
+                        self.fps = actual_fps
 
             # Verify camera with a test read
             ret, frame = self._cap.read()

--- a/tests/arduino/app_peripherals/camera/test_v4l_camera.py
+++ b/tests/arduino/app_peripherals/camera/test_v4l_camera.py
@@ -306,6 +306,7 @@ class TestV4LCameraRecovery:
         # Setup reconnection success
         mock_cap_reconnect = MagicMock()
         mock_cap_reconnect.isOpened.return_value = True
+        mock_cap_reconnect.get.return_value = 640
         mock_cap_reconnect.read.return_value = (True, np.zeros((480, 640, 3), dtype=np.uint8))
 
         mock_videocapture.side_effect = [
@@ -345,6 +346,7 @@ class TestV4LCameraRecovery:
         # Setup reconnection success
         mock_cap_reconnect = MagicMock()
         mock_cap_reconnect.isOpened.return_value = True
+        mock_cap_reconnect.get.return_value = 640
         mock_cap_reconnect.read.return_value = (True, np.zeros((480, 640, 3), dtype=np.uint8))
 
         mock_videocapture.side_effect = [


### PR DESCRIPTION
Defect: WIRE-1705

In case configured camera FPS cannot be read, properly report error and continue.
If FPS configuration cannot be read means that camera does not support that capability but it's still working.

This pull request improves the robustness of the camera FPS configuration in the `v4l_camera.py` module by adding validation for the FPS value returned by the camera. The main changes are as follows:

Camera FPS handling improvements:
* Added a check to ensure the FPS value returned from the camera (`cv2.CAP_PROP_FPS`) is valid (not NaN or non-positive) before using it, and logs a warning if the value is invalid.
* Imported the `math` module to support NaN checking for FPS validation.