### PR TITLE
fix(ci): broaden compose update regex to match any tag format, not only semver

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -256,7 +256,7 @@ jobs:
           find src -name "brick_compose.yaml" | while read f; do
             if grep -q "$CONTAINER" "$f"; then
               echo "  Updating: $f"
-              sed -i -E "s|${CONTAINER}:[0-9]+\.[0-9]+\.[0-9]+|${CONTAINER}:${VERSION}|g" "$f"
+              sed -i -E "s|${CONTAINER}:[^ \"']+|${CONTAINER}:${VERSION}|g" "$f"
             fi
           done
 
@@ -383,7 +383,7 @@ jobs:
           find src -name "brick_compose.yaml" | while read f; do
             if grep -q "$CONTAINER" "$f"; then
               echo "  Updating: $f"
-              sed -i -E "s|${CONTAINER}:[0-9]+\.[0-9]+\.[0-9]+|${CONTAINER}:${VERSION}|g" "$f"
+              sed -i -E "s|${CONTAINER}:[^ \"']+|${CONTAINER}:${VERSION}|g" "$f"
             fi
           done
 


### PR DESCRIPTION
## Summary

Previously the bricks compose update script matched only `[0-9]+\.[0-9]+\.[0-9]` thus not supporting other tag formats (`latest`, `dev-next` and so on). Modify the regex to match anything as tag.

### Tests

Tested on https://github.com/filippopisano/app-bricks-py/actions/runs/24778898007/job/72504490281 with resulting PR: https://github.com/filippopisano/app-bricks-py/pull/20/changes