### PR TITLE
fix(ci): prevent dev build workflow from running on main

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,6 +27,7 @@ permissions:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    if: github.ref_name != 'main'
     outputs:
       containers: ${{ steps.detect.outputs.containers }}
       downstream_containers: ${{ steps.detect.outputs.downstream_containers }}


### PR DESCRIPTION
Add guard on `detect-changes` step forcing it to be skipped for `main` branch. 
Thus, `build` and `build-downstream` (which both need it) are skipped automatically. 

This prevents the build workflow from being executed on the `main` branch when `workflow_dispatch` trigger is used.