### PR TITLE
fix: improve error logging for chat stream failures

### DIFF
--- a/src/arduino/app_bricks/cloud_llm/cloud_llm.py
+++ b/src/arduino/app_bricks/cloud_llm/cloud_llm.py
@@ -350,6 +350,11 @@ class CloudLLM:
             self._handle_stream_error(e)
 
     def _handle_stream_error(self, e: Exception) -> None:
+        """Handles stream errors and acts as an override hook for subclasses.
+
+        Args:
+            e (Exception): The exception that occurred during streaming.
+        """
         self._logger.error(f"Response generation failed: {e}")
         raise RuntimeError(f"Response generation failed: {e}") from e
 

--- a/src/arduino/app_bricks/cloud_llm/cloud_llm.py
+++ b/src/arduino/app_bricks/cloud_llm/cloud_llm.py
@@ -35,6 +35,8 @@ class CloudLLM:
     'one-shot' responses and streaming output, with optional conversational memory.
     """
 
+    _logger = logger
+
     def __init__(
         self,
         api_key: str = os.getenv("API_KEY", ""),
@@ -340,11 +342,16 @@ class CloudLLM:
             AlreadyGenerating: If a streaming session is already active.
         """
         try:
-            return self._chat_stream_invoke(message, images)
+            yield from self._chat_stream_invoke(message, images)
 
+        except AlreadyGenerating:
+            raise
         except Exception as e:
-            logger.error(f"Response generation failed: {e}")
-            raise RuntimeError(f"Response generation failed: {e}")
+            self._handle_stream_error(e)
+
+    def _handle_stream_error(self, e: Exception) -> None:
+        self._logger.error(f"Response generation failed: {e}")
+        raise RuntimeError(f"Response generation failed: {e}") from e
 
     def _chat_stream_invoke(self, message: str, images: List[str | bytes] = None) -> Iterator[str]:
         """Internal method to perform the chat streaming invocation with the model.

--- a/src/arduino/app_bricks/llm/local_llm.py
+++ b/src/arduino/app_bricks/llm/local_llm.py
@@ -25,6 +25,8 @@ class LargeLanguageModel(CloudLLM):
     'one-shot' responses and streaming output, with optional conversational memory.
     """
 
+    _logger = logger
+
     GENIE_MODEL = "genie"
     LLAMACPP_MODEL = "llamacpp"
     OLLAMA_MODEL = "ollama"
@@ -252,24 +254,27 @@ class LargeLanguageModel(CloudLLM):
             RuntimeError: If the internal chain is not initialized or if the API request fails.
             AlreadyGenerating: If a streaming session is already active.
         """
-        try:
-            in_thininkg = False
-            for chunk in super()._chat_stream_invoke(message=message, images=images):
-                if in_thininkg:
-                    if "</think>" in chunk:
-                        in_thininkg = False
-                        chunk = chunk.split("</think>")[-1]  # Take content after </think>
-                        if chunk is not None and chunk.strip() != "":
-                            yield chunk
-                    continue
+        in_thinking = False
+        for chunk in super().chat_stream(message=message, images=images):
+            if in_thinking:
+                if "</think>" in chunk:
+                    in_thinking = False
+                    chunk = chunk.split("</think>")[-1]  # Take content after </think>
+                    if chunk is not None and chunk.strip() != "":
+                        yield chunk
+                continue
 
-                if "<think>" in chunk:
-                    in_thininkg = True
-                    continue  # Skip the <think> tag itself
-                else:
-                    yield chunk
-        except (BadRequestError, APIError) as e:
+            if "<think>" in chunk:
+                in_thinking = True
+                continue  # Skip the <think> tag itself
+            else:
+                yield chunk
+
+    def _handle_stream_error(self, e: Exception) -> None:
+        if isinstance(e, (BadRequestError, APIError)):
             self._handle_api_error(logger, e)
+
+        super()._handle_stream_error(e)
 
     def stop_stream(self) -> None:
         """Signals the active streaming generation to stop.

--- a/tests/arduino/app_bricks/cloud_llm/test_cloud_llm_stream_logging.py
+++ b/tests/arduino/app_bricks/cloud_llm/test_cloud_llm_stream_logging.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import threading
+from unittest.mock import patch
+
+import pytest
+
+import arduino.app_bricks.cloud_llm.cloud_llm as cloud_llm_module
+from arduino.app_bricks.cloud_llm.cloud_llm import CloudLLM
+
+
+class FailingStreamModel:
+    def stream(self, *_args, **_kwargs):
+        raise ValueError("provider exploded")
+
+
+def test_chat_stream_logs_errors_raised_during_iteration():
+    llm = CloudLLM.__new__(CloudLLM)
+    llm._model = FailingStreamModel()
+    llm._keep_streaming = threading.Event()
+    llm._get_message_with_history = lambda *_args, **_kwargs: []
+
+    with patch.object(cloud_llm_module.logger, "error") as log_error:
+        with pytest.raises(RuntimeError, match="Response generation failed: provider exploded"):
+            list(llm.chat_stream("hello"))
+
+    log_error.assert_called_once_with("Response generation failed: provider exploded")

--- a/tests/arduino/app_bricks/llm/test_local_llm_stream_logging.py
+++ b/tests/arduino/app_bricks/llm/test_local_llm_stream_logging.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import threading
+from unittest.mock import patch
+
+import pytest
+
+import arduino.app_bricks.llm.local_llm as local_llm_module
+from arduino.app_bricks.llm.local_llm import LargeLanguageModel
+
+
+class FailingStreamModel:
+    def stream(self, *_args, **_kwargs):
+        raise ValueError("provider exploded")
+
+
+def test_local_llm_chat_stream_logs_non_api_errors_raised_during_iteration():
+    llm = LargeLanguageModel.__new__(LargeLanguageModel)
+    llm._model = FailingStreamModel()
+    llm._keep_streaming = threading.Event()
+    llm._get_message_with_history = lambda *_args, **_kwargs: []
+
+    with patch.object(local_llm_module.logger, "error") as log_error:
+        with pytest.raises(RuntimeError, match="Response generation failed: provider exploded"):
+            list(llm.chat_stream("hello"))
+
+    log_error.assert_called_once_with("Response generation failed: provider exploded")


### PR DESCRIPTION
This PR fixes a streaming error logging issue in the LLM chat flow. Errors raised while consuming streamed chat responses were being propagated to the app layer and shown in the frontend error box, but they were not always emitted in the Python logs.

## Technical Details

The root cause was that `CloudLLM.chat_stream()` returned the internal generator directly, so exceptions raised during generator iteration happened outside its `try/except` block.

## Changes:

- Updated `src/arduino/app_bricks/cloud_llm/cloud_llm.py`
  - `CloudLLM.chat_stream()` now uses `yield from` so stream iteration is covered by the logging/error handling block.
  - Added `_handle_stream_error()` as the common stream error handling hook.

- Updated `src/arduino/app_bricks/llm/local_llm.py`
  - `LargeLanguageModel.chat_stream()` now delegates to `super().chat_stream(...)`, sharing the same streaming/logging path as `CloudLLM`.
  - Kept local LLM-specific behavior isolated: filtering `<think>` chunks and handling OpenAI-compatible API errors via `_handle_api_error()`.

- Added brick-scoped regression tests:
  - `tests/arduino/app_bricks/cloud_llm/test_cloud_llm_stream_logging.py`
  - `tests/arduino/app_bricks/llm/test_local_llm_stream_logging.py`

## Validation

- `python3 -m pytest tests/arduino/app_bricks/cloud_llm/test_cloud_llm_stream_logging.py tests/arduino/app_bricks/llm/test_local_llm_stream_logging.py`
- `python3 -m ruff check src/arduino/app_bricks/cloud_llm/cloud_llm.py src/arduino/app_bricks/llm/local_llm.py tests/arduino/app_bricks/cloud_llm/test_cloud_llm_stream_logging.py tests/arduino/app_bricks/llm/test_local_llm_stream_logging.py`
