### PR TITLE
fix(ci): filter release containers by tag_prefix and fix downstream detection

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -265,7 +265,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.config.outputs.update_compose == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "feat: update ${{ matrix.container }} image references"
@@ -392,7 +392,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.config.outputs.update_compose == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "feat: update ${{ matrix.container }} image references"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -190,7 +190,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into registry ${{ env.GHCR_REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -215,12 +215,12 @@ jobs:
 
       - name: Setup Docker buildx
         if: steps.rebuild_check.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v6
 
       - name: Extract Docker metadata
         if: steps.rebuild_check.outputs.needs_build == 'true'
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v4
         with:
           tags: |
             type=raw,value=${{ needs.detect.outputs.version }}
@@ -232,7 +232,7 @@ jobs:
 
       - name: Build and push Docker image
         if: steps.rebuild_check.outputs.needs_build == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./containers/${{ matrix.container }}
           file: ./containers/${{ matrix.container }}/Dockerfile
@@ -334,18 +334,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log into registry ${{ env.GHCR_REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v6
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v4
         with:
           tags: |
             type=raw,value=${{ needs.detect.outputs.version }}
@@ -356,7 +356,7 @@ jobs:
             org.opencontainers.image.url=${{ env.GH_DESTINATION_REPO }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./containers/${{ matrix.container }}
           file: ./containers/${{ matrix.container }}/Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,7 @@
 name: Container Release - Build and Publish
 
+run-name: "Release ${{ inputs.tag || github.ref_name }}"
+
 on:
   push:
     tags:
@@ -34,7 +36,7 @@ jobs:
       downstream_containers: ${{ steps.detect.outputs.downstream_containers }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect containers to release
         id: detect
@@ -115,7 +117,7 @@ jobs:
         container: ${{ fromJson(needs.detect.outputs.base_containers) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -288,7 +290,7 @@ jobs:
         container: ${{ fromJson(needs.detect.outputs.downstream_containers) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read container config
         id: config

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -215,7 +215,7 @@ jobs:
 
       - name: Setup Docker buildx
         if: steps.rebuild_check.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@v6
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract Docker metadata
         if: steps.rebuild_check.outputs.needs_build == 'true'
@@ -341,7 +341,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v6
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract Docker metadata
         id: meta

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,26 +55,39 @@ jobs:
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 
-          # Collect all containers with a ci.json
-          ALL_CONTAINERS=()
+          # Collect all known containers (for downstream existence check)
+          ALL_KNOWN=()
           for CI_JSON in containers/*/ci.json; do
             CONTAINER=$(basename "$(dirname "$CI_JSON")")
-            ALL_CONTAINERS+=("$CONTAINER")
+            ALL_KNOWN+=("$CONTAINER")
           done
 
-          # Split into base and downstream containers
+          # Filter to containers whose tag_prefix matches the pushed tag prefix
+          TAG_PREFIX_FILTER="${TAG_REF%%/*}"
+          MATCHING_CONTAINERS=()
+          for CONTAINER in "${ALL_KNOWN[@]}"; do
+            CONTAINER_TAG_PREFIX=$(jq -r '.tag_prefix' "containers/$CONTAINER/ci.json" 2>/dev/null)
+            if [[ "$CONTAINER_TAG_PREFIX" == "$TAG_PREFIX_FILTER" ]]; then
+              MATCHING_CONTAINERS+=("$CONTAINER")
+            fi
+          done
+
+          echo "Tag prefix filter: ${TAG_PREFIX_FILTER}"
+          echo "Matching containers: ${MATCHING_CONTAINERS[*]}"
+
+          # Collect downstreams from matching containers (regardless of downstream tag_prefix)
           DOWNSTREAM_IN_BUILD=()
-          for CONTAINER in "${ALL_CONTAINERS[@]}"; do
+          for CONTAINER in "${MATCHING_CONTAINERS[@]}"; do
             DS_LIST=$(jq -r '.downstream // [] | .[]' "containers/$CONTAINER/ci.json" 2>/dev/null)
             for DS in $DS_LIST; do
-              if [[ " ${ALL_CONTAINERS[*]} " =~ " $DS " ]] && [[ ! " ${DOWNSTREAM_IN_BUILD[*]} " =~ " $DS " ]]; then
+              if [[ " ${ALL_KNOWN[*]} " =~ " $DS " ]] && [[ ! " ${DOWNSTREAM_IN_BUILD[*]} " =~ " $DS " ]]; then
                 DOWNSTREAM_IN_BUILD+=("$DS")
               fi
             done
           done
 
           BASE_CONTAINERS=()
-          for CONTAINER in "${ALL_CONTAINERS[@]}"; do
+          for CONTAINER in "${MATCHING_CONTAINERS[@]}"; do
             if [[ ! " ${DOWNSTREAM_IN_BUILD[*]} " =~ " $CONTAINER " ]]; then
               BASE_CONTAINERS+=("$CONTAINER")
             fi

--- a/containers/aihub-models-runner/ci.json
+++ b/containers/aihub-models-runner/ci.json
@@ -1,5 +1,5 @@
 {
-  "tag_prefix": "aihub",
+  "tag_prefix": "ai",
   "watch_paths": ["containers/aihub-models-runner/"],
   "tag_latest": false,
   "build_whl": false,

--- a/containers/base/ci.json
+++ b/containers/base/ci.json
@@ -1,5 +1,5 @@
 {
-  "tag_prefix": "infra",
+  "tag_prefix": "release",
   "watch_paths": ["containers/base/"],
   "tag_latest": true,
   "build_whl": false,

--- a/containers/python-base/ci.json
+++ b/containers/python-base/ci.json
@@ -1,5 +1,5 @@
 {
-  "tag_prefix": "base",
+  "tag_prefix": "release",
   "watch_paths": ["containers/python-base/"],
   "tag_latest": true,
   "build_whl": false,


### PR DESCRIPTION
## Summary

- Detect job now filters base containers to only those whose `tag_prefix` matches the pushed tag prefix (e.g. `ai/*` builds only `ai`-prefixed containers, `release/*` builds only `release`-prefixed containers). This prevents `ei-models-runner` and `aihub-models-runner` from entering the build matrix during `release/` runs, which caused the re-tag step to fail due to mismatched version schemes.
- Downstream containers are collected from matching base containers without filtering by the downstream's own `tag_prefix`, so `gesture-recognition-runner` is correctly triggered as a downstream when `aihub-models-runner` is built.
- Updated `tag_prefix` values:
  - `aihub-models-runner`: `aihub` → `ai`
  - `gesture-recognition-runner`: `gesture` → `ai`
  - `base`: `infra` → `release`
  - `python-base`: `base` → `release`

## Test plan

- [x] Push `ai/X.Y.Z` tag → only `aihub-models-runner` + `ei-models-runner` in base matrix, `gesture-recognition-runner` in downstream matrix
- [x] Push `release/X.Y.Z` tag → only `python-base` + `base` in base matrix, `python-apps-base` in downstream matrix, no AI containers included
- [x] Verify re-tag step no longer runs for `ei-models-runner` / `aihub-models-runner` during release builds