### PR TITLE
fix: anomaly detection brick

### DIFF
--- a/src/arduino/app_bricks/vibration_anomaly_detection/README.md
+++ b/src/arduino/app_bricks/vibration_anomaly_detection/README.md
@@ -15,6 +15,7 @@ The Vibration Anomaly Detection Brick allows you to:
 - **Edge-Impulse powered**: runs your deployed model via `EdgeImpulseRunnerFacade`.
 - **Sliding window ingestion**: samples are buffered to the model’s exact input length.
 - **Threshold callbacks**: invoke your handler when `anomaly_score ≥ threshold`.
+- **Raw anomaly score threshold**: the threshold is not a 0-1 confidence value; anomaly scores can be greater than 1.0.
 - **Flexible callback signatures**:
   - `callback()`
   - `callback(anomaly_score: float)`

--- a/src/arduino/app_bricks/vibration_anomaly_detection/__init__.py
+++ b/src/arduino/app_bricks/vibration_anomaly_detection/__init__.py
@@ -39,14 +39,16 @@ class VibrationAnomalyDetection(EdgeImpulseRunnerFacade):
         Args:
             anomaly_detection_threshold (float): Threshold applied to the model’s
                 anomaly score to decide whether to trigger the registered callback.
-                Typical starting point is 1.0; tune based on your dataset.
+                This is the raw anomaly score, not a normalized confidence value;
+                values above 1.0 are valid. Typical starting point is 1.0; tune
+                based on your dataset.
 
         Raises:
             ValueError: If the Edge Impulse runner is unreachable, or if the model
                 info is missing/invalid (e.g., non-positive `frequency` or
                 `input_features_count`).
         """
-        self._anomaly_detection_threshold = anomaly_detection_threshold
+        self._anomaly_detection_threshold = self._validate_anomaly_detection_threshold(anomaly_detection_threshold)
         super().__init__()
         model_info = self.get_model_info()
         if not model_info:
@@ -59,6 +61,33 @@ class VibrationAnomalyDetection(EdgeImpulseRunnerFacade):
         self._handler_lock = threading.Lock()
 
         self._buffer = SlidingWindowBuffer(window_size=model_info.input_features_count, slide_amount=int(model_info.input_features_count))
+
+    @property
+    def anomaly_detection_threshold(self) -> float:
+        """Raw anomaly score threshold used to decide when callbacks fire."""
+        return self._anomaly_detection_threshold
+
+    @anomaly_detection_threshold.setter
+    def anomaly_detection_threshold(self, value: float) -> None:
+        """Update the raw anomaly score threshold at runtime.
+
+        The value is intentionally not clamped to ``[0.0, 1.0]`` because Edge
+        Impulse anomaly scores are distances and can legitimately be greater
+        than 1.0.
+        """
+        self._anomaly_detection_threshold = self._validate_anomaly_detection_threshold(value)
+
+    @staticmethod
+    def _validate_anomaly_detection_threshold(value: float) -> float:
+        try:
+            threshold = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Anomaly detection threshold must be a finite non-negative number.") from exc
+
+        if not np.isfinite(threshold) or threshold < 0.0:
+            raise ValueError("Anomaly detection threshold must be a finite non-negative number.")
+
+        return threshold
 
     def accumulate_samples(self, sensor_samples: Iterable[float]) -> None:
         """Append one or more accelerometer samples to the sliding window buffer.

--- a/tests/arduino/app_bricks/vibration_anomaly_detection/test_vibration_anomaly_detection.py
+++ b/tests/arduino/app_bricks/vibration_anomaly_detection/test_vibration_anomaly_detection.py
@@ -6,6 +6,7 @@ import threading
 import pytest
 import random
 import time
+import numpy as np
 from arduino.app_bricks.vibration_anomaly_detection import VibrationAnomalyDetection
 from arduino.app_utils import HttpClient
 
@@ -309,3 +310,41 @@ def test_classify_success_with_more_arguments(app_instance: AppController, monke
         if key["class_name"] in ["nominal", "off"]:
             detected_classes += 1
     assert detected_classes == 2
+
+
+def test_threshold_property_update_controls_callback(app_instance: AppController, monkeypatch: pytest.MonkeyPatch):
+    classifier = VibrationAnomalyDetection(anomaly_detection_threshold=1.0)
+
+    monkeypatch.setattr(classifier._buffer, "pull", lambda: np.array([0.0] * 600))
+    monkeypatch.setattr(classifier, "infer_from_features", lambda features: {"result": {"anomaly": 2.5}})
+
+    anomaly_trigger_called = False
+
+    def callback_for_anomaly():
+        nonlocal anomaly_trigger_called
+        anomaly_trigger_called = True
+
+    classifier.on_anomaly(callback_for_anomaly)
+
+    classifier.anomaly_detection_threshold = 5.0
+    assert classifier.anomaly_detection_threshold == 5.0
+
+    classifier.loop()
+    assert not anomaly_trigger_called
+
+    classifier.anomaly_detection_threshold = 2.0
+    classifier.loop()
+    assert anomaly_trigger_called
+
+
+@pytest.mark.parametrize("threshold", [0, 0.1, 1.0, 5, "7.5"])
+def test_threshold_property_accepts_finite_non_negative_values(threshold):
+    classifier = VibrationAnomalyDetection(anomaly_detection_threshold=threshold)
+
+    assert classifier.anomaly_detection_threshold == float(threshold)
+
+
+@pytest.mark.parametrize("threshold", [-0.1, float("nan"), float("inf"), "not-a-number", None])
+def test_threshold_property_rejects_invalid_values(threshold):
+    with pytest.raises(ValueError, match="finite non-negative"):
+        VibrationAnomalyDetection(anomaly_detection_threshold=threshold)


### PR DESCRIPTION
This PR fixes runtime anomaly threshold updates in `VibrationAnomalyDetection`. 

The Brick now exposes a validated `anomaly_detection_threshold` **property**, so UI/runtime assignments update the actual threshold used by inference.

Also **clarifies** that anomaly scores are raw model scores, **not normalized 0-1 confidence values**, and adds **tests** for threshold updates and validation.