### PR TITLE
fix: align branch name sanitization regex with docker/metadata-action

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -15,9 +15,9 @@ jobs:
         id: branch
         run: |
           # Apply the same transform as docker/metadata-action type=ref,event=branch:
-          # lowercase, replace non-alphanumeric (except dash) with dash, strip leading/trailing dashes
+          # lowercase, replace non-alphanumeric (except dot, underscore, dash) with dash, strip leading/trailing dashes
           RAW="${{ github.event.ref }}"
-          SANITIZED=$(echo "$RAW" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/^-//;s/-$//')
+          SANITIZED=$(echo "$RAW" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]/-/g' | sed 's/^-//;s/-$//')
           echo "tag=$SANITIZED" >> $GITHUB_OUTPUT
 
       - name: Checkout repository


### PR DESCRIPTION
The previous regex stripped dots from branch names, while metadata-action preserves them for type=ref,event=branch. This caused a tag mismatch on branches containing dots, leaving stale images undeleted after branch removal.