### PR TITLE
feat: add AI framework brick compatibility flag

### DIFF
--- a/src/arduino/app_bricks/asr/brick_config.yaml
+++ b/src/arduino/app_bricks/asr/brick_config.yaml
@@ -4,6 +4,8 @@ description: Automatic Speech Recognition brick for offline speech-to-text proce
 category: audio
 requires_model: true
 requires_services: ["arduino:genie_audio"]
+ai_frameworks_compatibility:
+  - qnn
 model: whisper-small
 supported_boards: ["ventunoq"]
 model_configuration_variables:

--- a/src/arduino/app_bricks/audio_classification/brick_config.yaml
+++ b/src/arduino/app_bricks/audio_classification/brick_config.yaml
@@ -6,6 +6,8 @@ description: |
 category: audio
 requires_container: true
 requires_model: true
+ai_frameworks_compatibility:
+  - edgeimpulse
 model: glass-breaking
 model_configuration_variables:
   - EI_AUDIO_CLASSIFICATION_MODEL

--- a/src/arduino/app_bricks/image_classification/brick_config.yaml
+++ b/src/arduino/app_bricks/image_classification/brick_config.yaml
@@ -6,6 +6,8 @@ description: |
 category: video
 requires_container: true
 requires_model: true
+ai_frameworks_compatibility:
+  - edgeimpulse
 model: mobilenet-image-classification
 model_configuration_variables:
   - EI_CLASSIFICATION_MODEL

--- a/src/arduino/app_bricks/keyword_spotting/brick_config.yaml
+++ b/src/arduino/app_bricks/keyword_spotting/brick_config.yaml
@@ -8,6 +8,8 @@ required_devices:
   - microphone
 requires_container: true
 requires_model: true
+ai_frameworks_compatibility:
+  - edgeimpulse
 model: keyword-spotting-hey-arduino
 model_configuration_variables:
   - EI_KEYWORD_SPOTTING_MODEL

--- a/src/arduino/app_bricks/llm/brick_config.yaml
+++ b/src/arduino/app_bricks/llm/brick_config.yaml
@@ -5,3 +5,5 @@ requires_services: ["arduino:genie"]
 requires_model: true
 model: genie:qwen3-4b
 supported_boards: ["ventunoq"]
+ai_frameworks_compatibility:
+  - genie

--- a/src/arduino/app_bricks/motion_detection/brick_config.yaml
+++ b/src/arduino/app_bricks/motion_detection/brick_config.yaml
@@ -6,6 +6,8 @@ description: |
   You can use it with pre-trained models provided by the framework or with your custom motion classification models trained on the Edge Impulse platform.
 requires_container: true
 requires_model: true
+ai_frameworks_compatibility:
+  - edgeimpulse
 model: updown-wave-motion-detection
 model_configuration_variables:
   - EI_MOTION_DETECTION_MODEL

--- a/src/arduino/app_bricks/object_detection/brick_config.yaml
+++ b/src/arduino/app_bricks/object_detection/brick_config.yaml
@@ -6,6 +6,8 @@ description: |
 category: video
 requires_container: true
 requires_model: true
+ai_frameworks_compatibility:
+  - edgeimpulse
 model: yolox-object-detection
 model_configuration_variables:
   - EI_OBJ_DETECTION_MODEL

--- a/src/arduino/app_bricks/tts/brick_config.yaml
+++ b/src/arduino/app_bricks/tts/brick_config.yaml
@@ -5,4 +5,6 @@ category: audio
 requires_model: true
 supported_boards: ["ventunoq"]
 requires_services: ["arduino:genie_audio"]
+ai_frameworks_compatibility:
+  - qnn
 model: melo-tts-en

--- a/src/arduino/app_bricks/vibration_anomaly_detection/brick_config.yaml
+++ b/src/arduino/app_bricks/vibration_anomaly_detection/brick_config.yaml
@@ -6,6 +6,8 @@ description: |
   You can use it with pre-trained models provided by the framework or with your own custom anomaly detections models trained on the Edge Impulse platform.
 requires_container: true
 requires_model: true
+ai_frameworks_compatibility:
+  - edgeimpulse
 model: fan-anomaly-detection
 model_configuration_variables:
   - EI_VIBRATION_ANOMALY_DETECTION_MODEL

--- a/src/arduino/app_bricks/video_imageclassification/brick_config.yaml
+++ b/src/arduino/app_bricks/video_imageclassification/brick_config.yaml
@@ -8,6 +8,8 @@ description: |
 category: video
 requires_model: true
 requires_container: true
+ai_frameworks_compatibility:
+  - edgeimpulse
 mount_devices_into_container: true
 required_devices:
   - camera

--- a/src/arduino/app_bricks/video_objectdetection/brick_config.yaml
+++ b/src/arduino/app_bricks/video_objectdetection/brick_config.yaml
@@ -11,6 +11,8 @@ requires_container: true
 mount_devices_into_container: true
 required_devices:
   - camera
+ai_frameworks_compatibility:
+  - edgeimpulse
 model: yolox-object-detection
 model_configuration_variables:
   - EI_V_OBJ_DETECTION_MODEL

--- a/src/arduino/app_bricks/visual_anomaly_detection/brick_config.yaml
+++ b/src/arduino/app_bricks/visual_anomaly_detection/brick_config.yaml
@@ -6,6 +6,8 @@ description: |
 category: image
 requires_container: true
 requires_model: true
+ai_frameworks_compatibility:
+  - edgeimpulse
 model: concrete-crack-anomaly-detection
 model_configuration_variables:
   - EI_V_ANOMALY_DETECTION_MODEL

--- a/src/arduino/app_bricks/vlm/brick_config.yaml
+++ b/src/arduino/app_bricks/vlm/brick_config.yaml
@@ -5,3 +5,5 @@ requires_services: ["arduino:genie"]
 requires_model: true
 model: genie:qwen3-vl-4b
 supported_boards: ["ventunoq"]
+ai_frameworks_compatibility:
+  - genie

--- a/src/arduino/app_tools/module_listing.py
+++ b/src/arduino/app_tools/module_listing.py
@@ -47,6 +47,7 @@ class ArduinoBrick:
         env_variables: Dict[str, str] = None,
         supported_boards: List[str] = None,
         requires_services: List[str] = None,
+        ai_frameworks_compatibility: List[str] = None,
     ):
         self.id = id
         self.name = name
@@ -65,6 +66,7 @@ class ArduinoBrick:
         self.env_variables: Optional[Dict[str, str]] = env_variables
         self.supported_boards: Optional[List[str]] = supported_boards
         self.requires_services: Optional[List[str]] = requires_services
+        self.ai_frameworks_compatibility: Optional[List[str]] = ai_frameworks_compatibility
 
     def to_dict(self) -> dict:
         out_dict: dict = {
@@ -87,7 +89,8 @@ class ArduinoBrick:
             out_dict["supported_boards"] = self.supported_boards
         if self.requires_services:
             out_dict["requires_services"] = self.requires_services
-
+        if self.ai_frameworks_compatibility:
+            out_dict["ai_frameworks_compatibility"] = self.ai_frameworks_compatibility
         if self.env_variables and len(self.env_variables) > 0:
             additional_vars: List[EnvVariable] = []
             for var in self.env_variables:


### PR DESCRIPTION
For every AI brick, add a compatibility framework attribute, tobetter filter/organize by supported framework.

This will be used by AppLab to enable EdgeImpulse integration for the corresponding bricks.