### PR TITLE
fix(ci): exclude current tag from rebuild_check previous tag lookup

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -139,8 +139,9 @@ jobs:
         id: rebuild_check
         run: |
           TAG_PREFIX="${{ steps.config.outputs.tag_prefix }}"
+          CURRENT_TAG="${TAG_PREFIX}/${{ needs.detect.outputs.version }}"
           git fetch --tags
-          PREV_TAG=$(git tag --sort=-version:refname | grep "^${TAG_PREFIX}/" | head -1)
+          PREV_TAG=$(git tag --sort=-version:refname | grep "^${TAG_PREFIX}/" | grep -v "^${CURRENT_TAG}$" | head -1)
 
           if [[ -z "$PREV_TAG" ]]; then
             echo "No previous tag found for ${{ matrix.container }} — full build required"


### PR DESCRIPTION
## Summary
Exclude the current tag from the previous-tag search in `rebuild_check`. When using tags as trigger, the Workflow was calculating the diff against the just created tag