### PR TITLE
fix: remove trailing space in LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -35,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -109,6 +109,12 @@ tasks:
           fi
           rmdir "$licenses_dir"
         fi
+        # Strip trailing whitespace from license files.
+        # The upstream SPDX license texts (fetched by `reuse download`)
+        # contain stray trailing spaces that break license parsers such
+        # as `licensed`.  `sed -i` is POSIX-portable and available on
+        # every GitHub Actions runner.
+        find . -maxdepth 1 -name 'LICENSE*' -type f -exec sed -i 's/[[:space:]]*$//' {} +
 
   sbom:generate:internal:
     internal: true


### PR DESCRIPTION
This PR will produce a clean and easy to read parsed license by licensed in app-bricks-example repository.