### PR TITLE
Add SBOM delta generation for container builds

### DIFF
--- a/.github/actions/sbom-delta/action.yml
+++ b/.github/actions/sbom-delta/action.yml
@@ -1,0 +1,42 @@
+name: Generate SBOM Delta
+description: Install Syft, generate delta SBOM for a container, and upload the artifact.
+
+inputs:
+  container:
+    description: Container name to scan
+    required: true
+  version:
+    description: Image tag or version
+    required: true
+  registry:
+    description: Registry prefix (e.g. ghcr.io/org/)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install syft
+      shell: bash
+      run: curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
+    - name: Install task
+      shell: bash
+      run: which task || curl -sSfL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
+
+    - name: Generate delta SBOM
+      shell: bash
+      env:
+        CONTAINER: ${{ inputs.container }}
+        VERSION: ${{ inputs.version }}
+        REGISTRY: ${{ inputs.registry }}
+      run: |
+        task -t Taskfile.dist.yml sbom:delta -- \
+          --version "$VERSION" \
+          --registry "$REGISTRY" \
+          "$CONTAINER"
+
+    - name: Upload delta SBOM artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: sbom-delta-${{ inputs.container }}
+        path: ./containers/${{ inputs.container }}/sbom-delta/

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -210,6 +210,13 @@ jobs:
             REGISTRY=${{ env.DEV_REGISTRY_PATH }}
             BASE_IMAGE_VERSION=${{ needs.setup.outputs.image_tag }}
 
+      - name: SBOM Delta
+        uses: ./.github/actions/sbom-delta
+        with:
+          container: ${{ matrix.container }}
+          version: ${{ needs.setup.outputs.image_tag }}
+          registry: ${{ env.DEV_REGISTRY_PATH }}
+
   build-downstream:
     needs: [ setup, build ]
     if: needs.setup.outputs.downstream_containers != '[]'
@@ -302,3 +309,10 @@ jobs:
           build-args: |
             REGISTRY=${{ env.DEV_REGISTRY_PATH }}
             BASE_IMAGE_VERSION=${{ needs.setup.outputs.image_tag }}
+
+      - name: SBOM Delta
+        uses: ./.github/actions/sbom-delta
+        with:
+          container: ${{ matrix.container }}
+          version: ${{ needs.setup.outputs.image_tag }}
+          registry: ${{ env.DEV_REGISTRY_PATH }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -422,10 +422,21 @@ jobs:
           name: whl
           path: dist/
 
+      - name: Download all SBOM delta artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sbom-delta-*
+          path: sbom-delta/
+
+      - name: Zip SBOM artifacts
+        run: zip -r dist/sboms.zip sbom-delta/
+
       - name: Upload release asset
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/arduino*.whl
+          files: |
+            dist/arduino*.whl
+            dist/sboms.zip
           tag_name: ${{ needs.detect.outputs.tag_ref }}
           name: Release ${{ needs.detect.outputs.version }}
           prerelease: ${{ needs.detect.outputs.prerelease }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -261,6 +261,13 @@ jobs:
           provenance: false
           build-args: ${{ steps.config.outputs.build_args }}
 
+      - name: SBOM Delta
+        uses: ./.github/actions/sbom-delta
+        with:
+          container: ${{ matrix.container }}
+          version: ${{ needs.detect.outputs.version }}
+          registry: ${{ env.GHCR_DESTINATION_ORG }}
+
       - name: Update compose file references
         if: steps.config.outputs.update_compose == 'true'
         env:
@@ -363,6 +370,13 @@ jobs:
             ${{ steps.config.outputs.build_args }}
             BASE_IMAGE_VERSION=${{ needs.detect.outputs.version }}
             REGISTRY=${{ env.GHCR_DESTINATION_ORG }}/
+
+      - name: SBOM Delta
+        uses: ./.github/actions/sbom-delta
+        with:
+          container: ${{ matrix.container }}
+          version: ${{ needs.detect.outputs.version }}
+          registry: ${{ env.GHCR_DESTINATION_ORG }}
 
       - name: Update compose file references
         if: steps.config.outputs.update_compose == 'true'

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -76,7 +76,7 @@ tasks:
     desc: Format code
     cmds:
       - ruff format
-  
+
   build-dev:
     desc: Build a development package
     cmds:
@@ -253,3 +253,8 @@ tasks:
           IMAGE: 'public.ecr.aws/arduino/app-bricks/ei-models-runner'
           TAG: '{{.EI_TAG}}'
           DIR: './containers/ei-models-runner'
+
+  sbom:delta:
+    desc: Generate delta SBOMs for containers (requires syft and registry access)
+    cmds:
+      - python3 ./scripts/sbom_delta.py {{.CLI_ARGS}}

--- a/containers/aihub-models-runner/ci.json
+++ b/containers/aihub-models-runner/ci.json
@@ -5,5 +5,8 @@
   "build_whl": false,
   "update_compose": false,
   "build_args": {},
+  "sbom": {
+    "runtime_base": "ubuntu:24.04"
+  },
   "downstream": ["gesture-recognition-runner"]
 }

--- a/containers/ei-models-runner/ci.json
+++ b/containers/ei-models-runner/ci.json
@@ -4,5 +4,8 @@
   "tag_latest": false,
   "build_whl": false,
   "update_compose": true,
-  "build_args": {}
+  "build_args": {},
+  "sbom": {
+    "runtime_base": "public.ecr.aws/g7a8t7v6/inference-container:v1.92.3"
+  }
 }

--- a/containers/ei-qnn-models-runner/ci.json
+++ b/containers/ei-qnn-models-runner/ci.json
@@ -4,5 +4,8 @@
   "tag_latest": false,
   "build_whl": false,
   "update_compose": true,
-  "build_args": {}
+  "build_args": {},
+  "sbom": {
+    "runtime_base": "public.ecr.aws/z9b3d4t5/inference-container-qnn:v1.92.19-test-f19ce2e7"
+  }
 }

--- a/containers/gesture-recognition-runner/ci.json
+++ b/containers/gesture-recognition-runner/ci.json
@@ -5,5 +5,8 @@
   "build_whl": false,
   "update_compose": true,
   "build_args": {},
+  "sbom": {
+    "runtime_base": "${REGISTRY}app-bricks/aihub-models-runner:${BASE_IMAGE_VERSION}"
+  },
   "downstream": []
 }

--- a/containers/python-apps-base/ci.json
+++ b/containers/python-apps-base/ci.json
@@ -9,5 +9,8 @@
   "tag_latest": false,
   "build_whl": true,
   "update_compose": false,
-  "build_args": { }
+  "build_args": { },
+  "sbom": {
+    "runtime_base": "${REGISTRY}app-bricks/python-base:${BASE_IMAGE_VERSION}"
+  }
 }

--- a/containers/python-base/Dockerfile
+++ b/containers/python-base/Dockerfile
@@ -22,7 +22,8 @@ RUN set -ex; \
     echo "https://github.com/${OPENCV_REPO_OWNER}/app-bricks-py/releases/download/opencv/${OPENCV_VERSION}/opencv_python_headless-${OPENCV_VERSION}-${PYTHON_VERSION}-${PYTHON_VERSION}-linux_aarch64.whl" >> /app/requirements.txt; \
     # Install Python dependencies
     pip install --no-cache-dir uv; \
-    uv pip install --system --no-cache-dir -r /app/requirements.txt && rm /app/requirements.txt; \
+    uv pip install --system --no-cache-dir -r /app/requirements.txt; \
+    rm /app/requirements.txt; \
     # Strip debug symbols, tests and remove unneeded packages to reduce size
     find /usr/local/lib/python3.13/site-packages -type f -name "*.so" -exec strip -s {} +; \
     find /usr/local/lib/python3.13/site-packages -type f -name "*.so.*" -exec strip -s {} +; \
@@ -74,12 +75,13 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*; \
     rm -fr /var/cache/apt/archives/*.deb \
         /var/cache/apt/archives/partial/*.deb \
-        /usr/share/doc/* \
         /usr/share/man/* \
         /usr/share/locale/* \
         /var/cache/debconf/* \
-        /var/lib/dpkg/info/* \      
+        /var/lib/dpkg/info/* \
         /var/cache/apt/*.bin; \
+    find /usr/share/doc -type f ! -name 'copyright' -delete; \
+    find /usr/share/doc -type d -empty -delete; \
     # precompile python files to .pyc to speed up startup time
     python -m compileall /usr/local/bin; \
     python -m compileall /usr/local/lib

--- a/containers/python-base/ci.json
+++ b/containers/python-base/ci.json
@@ -5,5 +5,8 @@
   "build_whl": false,
   "update_compose": false,
   "build_args": {},
+  "sbom": {
+    "runtime_base": "python:3.13-slim"
+  },
   "downstream": ["python-apps-base"]
 }

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0

--- a/scripts/sbom_delta.py
+++ b/scripts/sbom_delta.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Compute delta reports between container SBOMs"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+VARIABLE_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class SbomDeltaError(RuntimeError):
+    """Raised when SBOM delta input or configuration is invalid."""
+
+
+def normalize_registry(registry: str) -> str:
+    """Ensure the registry prefix ends with a slash when not empty."""
+    if not registry or registry.endswith("/"):
+        return registry
+    return f"{registry}/"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    """Load and validate a JSON file as a dict."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SbomDeltaError(f"File not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SbomDeltaError(f"Invalid JSON in {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SbomDeltaError(f"Expected JSON object in {path}.")
+    return payload
+
+
+def load_container_config(containers_dir: Path, container: str) -> dict[str, Any]:
+    """Load ``ci.json`` metadata for a container."""
+    return load_json(containers_dir / container / "ci.json")
+
+
+def build_resolution_context(
+    config: dict[str, Any],
+    registry: str,
+    version: str,
+    build_args: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build the variable map used to resolve runtime base templates."""
+    default_build_args = config.get("build_args") or {}
+    if not isinstance(default_build_args, dict):
+        raise SbomDeltaError("Expected 'build_args' to be a JSON object.")
+
+    context = {str(k): str(v) for k, v in default_build_args.items()}
+    context["REGISTRY"] = normalize_registry(registry)
+    context["VERSION"] = version
+    context["BASE_IMAGE_VERSION"] = version
+
+    for key, value in (build_args or {}).items():
+        context[str(key)] = str(value)
+
+    context["REGISTRY"] = normalize_registry(context["REGISTRY"])
+    return context
+
+
+def resolve_template(template: str, context: dict[str, str]) -> str:
+    """Resolve ``${VAR}`` placeholders inside a template string."""
+    resolved = template
+    for _ in range(10):
+        matches = VARIABLE_PATTERN.findall(resolved)
+        if not matches:
+            return resolved
+        missing = sorted({name for name in matches if name not in context})
+        if missing:
+            raise SbomDeltaError(f"Missing template variables: {', '.join(missing)}")
+        resolved = VARIABLE_PATTERN.sub(lambda match: context[match.group(1)], resolved)
+    raise SbomDeltaError(f"Could not resolve template after 10 passes: {template}")
+
+
+def resolve_runtime_base(
+    containers_dir: Path,
+    container: str,
+    registry: str,
+    version: str,
+    build_args: dict[str, str] | None = None,
+) -> str:
+    """Resolve the fully qualified runtime base image for a container.
+
+    Uses the ``sbom.runtime_base`` template in the container's ``ci.json``,
+    expanding ``${VAR}`` placeholders with registry, version, and build args.
+    """
+    config = load_container_config(containers_dir, container)
+    sbom_config = config.get("sbom")
+    if not isinstance(sbom_config, dict):
+        raise SbomDeltaError(f"Container '{container}' is missing 'sbom.runtime_base'.")
+
+    runtime_base = sbom_config.get("runtime_base")
+    if not isinstance(runtime_base, str) or not runtime_base.strip():
+        raise SbomDeltaError(f"Container '{container}' is missing 'sbom.runtime_base'.")
+
+    context = build_resolution_context(config=config, registry=registry, version=version, build_args=build_args)
+    return resolve_template(runtime_base.strip(), context)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+class Package:
+    """Lightweight representation of a software package from a Syft SBOM."""
+
+    __slots__ = ("name", "version", "pkg_type", "purl", "licenses")
+
+    def __init__(
+        self,
+        name: str,
+        version: str,
+        pkg_type: str,
+        purl: str | None,
+        licenses: list[str],
+    ) -> None:
+        self.name = name
+        self.version = version
+        self.pkg_type = pkg_type
+        self.purl = purl
+        self.licenses = licenses
+
+
+# (lowercase name, lowercase type) -> Package
+PkgMap = dict[tuple[str, str], Package]
+# (lowercase name, lowercase type) -> (old Package, new Package)
+UpdateMap = dict[tuple[str, str], tuple[Package, Package]]
+
+# Package types that represent image metadata, not real software dependencies.
+_IGNORED_PACKAGE_TYPES = frozenset({"oci"})
+
+
+# ---------------------------------------------------------------------------
+# Parsing (Syft native JSON)
+# ---------------------------------------------------------------------------
+
+
+def _extract_license(lic_declared: str) -> str:
+    """Return the license string if meaningful, empty string otherwise."""
+    if lic_declared and lic_declared != "NOASSERTION" and lic_declared != "NONE":
+        return lic_declared
+    return ""
+
+
+def _extract_type_from_purl(purl: str) -> str:
+    """Extract the package type (e.g. 'pypi', 'deb') from a purl."""
+    match = re.match(r"pkg:([^/]+)/", purl)
+    return match.group(1) if match else "unknown"
+
+
+def load_spdx_packages(sbom_path: Path) -> PkgMap:
+    """Load all packages from an SPDX 2.3 JSON SBOM."""
+    sbom = load_json(sbom_path)
+    packages: PkgMap = {}
+    for pkg in sbom.get("packages", []):
+        if not isinstance(pkg, dict):
+            continue
+        spdxid = pkg.get("SPDXID", "")
+        if spdxid == "SPDXRef-DOCUMENT":
+            continue
+
+        name: str = pkg.get("name", "")
+        version: str = pkg.get("versionInfo", "")
+
+        # Extract purl and type from externalRefs
+        purl: str | None = None
+        pkg_type = "unknown"
+        for ref in pkg.get("externalRefs") or []:
+            if isinstance(ref, dict) and ref.get("referenceType") == "purl":
+                purl = str(ref["referenceLocator"])
+                pkg_type = _extract_type_from_purl(purl)
+                break
+
+        if pkg_type.lower() in _IGNORED_PACKAGE_TYPES:
+            continue
+
+        # Extract license
+        lic_str = _extract_license(pkg.get("licenseDeclared", ""))
+        licenses: list[str] = [lic_str] if lic_str else []
+
+        key = (name.lower(), pkg_type.lower())
+        packages[key] = Package(
+            name=name,
+            version=version,
+            pkg_type=pkg_type,
+            purl=purl,
+            licenses=licenses,
+        )
+    return packages
+
+
+# ---------------------------------------------------------------------------
+# Delta computation
+# ---------------------------------------------------------------------------
+
+
+def compute_delta(
+    base_sbom_path: Path,
+    full_sbom_path: Path,
+) -> tuple[PkgMap, UpdateMap, PkgMap]:
+    """Return (added, updated, removed) package maps."""
+    base_pkgs = load_spdx_packages(base_sbom_path)
+    child_pkgs = load_spdx_packages(full_sbom_path)
+
+    added: PkgMap = {}
+    updated: UpdateMap = {}
+    removed: PkgMap = {}
+
+    for key, pkg in child_pkgs.items():
+        if key not in base_pkgs:
+            added[key] = pkg
+        elif base_pkgs[key].version != pkg.version:
+            updated[key] = (base_pkgs[key], pkg)
+
+    for key, pkg in base_pkgs.items():
+        if key not in child_pkgs:
+            removed[key] = pkg
+
+    return added, updated, removed
+
+
+# ---------------------------------------------------------------------------
+# SPDX 2.3 output
+# ---------------------------------------------------------------------------
+
+_SPDXID_RE = re.compile(r"[^A-Za-z0-9.\-]")
+
+
+def _make_spdxid(pkg: Package, seen: set[str]) -> str:
+    """Produce a unique, spec-compliant SPDXID for a package."""
+    safe_name = _SPDXID_RE.sub("-", pkg.name)
+    safe_type = _SPDXID_RE.sub("-", pkg.pkg_type)
+    base_id = f"SPDXRef-{safe_name}-{safe_type}"
+    candidate = base_id
+    counter = 1
+    while candidate in seen:
+        candidate = f"{base_id}-{counter}"
+        counter += 1
+    seen.add(candidate)
+    return candidate
+
+
+def _pkg_to_spdx(
+    pkg: Package,
+    change_type: str,
+    now: str,
+    seen_ids: set[str],
+    from_version: str | None = None,
+) -> tuple[dict[str, Any], str]:
+    """Return (spdx_package_dict, spdxid)."""
+    spdxid = _make_spdxid(pkg, seen_ids)
+    license_declared = " AND ".join(pkg.licenses) if pkg.licenses else "NOASSERTION"
+
+    entry: dict[str, Any] = {
+        "SPDXID": spdxid,
+        "name": pkg.name,
+        "versionInfo": pkg.version,
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": False,
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": license_declared,
+        "copyrightText": "NOASSERTION",
+    }
+
+    if pkg.purl:
+        entry["externalRefs"] = [
+            {
+                "referenceCategory": "PACKAGE-MANAGER",
+                "referenceType": "purl",
+                "referenceLocator": pkg.purl,
+            }
+        ]
+
+    annotations = [
+        {
+            "annotationType": "OTHER",
+            "annotator": "Tool: arduino-sbom-delta",
+            "annotationDate": now,
+            "comment": f"change-type: {change_type}",
+        },
+    ]
+    if from_version is not None:
+        annotations.append({
+            "annotationType": "OTHER",
+            "annotator": "Tool: arduino-sbom-delta",
+            "annotationDate": now,
+            "comment": f"previous-version: {from_version}",
+        })
+    entry["annotations"] = annotations
+
+    return entry, spdxid
+
+
+def print_delta_summary(
+    added: PkgMap,
+    updated: UpdateMap,
+    removed: PkgMap,
+) -> None:
+    """Print a human-readable delta summary to stderr."""
+    print(f"\n{'=' * 72}", file=sys.stderr)
+    print(
+        f"SBOM Delta — {len(added)} added, {len(updated)} updated, {len(removed)} removed",
+        file=sys.stderr,
+    )
+    print(f"{'=' * 72}", file=sys.stderr)
+
+    if added:
+        print(f"\n[+] ADDED ({len(added)})", file=sys.stderr)
+        for (_, pkg_type), pkg in sorted(added.items()):
+            print(f"    {pkg.name:<42} {pkg.version:<22} [{pkg_type}]", file=sys.stderr)
+
+    if updated:
+        print(f"\n[~] UPDATED ({len(updated)})", file=sys.stderr)
+        for (_, pkg_type), (old, new) in sorted(updated.items()):
+            print(f"    {old.name:<42} {old.version} → {new.version} [{pkg_type}]", file=sys.stderr)
+
+    if removed:
+        print(f"\n[-] REMOVED ({len(removed)})", file=sys.stderr)
+        for (_, pkg_type), pkg in sorted(removed.items()):
+            print(f"    {pkg.name:<42} {pkg.version:<22} [{pkg_type}]", file=sys.stderr)
+
+    print(f"\nTotal: {len(added) + len(updated) + len(removed)} changed packages\n", file=sys.stderr)
+
+
+def build_delta_report(
+    base_sbom_path: Path,
+    full_sbom_path: Path,
+    name: str,
+    version: str,
+    base_image: str | None = None,
+    target_image: str | None = None,
+) -> dict[str, Any]:
+    """Compute the SBOM delta between two Syft native JSON documents.
+
+    Returns a valid SPDX 2.3 JSON document containing only the packages
+    added or updated in the target image relative to the base.
+    Each delta package includes annotations for change-type, package-type,
+    and (for updates) the previous-version.
+    Removed packages are reported to stderr.
+    """
+    added, updated, removed = compute_delta(base_sbom_path, full_sbom_path)
+    print_delta_summary(added, updated, removed)
+
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    doc_namespace = f"https://arduino.cc/sbom/delta/{name}-{version}-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+
+    container_spdxid = "SPDXRef-Container"
+    seen_ids: set[str] = {"SPDXRef-DOCUMENT", container_spdxid}
+
+    packages: list[dict[str, Any]] = []
+    relationships: list[dict[str, Any]] = []
+
+    # Container package (the thing the delta describes)
+    packages.append({
+        "SPDXID": container_spdxid,
+        "name": name,
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": False,
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "NOASSERTION",
+        "copyrightText": "NOASSERTION",
+        "comment": f"Delta SBOM for {target_image} — changes relative to base image {base_image}",
+    })
+    relationships.append({
+        "spdxElementId": "SPDXRef-DOCUMENT",
+        "relationshipType": "DESCRIBES",
+        "relatedSpdxElement": container_spdxid,
+    })
+
+    # Added packages
+    for key, pkg in sorted(added.items()):
+        entry, spdxid = _pkg_to_spdx(pkg, "added", now, seen_ids)
+        packages.append(entry)
+        relationships.append({
+            "spdxElementId": container_spdxid,
+            "relationshipType": "CONTAINS",
+            "relatedSpdxElement": spdxid,
+        })
+
+    # Updated packages
+    for key, (old_pkg, new_pkg) in sorted(updated.items()):
+        entry, spdxid = _pkg_to_spdx(new_pkg, "updated", now, seen_ids, from_version=old_pkg.version)
+        packages.append(entry)
+        relationships.append({
+            "spdxElementId": container_spdxid,
+            "relationshipType": "CONTAINS",
+            "relatedSpdxElement": spdxid,
+        })
+
+    # Removed packages
+    for key, pkg in sorted(removed.items()):
+        entry, spdxid = _pkg_to_spdx(pkg, "removed", now, seen_ids)
+        packages.append(entry)
+        relationships.append({
+            "spdxElementId": container_spdxid,
+            "relationshipType": "CONTAINS",
+            "relatedSpdxElement": spdxid,
+        })
+
+    return {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": name,
+        "documentNamespace": doc_namespace,
+        "creationInfo": {
+            "created": now,
+            "creators": [
+                "Tool: arduino-sbom-delta",
+                "Organization: Arduino SRL",
+            ],
+        },
+        "documentDescribes": [container_spdxid],
+        "packages": packages,
+        "relationships": relationships,
+    }
+
+
+def write_output(output_path: Path, content: str) -> None:
+    """Write content to a file."""
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+
+
+def require_command(command: str, install_hint: str) -> None:
+    """Ensure an external command exists on PATH."""
+    if shutil.which(command) is None:
+        raise SbomDeltaError(f"'{command}' not found. {install_hint}")
+
+
+def discover_containers(containers_dir: Path) -> list[str]:
+    """Discover containers by looking for ``ci.json`` files."""
+    return sorted(p.parent.name for p in containers_dir.glob("*/ci.json") if p.is_file())
+
+
+def build_container_image(registry: str, container: str, version: str) -> str:
+    """Build the fully qualified image reference for a container."""
+    return f"{normalize_registry(registry)}app-bricks/{container}:{version}"
+
+
+PLATFORM = "linux/arm64"
+
+
+def scan_image(image: str, output_path: Path) -> None:
+    """Scan an image with Syft and save the SPDX JSON report."""
+    print(f"    syft scan: {image}", file=sys.stderr)
+
+    commands = [
+        ["syft", f"registry:{image}", "--platform", PLATFORM, "-o", "spdx-json", "--file", str(output_path), "--quiet"],
+        ["syft", image, "--platform", PLATFORM, "-o", "spdx-json", "--file", str(output_path), "--quiet"],
+    ]
+
+    last_result: subprocess.CompletedProcess[str] | None = None
+    for cmd in commands:
+        last_result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if last_result.returncode == 0:
+            return
+
+    details = (last_result.stderr or last_result.stdout or "").strip() if last_result else ""
+    if not details and last_result:
+        details = f"syft exited with status {last_result.returncode}"
+    raise SbomDeltaError(f"failed to scan image '{image}': {details}")
+
+
+def generate_delta_for_container(
+    containers_dir: Path,
+    output_dir: Path,
+    container: str,
+    registry: str,
+    version: str,
+) -> None:
+    """Generate delta SBOM artifacts for a single container."""
+    base_image = resolve_runtime_base(containers_dir=containers_dir, container=container, registry=registry, version=version)
+    target_image = build_container_image(registry=registry, container=container, version=version)
+
+    print(f"[{container}]")
+    print(f"  base      : {base_image}")
+    print(f"  container : {target_image}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    base_sbom = output_dir / "base.spdx.json"
+    full_sbom = output_dir / "full.spdx.json"
+
+    print("  scanning base...")
+    scan_image(image=base_image, output_path=base_sbom)
+    print("  scanning container...")
+    scan_image(image=target_image, output_path=full_sbom)
+
+    print("  computing delta...")
+    report = build_delta_report(
+        base_sbom_path=base_sbom,
+        full_sbom_path=full_sbom,
+        name=container,
+        version=version,
+        base_image=base_image,
+        target_image=target_image,
+    )
+
+    output_path = output_dir / "delta.spdx.json"
+    write_output(output_path, json.dumps(report, indent=2, sort_keys=True) + "\n")
+    print(f"  delta -> {output_path}")
+
+
+def run_generate(args: argparse.Namespace) -> int:
+    """Run the end-to-end delta generation workflow."""
+    require_command("syft", "Install from: https://github.com/anchore/syft#installation")
+
+    containers_dir = REPO_ROOT / "containers"
+    containers = list(args.containers) if args.containers else discover_containers(containers_dir)
+    if not containers:
+        raise SbomDeltaError(f"No containers found (looked for ci.json under {containers_dir}).")
+
+    registry = normalize_registry(args.registry)
+
+    print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+    print(f" SBOM Delta Generator  |  {registry}  v{args.version}  ({PLATFORM})")
+    print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
+
+    failed: list[str] = []
+    for container in containers:
+        output_dir = containers_dir / container / "sbom-delta"
+        try:
+            generate_delta_for_container(
+                containers_dir=containers_dir,
+                output_dir=output_dir,
+                container=container,
+                registry=registry,
+                version=args.version,
+            )
+        except SbomDeltaError as exc:
+            print(f"  ERROR: {exc}", file=sys.stderr)
+            failed.append(container)
+        print("")
+
+    if failed:
+        raise SbomDeltaError(f"Failed: {' '.join(failed)}")
+
+    print("Done.")
+    return 0
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the CLI argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("containers", nargs="*", help="Container names (default: all with ci.json).")
+    parser.add_argument("--registry", default=os.environ.get("REGISTRY", "ghcr.io/arduino/"), help="Registry prefix.")
+    parser.add_argument("--version", default=os.environ.get("VERSION", "latest"), help="Image tag to scan.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    args = create_parser().parse_args(sys.argv[1:] if argv is None else argv)
+
+    try:
+        return run_generate(args)
+    except SbomDeltaError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sbom_delta.py
+++ b/scripts/sbom_delta.py
@@ -290,21 +290,18 @@ def _pkg_to_spdx(
             }
         ]
 
+    delta_info: dict[str, str] = {"change": change_type}
+    if from_version is not None:
+        delta_info["previous-version"] = from_version
+
     annotations = [
         {
             "annotationType": "OTHER",
             "annotator": "Tool: arduino-sbom-delta",
             "annotationDate": now,
-            "comment": f"change-type: {change_type}",
+            "comment": json.dumps(delta_info),
         },
     ]
-    if from_version is not None:
-        annotations.append({
-            "annotationType": "OTHER",
-            "annotator": "Tool: arduino-sbom-delta",
-            "annotationDate": now,
-            "comment": f"previous-version: {from_version}",
-        })
     entry["annotations"] = annotations
 
     return entry, spdxid
@@ -473,6 +470,9 @@ def scan_image(image: str, output_path: Path) -> None:
     for cmd in commands:
         last_result = subprocess.run(cmd, capture_output=True, text=True, check=False)
         if last_result.returncode == 0:
+            # Re-write as pretty-printed JSON
+            raw = load_json(output_path)
+            output_path.write_text(json.dumps(raw, indent=2, sort_keys=True) + "\n", encoding="utf-8")
             return
 
     details = (last_result.stderr or last_result.stdout or "").strip() if last_result else ""


### PR DESCRIPTION
Introduce SBOM deltas for container images.
Adds:
- a new `sbom_delta.py` script that calculates differences between SBOM versions
- a reusable GitHub Action (sbom-delta), and integration into the Docker build/publish workflows. 
- unit tests and updated ci.json configs for all container targets.