### PR TITLE
feat: align cloud_asr apis with the asr brick

### DIFF
--- a/src/arduino/app_bricks/cloud_asr/README.md
+++ b/src/arduino/app_bricks/cloud_asr/README.md
@@ -80,3 +80,8 @@ You can select a provider using the `CloudProvider` enum or by passing its raw s
 
 - **`transcribe(duration=60.0)`**: Returns the first finalized transcription (`text`).
 - **`transcribe_stream(duration=60.0)`**: Yields `ASREvent` items (`speech_start`, `partial_text`, `text`, `speech_stop`).
+- **`transcribe_sentence(timeout=60.0)`**: Returns the first sentence as a string. Stops at the provider's sentence boundary (VAD) or when `timeout` elapses.
+- **`transcribe_sentence_stream(timeout=60.0)`**: Yields `ASREvent` items for a single sentence; the stream ends after the first `text` event.
+- **`transcribe_until_cancelled()`**: Yields one sentence (`str`) per `text` event; runs until `cancel()` or silence timeout.
+- **`cancel()`**: Cancels the active transcription session, if any.
+- **`is_transcribing()`**: Returns `True` if a transcription session is currently active.

--- a/src/arduino/app_bricks/cloud_asr/cloud_asr.py
+++ b/src/arduino/app_bricks/cloud_asr/cloud_asr.py
@@ -42,6 +42,10 @@ class SessionInfo:
     silence_deadline: float
 
 
+def _normalize_duration(value: float) -> float:
+    return math.inf if value <= 0 else value
+
+
 @brick
 class CloudASR:
     """
@@ -113,11 +117,12 @@ class CloudASR:
 
         Args:
             duration (float): Max seconds for the transcription session.
+                ``0`` means unbounded.
 
         Returns:
             str: The transcribed text.
         """
-        with self._session_scope(duration=duration) as session:
+        with self._session_scope(duration=_normalize_duration(duration)) as session:
             for resp in self._transcribe_stream(session):
                 if resp.type == "text":
                     return resp.data or ""
@@ -130,11 +135,12 @@ class CloudASR:
 
         Args:
             duration (float): Max seconds for the transcription session.
+                ``0`` means unbounded.
 
         Returns:
             Iterator[ASREvent]: Generator yielding transcription events.
         """
-        with self._session_scope(duration=duration) as session:
+        with self._session_scope(duration=_normalize_duration(duration)) as session:
             gen = self._transcribe_stream(session)
             try:
                 yield gen
@@ -150,6 +156,7 @@ class CloudASR:
 
         Args:
             timeout (float): Max seconds to wait for the sentence.
+                ``0`` means no timeout.
 
         Returns:
             str: The transcribed sentence.
@@ -170,11 +177,12 @@ class CloudASR:
 
         Args:
             timeout (float): Max seconds to wait for the sentence.
+                ``0`` means no timeout.
 
         Yields:
             ASREvent: Transcription events.
         """
-        with self._session_scope(duration=timeout) as session:
+        with self._session_scope(duration=_normalize_duration(timeout)) as session:
 
             def sentence_gen() -> Generator[ASREvent, None, None]:
                 inner = self._transcribe_stream(session)

--- a/src/arduino/app_bricks/cloud_asr/cloud_asr.py
+++ b/src/arduino/app_bricks/cloud_asr/cloud_asr.py
@@ -2,12 +2,14 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+import math
 import os
 import queue
 import threading
 import time
 from contextlib import contextmanager
-from typing import Generator, Union, Iterator, Generator, cast
+from dataclasses import dataclass
+from typing import Generator, Iterator, Union, cast
 
 import numpy as np
 
@@ -30,6 +32,14 @@ class TranscriptionTimeoutError(TimeoutError):
 
 class TranscriptionStreamError(RuntimeError):
     pass
+
+
+@dataclass
+class SessionInfo:
+    cancelled: threading.Event
+    duration: float
+    overall_deadline: float
+    silence_deadline: float
 
 
 @brick
@@ -67,6 +77,9 @@ class CloudASR:
         )
         self._shutdown = threading.Event()
 
+        self._active_session_lock = threading.Lock()
+        self._active_session: SessionInfo | None = None
+
     def start(self):
         """Start the ASR service by initializing the microphone."""
         self._shutdown.clear()
@@ -80,8 +93,19 @@ class CloudASR:
         the mic if owned.
         """
         self._shutdown.set()
+        self.cancel()
         if self._owns_mic:
             self._mic.stop()
+
+    def cancel(self) -> None:
+        """Cancel the active transcription session, if any."""
+        if self._active_session is None:
+            return
+        self._active_session.cancelled.set()
+
+    def is_transcribing(self) -> bool:
+        """Return True if a transcription session is currently active on this instance."""
+        return self._active_session is not None
 
     def transcribe(self, duration: float = 60.0) -> str:
         """
@@ -93,16 +117,11 @@ class CloudASR:
         Returns:
             str: The transcribed text.
         """
-
-        gen = self._transcribe_stream(duration=duration)
-
-        try:
-            for resp in gen:
+        with self._session_scope(duration=duration) as session:
+            for resp in self._transcribe_stream(session):
                 if resp.type == "text":
                     return resp.data or ""
             raise TranscriptionStreamError("No transcription received.")
-        finally:
-            gen.close()
 
     @contextmanager
     def transcribe_stream(self, duration: float = 60.0) -> Iterator[Iterator[ASREvent]]:
@@ -115,20 +134,112 @@ class CloudASR:
         Returns:
             Iterator[ASREvent]: Generator yielding transcription events.
         """
+        with self._session_scope(duration=duration) as session:
+            gen = self._transcribe_stream(session)
+            try:
+                yield gen
+            finally:
+                gen.close()
 
-        gen = self._transcribe_stream(duration=duration)
-
-        try:
-            yield gen
-        finally:
-            gen.close()
-
-    def _transcribe_stream(self, duration: float = 60.0) -> Generator[ASREvent, None, None]:
+    def transcribe_sentence(self, timeout: float = 60.0) -> str:
         """
-        Perform continuous speech-to-text recognition with detailed events.
+        Transcribe a single sentence and return its text.
+
+        Stops at the first sentence boundary produced by the provider, or when
+        ``timeout`` elapses. VAD is managed by the cloud provider.
 
         Args:
-            duration (float): Max seconds for the transcription session.
+            timeout (float): Max seconds to wait for the sentence.
+
+        Returns:
+            str: The transcribed sentence.
+        """
+        with self.transcribe_sentence_stream(timeout=timeout) as stream:
+            for event in stream:
+                if event.type == "text":
+                    return event.data or ""
+        raise TranscriptionStreamError("No transcription received.")
+
+    @contextmanager
+    def transcribe_sentence_stream(self, timeout: float = 60.0) -> Iterator[Iterator[ASREvent]]:
+        """
+        Yield transcription events for a single sentence.
+
+        The stream ends after the first ``text`` event or when ``timeout``
+        elapses. VAD is managed by the cloud provider.
+
+        Args:
+            timeout (float): Max seconds to wait for the sentence.
+
+        Yields:
+            ASREvent: Transcription events.
+        """
+        with self._session_scope(duration=timeout) as session:
+
+            def sentence_gen() -> Generator[ASREvent, None, None]:
+                inner = self._transcribe_stream(session)
+                try:
+                    for event in inner:
+                        yield event
+                        if event.type == "text":
+                            return
+                finally:
+                    inner.close()
+
+            gen = sentence_gen()
+            try:
+                yield gen
+            finally:
+                gen.close()
+
+    @contextmanager
+    def transcribe_until_cancelled(self) -> Iterator[Iterator[str]]:
+        """
+        Yield one sentence per ``text`` event until ``cancel()`` is called
+        or the silence timeout fires. VAD is managed by the cloud provider.
+
+        Yields:
+            str: A complete sentence as recognized by the provider.
+        """
+        with self._session_scope(duration=math.inf) as session:
+
+            def sentence_gen() -> Generator[str, None, None]:
+                inner = self._transcribe_stream(session)
+                try:
+                    for event in inner:
+                        data = event.data
+                        if event.type == "text" and data and data.strip():
+                            yield data
+                finally:
+                    inner.close()
+
+            gen = sentence_gen()
+            try:
+                yield gen
+            finally:
+                gen.close()
+
+    @contextmanager
+    def _session_scope(self, duration: float) -> Iterator[SessionInfo]:
+        if not self._active_session_lock.acquire(blocking=False):
+            raise TranscriptionStreamError("transcription session already active")
+        now = time.monotonic()
+        session = SessionInfo(
+            cancelled=threading.Event(),
+            duration=duration,
+            overall_deadline=now + duration,
+            silence_deadline=now + self.silence_timeout,
+        )
+        self._active_session = session
+        try:
+            yield session
+        finally:
+            self._active_session = None
+            self._active_session_lock.release()
+
+    def _transcribe_stream(self, session: SessionInfo) -> Generator[ASREvent, None, None]:
+        """
+        Perform continuous speech-to-text recognition with detailed events.
 
         Returns:
             Iterator[dict]: Generator yielding
@@ -136,31 +247,28 @@ class CloudASR:
             messages.
         """
         messages: queue.Queue[Union[ASRProviderEvent, BaseException]] = queue.Queue()
-        stop_event = threading.Event()
-        overall_deadline = time.monotonic() + duration
-        silence_deadline = time.monotonic() + self.silence_timeout
 
         def _send():
             try:
                 for chunk in self._mic.stream():
-                    if stop_event.is_set() or self._shutdown.is_set():
+                    if session.cancelled.is_set() or self._shutdown.is_set():
                         break
                     if chunk is None:
                         continue
                     pcm_chunk_np = np.asarray(chunk, dtype=np.int16)
                     self._provider.send_audio(pcm_chunk_np.tobytes())
             except Exception as exc:
-                if stop_event.is_set() or self._shutdown.is_set():
+                if session.cancelled.is_set() or self._shutdown.is_set():
                     return
                 messages.put(ASRProviderError(f"Error while streaming microphone audio: {exc}"))
-                stop_event.set()
+                session.cancelled.set()
 
         partial_buffer = ""
 
         def _recv():
             nonlocal partial_buffer
             try:
-                while not stop_event.is_set() and not self._shutdown.is_set():
+                while not session.cancelled.is_set() and not self._shutdown.is_set():
                     result = self._provider.recv()
                     if result is None:
                         time.sleep(0.005)  # Avoid busy waiting
@@ -179,10 +287,10 @@ class CloudASR:
                     messages.put(result)
 
             except Exception as exc:
-                if stop_event.is_set() or self._shutdown.is_set():
+                if session.cancelled.is_set() or self._shutdown.is_set():
                     return
                 messages.put(exc)
-                stop_event.set()
+                session.cancelled.set()
 
         send_thread = threading.Thread(target=_send, daemon=True)
         recv_thread = threading.Thread(target=_recv, daemon=True)
@@ -194,8 +302,9 @@ class CloudASR:
             while (
                 (recv_thread.is_alive() or send_thread.is_alive() or not messages.empty())
                 and not self._shutdown.is_set()
-                and time.monotonic() < overall_deadline
-                and time.monotonic() < silence_deadline
+                and not session.cancelled.is_set()
+                and time.monotonic() < session.overall_deadline
+                and time.monotonic() < session.silence_deadline
             ):
                 try:
                     msg = messages.get(timeout=0.1)
@@ -206,7 +315,7 @@ class CloudASR:
                     raise msg
 
                 if msg.type in ("partial_text", "text"):
-                    silence_deadline = time.monotonic() + self.silence_timeout
+                    session.silence_deadline = time.monotonic() + self.silence_timeout
 
                 api_event = self._to_api(msg)
                 if api_event is not None:
@@ -221,14 +330,14 @@ class CloudASR:
                 except queue.Empty:
                     break
 
-            if time.monotonic() >= overall_deadline:
-                raise TranscriptionTimeoutError(f"Maximum ASR time of {duration}s exceeded")
-            if time.monotonic() >= silence_deadline:
+            if time.monotonic() >= session.overall_deadline:
+                raise TranscriptionTimeoutError(f"Maximum ASR time of {session.duration}s exceeded")
+            if time.monotonic() >= session.silence_deadline:
                 raise TranscriptionTimeoutError(f"No speech detected for {self.silence_timeout}s, timing out.")
 
         finally:
             logger.debug("Releasing ASR resources...")
-            stop_event.set()
+            session.cancelled.set()
             self._provider.stop()
             send_thread.join(timeout=1)
             recv_thread.join(timeout=1)

--- a/tests/arduino/app_bricks/cloud_asr/test_cloud_asr.py
+++ b/tests/arduino/app_bricks/cloud_asr/test_cloud_asr.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from arduino.app_bricks.cloud_asr import CloudASR, CloudProvider
+from arduino.app_bricks.cloud_asr.cloud_asr import TranscriptionStreamError
 from arduino.app_bricks.cloud_asr.providers import ASRProviderEvent, ASRProviderError
 from arduino.app_peripherals.microphone.base_microphone import BaseMicrophone
 
@@ -169,6 +170,121 @@ def test_transcribe_stream_resets_partial_buffer_in_replace_mode(make_provider):
     assert results[2].data == "due"
     assert results[4].data == "tre"
     assert provider.stop_called is True
+
+
+def test_transcribe_sentence_returns_first_text(make_provider):
+    events = [
+        ASRProviderEvent(type="partial_text", data="Hel"),
+        ASRProviderEvent(type="text", data="Hello"),
+        ASRProviderEvent(type="text", data="Should not be returned"),
+    ]
+    audio_chunks = [np.array([1, 2, 3], dtype=np.int16), np.array([4, 5, 6], dtype=np.int16)]
+    mic = MockMicrophone(audio_chunks)
+    mic.start()
+    provider = make_provider(events=events, audio_chunks_len=2)
+    asr = CloudASR(api_key="dummy", mic=mic, provider=CloudProvider.OPENAI_TRANSCRIBE)
+
+    try:
+        result = asr.transcribe_sentence()
+    finally:
+        asr.stop()
+        mic.stop()
+
+    assert result == "Hello"
+    assert provider.start_called is True
+    assert provider.stop_called is True
+
+
+def test_transcribe_sentence_stream_stops_at_first_text(make_provider):
+    events = [
+        ASRProviderEvent(type="partial_text", data="Hel"),
+        ASRProviderEvent(type="partial_text", data="lo"),
+        ASRProviderEvent(type="text", data=None),
+        ASRProviderEvent(type="text", data="Should not appear"),
+    ]
+    audio_chunks = [np.array([1, 2, 3], dtype=np.int16) for _ in range(4)]
+    mic = MockMicrophone(audio_chunks)
+    mic.start()
+    make_provider(events=events, partial_mode="append", audio_chunks_len=4)
+    asr = CloudASR(api_key="dummy", mic=mic, provider=CloudProvider.OPENAI_TRANSCRIBE)
+
+    try:
+        with asr.transcribe_sentence_stream() as stream:
+            seen = list(stream)
+    finally:
+        asr.stop()
+        mic.stop()
+
+    assert [e.type for e in seen] == ["partial_text", "partial_text", "text"]
+    assert seen[-1].data == "Hello"
+
+
+def test_transcribe_until_cancelled_yields_sentences_and_stops_on_cancel(make_provider):
+    events = [
+        ASRProviderEvent(type="text", data="first"),
+        ASRProviderEvent(type="text", data="second"),
+    ]
+    audio_chunks = [np.array([1, 2, 3], dtype=np.int16) for _ in range(5)]
+    mic = MockMicrophone(audio_chunks)
+    mic.start()
+    make_provider(events=events, audio_chunks_len=2)
+    asr = CloudASR(
+        api_key="dummy",
+        mic=mic,
+        provider=CloudProvider.OPENAI_TRANSCRIBE,
+        silence_timeout=60.0,
+    )
+
+    try:
+        with asr.transcribe_until_cancelled() as stream:
+            first = next(stream)
+            second = next(stream)
+            asr.cancel()
+            remaining = list(stream)
+    finally:
+        asr.stop()
+        mic.stop()
+
+    assert first == "first"
+    assert second == "second"
+    assert remaining == []
+
+
+def test_is_transcribing_reflects_session_state(make_provider):
+    events = [ASRProviderEvent(type="text", data="hello")]
+    audio_chunks = [np.array([1, 2], dtype=np.int16)]
+    mic = MockMicrophone(audio_chunks)
+    mic.start()
+    make_provider(events=events, audio_chunks_len=1)
+    asr = CloudASR(api_key="dummy", mic=mic, provider=CloudProvider.OPENAI_TRANSCRIBE)
+
+    try:
+        assert asr.is_transcribing() is False
+        with asr.transcribe_stream() as stream:
+            next(stream, None)
+            assert asr.is_transcribing() is True
+        assert asr.is_transcribing() is False
+    finally:
+        asr.stop()
+        mic.stop()
+
+
+def test_concurrent_session_raises(make_provider):
+    events = [ASRProviderEvent(type="text", data="ok")]
+    audio_chunks = [np.array([1, 2], dtype=np.int16)]
+    mic = MockMicrophone(audio_chunks)
+    mic.start()
+    make_provider(events=events, audio_chunks_len=1)
+    asr = CloudASR(api_key="dummy", mic=mic, provider=CloudProvider.OPENAI_TRANSCRIBE)
+
+    try:
+        with asr.transcribe_stream() as stream:
+            next(stream, None)
+            with pytest.raises(TranscriptionStreamError, match="already active"):
+                asr.transcribe(duration=1.0)
+    finally:
+        asr.stop()
+        mic.stop()
 
 
 def test_transcribe_stream_surfaces_provider_errors(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
- Align `cloud_asr` public surface with `local_asr`'s: adds `transcribe_sentence`, `transcribe_sentence_stream`, `transcribe_until_cancelled`, `cancel()` and `is_transcribing()`.
- Adds a single-session lock that raises `TranscriptionStreamError` on concurrent calls.