### PR TITLE
refactor: remove `require_container` field from brick config

### DIFF
--- a/src/arduino/app_tools/module_listing.py
+++ b/src/arduino/app_tools/module_listing.py
@@ -51,7 +51,6 @@ class ArduinoBrick:
         self.path = fs_path
         self.compose_file: Optional[str] = self.get_compose_file()
         self.readme_file: Optional[str] = self.get_readme_file()
-        self.require_container: bool = self.compose_file is not None
         self.model_name: str = model_name
         self.require_model: bool = model_name != ""
         self.category = category
@@ -65,7 +64,6 @@ class ArduinoBrick:
             "id": self.id,
             "name": self.name,
             "description": self.brick_description,
-            "require_container": self.require_container,
             "require_model": self.require_model,
             "mount_devices_into_container": self.mount_devices_into_container,
             "ports": self.ports,
@@ -217,7 +215,7 @@ def list_installed_packages_pkg_resources() -> Dict[str, List[ArduinoBrick]]:
 
 def save_compose_file(module: ArduinoBrick, output_dir: str, appslab_version: str):
     """Save the compose file to the specified output directory."""
-    if not module.require_container:
+    if module.compose_file is None:
         return
 
     # We cannot save a folder containing the `:`, therefore we split and save it
@@ -342,7 +340,7 @@ def release():
         for module in module_list:
             modules.append(module.to_dict())
             # Update the compose file with the release version
-            if module.require_container:
+            if module.compose_file is not None:
                 print(f"Processing compose file {module.compose_file} for arduino bricks version {arduino_bricks_version}")
                 _update_compose_release_version(
                     compose_file_path=module.compose_file,
@@ -390,7 +388,7 @@ def update_ai_container_references():
         for module in module_list:
             modules.append(module.to_dict())
             # Update the compose file with the release version
-            if module.require_container:
+            if module.compose_file is not None:
                 _update_compose_release_version(
                     compose_file_path=module.compose_file,
                     release_version=arduino_bricks_version,


### PR DESCRIPTION
## Motivation
Reduce the number of files to be edited to define a custom brick.

The `require_container` boolean flag can be removed and the `brick_compose.yaml` file.
The brick requires a container, if the `brick_compose.yaml` has at least 1 service


See 
https://github.com/arduino/app-bricks-py/pull/169