### PR TITLE
feat: add model warmup for asr and tts on brick start

### DIFF
--- a/src/arduino/app_bricks/asr/__init__.py
+++ b/src/arduino/app_bricks/asr/__init__.py
@@ -11,6 +11,7 @@ from .local_asr import (
     AutomaticSpeechRecognition,
     TranscriptionStream,
 )
+from .local_asr_wav import WAVAutomaticSpeechRecognition
 
 __all__ = [
     "ASREvent",
@@ -18,6 +19,7 @@ __all__ = [
     "ASRBusyError",
     "ASRServiceBusyError",
     "ASRUnavailableError",
-    "AutomaticSpeechRecognition",
     "TranscriptionStream",
+    "AutomaticSpeechRecognition",
+    "WAVAutomaticSpeechRecognition",
 ]

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -182,6 +182,7 @@ class BaseASR:
             self._worker_loop = Future()
         if self._owns_source:
             self._source.start()
+        self._warmup()
 
     def stop(self):
         """Stop the ASR and clean up resources. Stops the owned mic if applicable."""
@@ -268,6 +269,25 @@ class BaseASR:
                 loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             loop.close()
             logger.debug("Asyncio event loop stopped")
+
+    def _warmup(self) -> None:
+        """Best-effort warmup: create and immediately close a transcription session so the
+        inference container loads the ASR model before the first real transcription."""
+        if self._stop_worker.is_set():
+            return
+        started_at = time.perf_counter()
+        try:
+            session_id = self._create_transcription_session(language=self.language)
+        except Exception as e:
+            logger.warning(f"ASR warmup failed during session creation: {e}")
+            return
+        try:
+            self._close_transcription_session(session_id)
+        except Exception as e:
+            logger.warning(f"ASR warmup failed during closing session {session_id}: {e}")
+            return
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        logger.debug(f"ASR warmup completed in {elapsed_ms:.2f} ms")
 
     def _transcribe_stream(self, duration: int = 0, vad_ms: int | None = None) -> Generator[ASREvent, None, None]:
         if self._stop_worker.is_set():
@@ -402,7 +422,7 @@ class BaseASR:
 
         state = result.get("state")
         if state != "asr_initialized":
-            logger.warning(f"ASR session {session_id} created but not initialized (state={state})")
+            raise ASRError(f"Unexpected session state: {state}")
 
         return session_id
 

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -361,7 +361,7 @@ class AutomaticSpeechRecognition:
         self._ensure_source_started()
         return TranscriptionStream(self._transcribe_stream(duration=duration))
 
-    def transcribe_sentence(self, hangover: int = 700, timeout: int = 0) -> str:
+    def transcribe_sentence(self, timeout: int = 0) -> str:
         """
         Transcribe a sentence returning the full text.
 
@@ -369,8 +369,6 @@ class AutomaticSpeechRecognition:
         without one or when the source is exhausted.
 
         Args:
-            hangover (int): Time in milliseconds to wait when detecting silence after
-                speech. Tune to allow short pauses within sentences. Default: 700 ms.
             timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
                 Ignored for finite sources (WAV/ndarray). Default: ``0``.
 
@@ -386,7 +384,7 @@ class AutomaticSpeechRecognition:
         last_partial = ""
         final_text = ""
 
-        with self.transcribe_sentence_stream(hangover=hangover, timeout=timeout) as stream:
+        with self.transcribe_sentence_stream(timeout=timeout) as stream:
             for chunk in stream:
                 if chunk.type == "partial_text" and chunk.data.strip():
                     last_partial = chunk.data
@@ -400,7 +398,7 @@ class AutomaticSpeechRecognition:
             return last_partial
         return ""
 
-    def transcribe_sentence_stream(self, hangover: int = 700, timeout: int = 0) -> TranscriptionStream[ASREvent]:
+    def transcribe_sentence_stream(self, timeout: int = 0) -> TranscriptionStream[ASREvent]:
         """
         Transcribe a sentence and yield the intermediate transcription events.
 
@@ -408,8 +406,6 @@ class AutomaticSpeechRecognition:
         elapses without one or when the source is exhausted.
 
         Args:
-            hangover (int): Time in milliseconds to wait when detecting silence after
-                speech. Tune to allow short pauses within sentences. Default: 700 ms.
             timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
                 Ignored for finite sources (WAV/ndarray). Default: ``0``.
 
@@ -426,7 +422,7 @@ class AutomaticSpeechRecognition:
         self._ensure_source_started()
 
         def sentence_gen() -> Generator[ASREvent, None, None]:
-            inner = self._transcribe_stream(duration=timeout, vad_ms=hangover)
+            inner = self._transcribe_stream(duration=timeout)
             try:
                 for event in inner:
                     yield event

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -609,9 +609,7 @@ class AutomaticSpeechRecognition:
         sampling_rate = str(self._source.sample_rate)
         channels = str(self._source.channels)
 
-        # The API expects VAD hangover in 10ms slots, not milliseconds
-        hangover_ms = vad_ms if vad_ms is not None else self._DEFAULT_VAD_MS
-        vad_slots = str(hangover_ms // 10)
+        hangover_ms = str(vad_ms if vad_ms is not None else self._DEFAULT_VAD_MS)
 
         create_url = f"{self.api_base_url}/transcriptions/create"
         create_data = {
@@ -621,7 +619,7 @@ class AutomaticSpeechRecognition:
                 {"key": "sampling_rate", "value": sampling_rate},
                 {"key": "channels", "value": channels},
                 {"key": "format", "value": self._pcm_format},
-                {"key": "vad", "value": vad_slots},
+                {"key": "vad", "value": hangover_ms},
             ]),
         }
         if language is not None:

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -304,14 +304,14 @@ class AutomaticSpeechRecognition:
         """
         return self._active_session is not None
 
-    def transcribe(self, duration: int = 0) -> str:
+    def transcribe(self, duration: int = 60) -> str:
         """
         Transcribe audio for a duration and return the final text.
 
         Args:
             duration (int): Maximum recording time in seconds. ``0`` means unbounded.
                 Ignored for finite sources (WAV/ndarray), which are consumed
-                to completion regardless. Default: ``0``.
+                to completion regardless. Default: ``60``.
 
         Returns:
             str: The transcribed text, or an empty string if no speech was detected.
@@ -346,7 +346,7 @@ class AutomaticSpeechRecognition:
 
         Args:
             duration (int): Maximum recording time in seconds. ``0`` means unbounded.
-                Ignored for finite sources (WAV/ndarray). Default: ``0``.
+                Ignored for finite sources (WAV/ndarray). Default: ``60``.
 
         Yields:
             ASREvent: objects representing transcription events.

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -306,7 +306,7 @@ class AutomaticSpeechRecognition:
 
     def transcribe(self, duration: int = 0) -> str:
         """
-        Transcribe audio from the configured source and return the final text.
+        Transcribe audio for a duration and return the final text.
 
         Args:
             duration (int): Maximum recording time in seconds. ``0`` means unbounded.
@@ -342,7 +342,7 @@ class AutomaticSpeechRecognition:
 
     def transcribe_stream(self, duration: int = 0) -> TranscriptionStream[ASREvent]:
         """
-        Transcribe audio from the configured source and stream events.
+        Transcribe audio for a duration and yield intermediate transcription events.
 
         Args:
             duration (int): Maximum recording time in seconds. ``0`` means unbounded.
@@ -363,11 +363,10 @@ class AutomaticSpeechRecognition:
 
     def transcribe_sentence(self, hangover: int = 700, timeout: int = 0) -> str:
         """
-        Transcribe audio until a sentence boundary is detected or timeout is reached, and return the text.
+        Transcribe a sentence returning the full text.
 
-        For finite sources (WAV/ndarray), if the source is consumed before a
-        sentence boundary is detected, the best-effort partial transcription is
-        returned instead.
+        Runs until the sentence boundary is detected, the timeout elapses
+        without one or when the source is exhausted.
 
         Args:
             hangover (int): Time in milliseconds to wait when detecting silence after
@@ -403,11 +402,10 @@ class AutomaticSpeechRecognition:
 
     def transcribe_sentence_stream(self, hangover: int = 700, timeout: int = 0) -> TranscriptionStream[ASREvent]:
         """
-        Transcribe audio from the configured source and stream events until a
-        sentence boundary is detected.
+        Transcribe a sentence and yield the intermediate transcription events.
 
-        The stream ends after the first non-empty ``full_text`` event, or when
-        the source is exhausted / the timeout elapses without one.
+        The stream ends after the sentence boundary is detected, the timeout
+        elapses without one or when the source is exhausted.
 
         Args:
             hangover (int): Time in milliseconds to wait when detecting silence after
@@ -442,10 +440,9 @@ class AutomaticSpeechRecognition:
     def transcribe_continuous(self, timeout: int = 0) -> TranscriptionStream[str]:
         """
         Transcribe audio indefinitely and yield one sentence at a time.
-
-        Each iteration returns a single decoded sentence as a ``str``. Stop by
-        ``break``-ing out of the loop, calling :meth:`cancel`, or — for finite
-        sources (WAV/ndarray) — letting the source exhaust.
+        
+        The stream ends when :meth:`cancel` is called, the timeout elapses, or
+        when the source is exhausted.
 
         Args:
             timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
@@ -475,10 +472,10 @@ class AutomaticSpeechRecognition:
 
     def transcribe_continuous_stream(self, timeout: int = 0) -> TranscriptionStream[ASREvent]:
         """
-        Transcribe audio from the configured source indefinitely and stream events.
+        Transcribe audio indefinitely and yield intermediate transcription events.
 
-        Runs until ``cancel()`` is called, the timeout elapses, or — for finite
-        sources (WAV/ndarray) — the source is exhausted.
+        The stream ends when :meth:`cancel` is called, the timeout elapses, or
+        when the source is exhausted.
 
         Args:
             timeout (int): Maximum recording time in seconds. ``0`` means no timeout.

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -4,12 +4,10 @@
 
 import asyncio
 import base64
-import io
 import json
 import queue
 import threading
 import time
-import wave
 from collections.abc import Generator, Iterator
 from concurrent.futures import CancelledError, Future
 from dataclasses import dataclass
@@ -116,65 +114,6 @@ class TranscriptionStream(Generic[T], ContextManager["TranscriptionStream[T]"], 
         self._generator.close()
 
 
-class InMemoryAudioSource:
-    """
-    Audio source wrapping WAV bytes or a raw PCM ndarray.
-
-    Exposes only the subset of BaseMicrophone attributes/methods that ASR uses,
-    so it can be used uniformly. ``capture()`` raises ``AudioSourceExhausted``
-    when the underlying buffer is drained.
-    """
-
-    _DEFAULT_SAMPLING_RATE = 16000
-    _DEFAULT_CHANNELS = 1
-    _DEFAULT_BUFFER_SIZE = 1024
-
-    def __init__(self, samples: bytes | np.ndarray):
-        if isinstance(samples, (bytes, bytearray)):
-            with wave.open(io.BytesIO(bytes(samples)), "rb") as wf:
-                self.sample_rate = wf.getframerate()
-                self.channels = wf.getnchannels()
-                sample_width = wf.getsampwidth()
-                frames = wf.readframes(wf.getnframes())
-            # Derive numpy dtype from WAV sample width (signed int, little-endian — WAV convention)
-            dtype_map = {1: np.uint8, 2: np.int16, 4: np.int32}
-            if sample_width not in dtype_map:
-                raise ValueError(f"Unsupported WAV sample width: {sample_width}")
-            self.format = np.dtype(dtype_map[sample_width])
-            self._samples = np.frombuffer(frames, dtype=self.format)
-        elif isinstance(samples, np.ndarray):
-            self.sample_rate = self._DEFAULT_SAMPLING_RATE
-            self.channels = self._DEFAULT_CHANNELS
-            self.format = samples.dtype
-            self._samples = samples
-        else:
-            raise TypeError(f"Unsupported in-memory audio source type: {type(samples)!r}")
-
-        self.format_is_packed = False
-        self.buffer_size = self._DEFAULT_BUFFER_SIZE
-        self._started = True  # It's started by default, this is not a real device
-        self._cursor = 0
-
-    def is_started(self) -> bool:
-        return self._started
-
-    def start(self) -> None:
-        self._started = True
-
-    def stop(self) -> None:
-        self._started = False
-
-    def capture(self) -> np.ndarray:
-        step = self.buffer_size * self.channels
-        if self._cursor >= len(self._samples):
-            raise AudioSourceExhausted()
-
-        chunk = self._samples[self._cursor : self._cursor + step]
-        self._cursor += step
-
-        return chunk
-
-
 @dataclass
 class SessionInfo:
     session_id: str
@@ -190,41 +129,19 @@ class SessionInfo:
 _END_SENTINEL = object()  # Sentinel value to signal end of audio stream in the chunk queue
 
 
-@brick
-class AutomaticSpeechRecognition:
+class BaseASR:
+    """
+    Shared logic for ASR bricks. Subclasses bind the audio source
+    via :meth:`_build_source` and add their own public ``transcribe*`` surface.
+
+    Not decorated with ``@brick`` — only the concrete subclasses register.
+    """
+
     _APP_SERVICE_NAME = "audio-analytics-runner"
     _FLUSH_INTERVAL_SECONDS = 5
     _DEFAULT_VAD_MS = 700
 
-    def __init__(
-        self,
-        source: BaseMicrophone | np.ndarray | bytes | None = None,
-        language: str | None = None,
-    ):
-        """
-        ASR brick that uses a local audio analytics service to decode audio streams.
-
-        Args:
-            source: Audio source for transcription. One of:
-                BaseMicrophone: used as-is; the caller owns its
-                    lifecycle (ASR never calls start()/stop() on it).
-                bytes: treated as a WAV container and wrapped internally.
-                np.ndarray: treated as raw PCM samples at 16 kHz mono
-                    (dtype inferred) and wrapped internally.
-                None: ASR constructs a default Microphone() and owns its
-                    lifecycle (started on start(), stopped on stop()).
-                Default: None.
-            language (str): Language code for the ASR model (e.g. "en" for
-                English). This is typically auto-detected by the model,
-                but can be overridden here if needed. It is exposed as
-                the public ``language`` attribute and may be reassigned at
-                runtime; the new value takes effect on the next session.
-
-        Note:
-            Only one transcription can be active per instance at a time. For
-            concurrent transcriptions on different mics, create multiple ASR
-            instances.
-        """
+    def __init__(self, source, language: str | None = None):
         # API configuration
         self.api_host = resolve_address(self._APP_SERVICE_NAME)
         if not self.api_host:
@@ -244,17 +161,7 @@ class AutomaticSpeechRecognition:
 
         self.language = language
 
-        if source is None:
-            self._source = Microphone()
-            self._owns_source = True
-        elif isinstance(source, BaseMicrophone):
-            self._source = source
-            self._owns_source = False
-        elif isinstance(source, (bytes, bytearray, np.ndarray)):
-            self._source = InMemoryAudioSource(source)
-            self._owns_source = False
-        else:
-            raise TypeError(f"Unsupported source type: {type(source)!r}")
+        self._source, self._owns_source = self._build_source(source)
 
         self._pcm_format = _dtype_to_pcm_format(
             self._source.format,
@@ -304,29 +211,26 @@ class AutomaticSpeechRecognition:
         """
         return self._active_session is not None
 
-    def transcribe(self, duration: int = 60) -> str:
+    def _build_source(self, source) -> tuple:
+        """Bind the audio source. Subclasses must override."""
+        raise NotImplementedError("Subclasses must override _build_source")
+
+    def _ensure_source_started(self) -> None:
+        if not self._source.is_started():
+            raise RuntimeError("Audio source must be started before transcription.")
+
+    def _collect_transcription(self, stream: TranscriptionStream[ASREvent]) -> str:
         """
-        Transcribe audio for a duration and return the final text.
+        Drain an event stream into a single transcription string.
 
-        Args:
-            duration (int): Maximum recording time in seconds. ``0`` means unbounded.
-                Ignored for finite sources (WAV/ndarray), which are consumed
-                to completion regardless. Default: ``60``.
-
-        Returns:
-            str: The transcribed text, or an empty string if no speech was detected.
-
-        Raises:
-            ASRBusyError: If this instance already has an active session.
-            ASRServiceBusyError: If no more concurrent sessions are available.
-            ASRUnavailableError: If the inference service is unreachable or the
-                connection drops mid-session.
-            RuntimeError: If the audio source has not been started.
+        Accumulates non-empty ``full_text`` events; if none arrive, falls back
+        to the most recent non-empty ``partial_text``. Returns ``""`` if no
+        speech was detected.
         """
         last_partial = ""
         final_text = ""
 
-        with self.transcribe_stream(duration=duration) as stream:
+        with stream:
             for chunk in stream:
                 if chunk.type == "partial_text" and chunk.data.strip():
                     last_partial = chunk.data
@@ -339,156 +243,6 @@ class AutomaticSpeechRecognition:
             logger.warning("ASR returned empty full_text, falling back to last partial_text")
             return last_partial
         return ""
-
-    def transcribe_stream(self, duration: int = 0) -> TranscriptionStream[ASREvent]:
-        """
-        Transcribe audio for a duration and yield intermediate transcription events.
-
-        Args:
-            duration (int): Maximum recording time in seconds. ``0`` means unbounded.
-                Ignored for finite sources (WAV/ndarray). Default: ``60``.
-
-        Yields:
-            ASREvent: objects representing transcription events.
-
-        Raises:
-            ASRBusyError: If this instance already has an active session.
-            ASRServiceBusyError: If no more concurrent sessions are available.
-            ASRUnavailableError: If the inference service is unreachable or the
-                connection drops mid-session.
-            RuntimeError: If the audio source has not been started.
-        """
-        self._ensure_source_started()
-        return TranscriptionStream(self._transcribe_stream(duration=duration))
-
-    def transcribe_sentence(self, timeout: int = 0) -> str:
-        """
-        Transcribe a sentence returning the full text.
-
-        Runs until the sentence boundary is detected, the timeout elapses
-        without one or when the source is exhausted.
-
-        Args:
-            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
-                Ignored for finite sources (WAV/ndarray). Default: ``0``.
-
-        Returns:
-            str: The transcribed text, or an empty string if no speech was detected.
-
-        Raises:
-            ASRBusyError: If this instance already has an active session.
-            ASRServiceBusyError: If no more concurrent sessions are available.
-            ASRUnavailableError: If the inference service is unreachable or the connection drops mid-session.
-            RuntimeError: If the audio source has not been started.
-        """
-        last_partial = ""
-        final_text = ""
-
-        with self.transcribe_sentence_stream(timeout=timeout) as stream:
-            for chunk in stream:
-                if chunk.type == "partial_text" and chunk.data.strip():
-                    last_partial = chunk.data
-                elif chunk.type == "full_text" and chunk.data.strip():
-                    final_text += chunk.data
-
-        if final_text.strip():
-            return final_text
-        if last_partial.strip():
-            logger.warning("ASR returned empty full_text, falling back to last partial_text")
-            return last_partial
-        return ""
-
-    def transcribe_sentence_stream(self, timeout: int = 0) -> TranscriptionStream[ASREvent]:
-        """
-        Transcribe a sentence and yield the intermediate transcription events.
-
-        The stream ends after the sentence boundary is detected, the timeout
-        elapses without one or when the source is exhausted.
-
-        Args:
-            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
-                Ignored for finite sources (WAV/ndarray). Default: ``0``.
-
-        Yields:
-            ASREvent: objects representing transcription events.
-
-        Raises:
-            ASRBusyError: If this instance already has an active session.
-            ASRServiceBusyError: If no more concurrent sessions are available.
-            ASRUnavailableError: If the inference service is unreachable or the
-                connection drops mid-session.
-            RuntimeError: If the audio source has not been started.
-        """
-        self._ensure_source_started()
-
-        def sentence_gen() -> Generator[ASREvent, None, None]:
-            inner = self._transcribe_stream(duration=timeout)
-            try:
-                for event in inner:
-                    yield event
-                    if event.type == "full_text" and event.data.strip():
-                        return
-            finally:
-                inner.close()
-
-        return TranscriptionStream(sentence_gen())
-
-    def transcribe_continuous(self, timeout: int = 0) -> TranscriptionStream[str]:
-        """
-        Transcribe audio indefinitely and yield one sentence at a time.
-
-        The stream ends when :meth:`cancel` is called, the timeout elapses, or
-        when the source is exhausted.
-
-        Args:
-            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
-                Ignored for finite sources (WAV/ndarray). Default: ``0``.
-
-        Yields:
-            str: a complete sentence as recognized by the ASR.
-
-        Raises:
-            ASRBusyError: If this instance already has an active session.
-            ASRServiceBusyError: If no more concurrent sessions are available.
-            ASRUnavailableError: If the inference service is unreachable or the connection drops mid-session.
-            RuntimeError: If the audio source has not been started.
-        """
-        self._ensure_source_started()
-
-        def sentence_gen() -> Generator[str, None, None]:
-            inner = self._transcribe_stream(duration=timeout)
-            try:
-                for event in inner:
-                    if event.type == "full_text" and event.data.strip():
-                        yield event.data
-            finally:
-                inner.close()
-
-        return TranscriptionStream(sentence_gen())
-
-    def transcribe_continuous_stream(self, timeout: int = 0) -> TranscriptionStream[ASREvent]:
-        """
-        Transcribe audio indefinitely and yield intermediate transcription events.
-
-        The stream ends when :meth:`cancel` is called, the timeout elapses, or
-        when the source is exhausted.
-
-        Args:
-            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
-                Ignored for finite sources (WAV/ndarray). Default: ``0``.
-
-        Yields:
-            ASREvent: objects representing transcription events.
-
-        Raises:
-            ASRBusyError: If this instance already has an active session.
-            ASRServiceBusyError: If no more concurrent sessions are available.
-            ASRUnavailableError: If the inference service is unreachable or the
-                connection drops mid-session.
-            RuntimeError: If the audio source has not been started.
-        """
-        self._ensure_source_started()
-        return TranscriptionStream(self._transcribe_stream(duration=timeout))
 
     @brick.execute
     def _asyncio_loop(self):
@@ -515,10 +269,6 @@ class AutomaticSpeechRecognition:
             loop.close()
             logger.debug("Asyncio event loop stopped")
 
-    def _ensure_source_started(self) -> None:
-        if not self._source.is_started():
-            raise RuntimeError("Audio source must be started before transcription.")
-
     def _transcribe_stream(self, duration: int = 0, vad_ms: int | None = None) -> Generator[ASREvent, None, None]:
         if self._stop_worker.is_set():
             raise RuntimeError("Brick is stopping or already stopped")
@@ -535,7 +285,7 @@ class AutomaticSpeechRecognition:
             active_id = self._active_session.session_id if self._active_session else "unknown"
             raise ASRBusyError(
                 f"A transcription session (id={active_id}) is already active on this instance. "
-                f"Create a separate AutomaticSpeechRecognition instance for concurrent transcriptions."
+                f"Create a separate ASR instance for concurrent transcriptions."
             )
 
         session_info: SessionInfo | None = None
@@ -956,3 +706,194 @@ class AutomaticSpeechRecognition:
         if response.status_code != 200:
             raise RuntimeError(f"HTTP status {response.status_code}: {response.text}")
         logger.debug(f"Session {session_id} closed successfully")
+
+
+@brick
+class AutomaticSpeechRecognition(BaseASR):
+    """ASR brick for live audio transcription from a microphone."""
+
+    def __init__(
+        self,
+        mic: BaseMicrophone | None = None,
+        language: str | None = None,
+    ):
+        """
+        ASR brick that transcribes a live audio stream from a microphone.
+
+        Args:
+            mic: Microphone to be captured for transcription. One of:
+                BaseMicrophone: used as-is; the caller owns its
+                    lifecycle (ASR never calls start()/stop() on it).
+                None: ASR constructs a default Microphone() and owns its
+                    lifecycle (started on start(), stopped on stop()).
+                Default: None.
+            language (str): Language code for the ASR model (e.g. "en" for
+                English). This is typically auto-detected by the model,
+                but can be overridden here if needed. It is exposed as
+                the public ``language`` attribute and may be reassigned at
+                runtime; the new value takes effect on the next session.
+
+        Note:
+            Only one transcription can be active at a time.
+        """
+        super().__init__(source=mic, language=language)
+
+    def _build_source(self, source) -> tuple:
+        if source is None:
+            return Microphone(), True
+        if isinstance(source, BaseMicrophone):
+            return source, False
+        raise TypeError(f"Unsupported source type: {type(source)!r}")
+
+    def transcribe(self, duration: int = 60) -> str:
+        """
+        Transcribe audio for a duration and return the final text.
+
+        Args:
+            duration (int): Maximum recording time in seconds. ``0`` means unbounded.
+                Default: ``60``.
+
+        Returns:
+            str: The transcribed text, or an empty string if no speech was detected.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the
+                connection drops mid-session.
+            RuntimeError: If the microphone has not been started.
+        """
+        return self._collect_transcription(self.transcribe_stream(duration=duration))
+
+    def transcribe_stream(self, duration: int = 0) -> TranscriptionStream[ASREvent]:
+        """
+        Transcribe audio for a duration and yield intermediate transcription events.
+
+        Args:
+            duration (int): Maximum recording time in seconds. ``0`` means unbounded.
+                Default: ``0``.
+
+        Yields:
+            ASREvent: objects representing transcription events.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the
+                connection drops mid-session.
+            RuntimeError: If the microphone has not been started.
+        """
+        self._ensure_source_started()
+        return TranscriptionStream(self._transcribe_stream(duration=duration))
+
+    def transcribe_sentence(self, timeout: int = 0) -> str:
+        """
+        Transcribe a sentence returning the full text.
+
+        Runs until the sentence boundary is detected, the timeout elapses
+        without one.
+
+        Args:
+            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
+                Default: ``0``.
+
+        Returns:
+            str: The transcribed text, or an empty string if no speech was detected.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the connection drops mid-session.
+            RuntimeError: If the microphone has not been started.
+        """
+        return self._collect_transcription(self.transcribe_sentence_stream(timeout=timeout))
+
+    def transcribe_sentence_stream(self, timeout: int = 0) -> TranscriptionStream[ASREvent]:
+        """
+        Transcribe a sentence and yield the intermediate transcription events.
+
+        The stream ends after the sentence boundary is detected, the timeout
+        elapses without one.
+
+        Args:
+            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
+                Default: ``0``.
+
+        Yields:
+            ASREvent: objects representing transcription events.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the
+                connection drops mid-session.
+            RuntimeError: If the microphone has not been started.
+        """
+        self._ensure_source_started()
+
+        def sentence_gen() -> Generator[ASREvent, None, None]:
+            inner = self._transcribe_stream(duration=timeout)
+            try:
+                for event in inner:
+                    yield event
+                    if event.type == "full_text" and event.data.strip():
+                        return
+            finally:
+                inner.close()
+
+        return TranscriptionStream(sentence_gen())
+
+    def transcribe_continuous(self, timeout: int = 0) -> TranscriptionStream[str]:
+        """
+        Transcribe audio indefinitely and yield one sentence at a time.
+
+        The stream ends when :meth:`cancel` is called or the timeout elapses.
+
+        Args:
+            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
+                Default: ``0``.
+
+        Yields:
+            str: a complete sentence as recognized by the ASR.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the connection drops mid-session.
+            RuntimeError: If the microphone has not been started.
+        """
+        self._ensure_source_started()
+
+        def sentence_gen() -> Generator[str, None, None]:
+            inner = self._transcribe_stream(duration=timeout)
+            try:
+                for event in inner:
+                    if event.type == "full_text" and event.data.strip():
+                        yield event.data
+            finally:
+                inner.close()
+
+        return TranscriptionStream(sentence_gen())
+
+    def transcribe_continuous_stream(self, timeout: int = 0) -> TranscriptionStream[ASREvent]:
+        """
+        Transcribe audio indefinitely and yield intermediate transcription events.
+
+        The stream ends when :meth:`cancel` is called or the timeout elapses.
+
+        Args:
+            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
+                Default: ``0``.
+
+        Yields:
+            ASREvent: objects representing transcription events.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the
+                connection drops mid-session.
+            RuntimeError: If the microphone has not been started.
+        """
+        self._ensure_source_started()
+        return TranscriptionStream(self._transcribe_stream(duration=timeout))

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -192,7 +192,7 @@ _END_SENTINEL = object()  # Sentinel value to signal end of audio stream in the 
 class AutomaticSpeechRecognition:
     _APP_SERVICE_NAME = "audio-analytics-runner"
     _FLUSH_INTERVAL_SECONDS = 5
-    _DEFAULT_VAD = "700"
+    _DEFAULT_VAD_MS = 700
 
     def __init__(
         self,
@@ -253,7 +253,6 @@ class AutomaticSpeechRecognition:
             raise TypeError(f"Unsupported source type: {type(source)!r}")
 
         self._worker_loop: asyncio.AbstractEventLoop | None = None
-        self._worker_ready = threading.Event()
         self._stop_worker = threading.Event()
 
         self._active_session_lock = threading.Lock()
@@ -318,7 +317,6 @@ class AutomaticSpeechRecognition:
         if last_partial.strip():
             logger.warning("ASR returned empty full_text, falling back to last partial_text")
             return last_partial
-        logger.info("ASR returned no speech / empty transcription")
         return ""
 
     def transcribe_stream(self, duration: int = 0) -> TranscriptionStream[ASREvent]:
@@ -339,9 +337,145 @@ class AutomaticSpeechRecognition:
                 connection drops mid-session.
             RuntimeError: If the audio source has not been started.
         """
+        self._ensure_source_started()
+        return TranscriptionStream(self._transcribe_stream(duration=duration))
+
+    def transcribe_sentence(self, hangover: int = 700, timeout: int = 0) -> str:
+        """
+        Transcribe audio until a sentence boundary is detected or timeout is reached, and return the text.
+
+        Args:
+            hangover (int): Time in milliseconds to wait when detecting silence after
+                speech. Tune to allow short pauses within sentences. Default: 700 ms.
+            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
+                Default: ``0``.
+
+        Returns:
+            str: The transcribed text, or an empty string if no speech was detected.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the connection drops mid-session.
+            RuntimeError: If the audio source has not been started.
+        """
+        last_partial = ""
+        final_text = ""
+
+        with self.transcribe_sentence_stream(hangover=hangover, timeout=timeout) as stream:
+            for chunk in stream:
+                if chunk.type == "partial_text" and chunk.data.strip():
+                    last_partial = chunk.data
+                elif chunk.type == "full_text" and chunk.data.strip():
+                    final_text += chunk.data
+
+        if final_text.strip():
+            return final_text
+        if last_partial.strip():
+            logger.warning("ASR returned empty full_text, falling back to last partial_text")
+            return last_partial
+        return ""
+
+    def transcribe_sentence_stream(self, hangover: int = 700, timeout: int = 0) -> TranscriptionStream[ASREvent]:
+        """
+        Transcribe audio from the configured source and stream events until a
+        sentence boundary is detected.
+
+        The stream ends after the first non-empty ``full_text`` event, or when
+        the source is exhausted / the timeout elapses without one.
+
+        Args:
+            hangover (int): Time in milliseconds to wait when detecting silence after
+                speech. Tune to allow short pauses within sentences. Default: 700 ms.
+            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
+                Ignored for finite sources (WAV/ndarray). Default: ``0``.
+
+        Yields:
+            ASREvent: objects representing transcription events.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the
+                connection drops mid-session.
+            RuntimeError: If the audio source has not been started.
+        """
+        self._ensure_source_started()
+
+        def sentence_gen() -> Generator[ASREvent, None, None]:
+            inner = self._transcribe_stream(duration=timeout, vad_ms=hangover)
+            try:
+                for event in inner:
+                    yield event
+                    if event.type == "full_text" and event.data.strip():
+                        return
+            finally:
+                inner.close()
+
+        return TranscriptionStream(sentence_gen())
+
+    def transcribe_continuous(self, timeout: int = 0) -> str:
+        """
+        Transcribe audio indefinitely, returning text whenever cancel() is called.
+
+        Args:
+            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
+                Default: ``0``.
+
+        Returns:
+            str: The transcribed text, or an empty string if no speech was detected.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the connection drops mid-session.
+            RuntimeError: If the audio source has not been started.
+
+        """
+        last_partial = ""
+        final_text = ""
+
+        with self.transcribe_continuous_stream(timeout=timeout) as stream:
+            for chunk in stream:
+                if chunk.type == "partial_text" and chunk.data.strip():
+                    last_partial = chunk.data
+                elif chunk.type == "full_text" and chunk.data.strip():
+                    final_text += chunk.data
+
+        if final_text.strip():
+            return final_text
+        if last_partial.strip():
+            logger.warning("ASR returned empty full_text, falling back to last partial_text")
+            return last_partial
+        return ""
+
+    def transcribe_continuous_stream(self, timeout: int = 0) -> TranscriptionStream[ASREvent]:
+        """
+        Transcribe audio from the configured source indefinitely and stream events.
+
+        Runs until ``cancel()`` is called, the timeout elapses, or — for finite
+        sources (WAV/ndarray) — the source is exhausted.
+
+        Args:
+            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
+                Ignored for finite sources (WAV/ndarray). Default: ``0``.
+
+        Yields:
+            ASREvent: objects representing transcription events.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the
+                connection drops mid-session.
+            RuntimeError: If the audio source has not been started.
+        """
+        self._ensure_source_started()
+        return TranscriptionStream(self._transcribe_stream(duration=timeout))
+
+    def _ensure_source_started(self) -> None:
         if not self._source.is_started():
             raise RuntimeError("Audio source must be started before transcription.")
-        return TranscriptionStream(self._transcribe_stream(duration=duration))
 
     def _flush_transcription_session(self, session_id: str) -> None:
         logger.debug(f"Flushing transcription session {session_id}")
@@ -367,10 +501,14 @@ class AutomaticSpeechRecognition:
             raise RuntimeError(f"HTTP status {response.status_code}: {response.text}")
         logger.debug(f"Session {session_id} closed successfully")
 
-    def _create_transcription_session(self) -> str:
+    def _create_transcription_session(self, vad_ms: int | None = None) -> str:
         sampling_rate = str(self._source.sample_rate)
         channels = str(self._source.channels)
         pcm_format = _dtype_to_pcm_format(self._source.format, getattr(self._source, "format_is_packed", False))
+
+        # The API expects VAD hangover in 10ms slots, not milliseconds
+        hangover_ms = vad_ms if vad_ms is not None else self._DEFAULT_VAD_MS
+        vad_slots = str(hangover_ms // 10)
 
         create_url = f"{self.api_base_url}/transcriptions/create"
         create_data = {
@@ -380,7 +518,7 @@ class AutomaticSpeechRecognition:
                 {"key": "sampling_rate", "value": sampling_rate},
                 {"key": "channels", "value": channels},
                 {"key": "format", "value": pcm_format},
-                {"key": "vad", "value": self._DEFAULT_VAD},
+                {"key": "vad", "value": vad_slots},
             ]),
         }
         if self.language is not None:
@@ -421,9 +559,9 @@ class AutomaticSpeechRecognition:
 
         return session_id
 
-    def _transcribe_stream(self, duration: int = 0) -> Generator[ASREvent, None, None]:
-        if not self._worker_ready.wait(timeout=5):
-            raise RuntimeError("Worker loop not initialized. Call start() first.")
+    def _transcribe_stream(self, duration: int = 0, vad_ms: int | None = None) -> Generator[ASREvent, None, None]:
+        if self._worker_loop is None:
+            raise RuntimeError("Worker loop is not initialized. Call start() first.")
         if self._stop_worker.is_set():
             raise RuntimeError("ASR is stopping or stopped")
 
@@ -440,7 +578,7 @@ class AutomaticSpeechRecognition:
         try:
             logger.debug(f"Creating transcription session with model={self.model}, language={self.language}")
 
-            session_id = self._create_transcription_session()
+            session_id = self._create_transcription_session(vad_ms=vad_ms)
 
             session_info = SessionInfo(
                 session_id=session_id,
@@ -504,7 +642,6 @@ class AutomaticSpeechRecognition:
         logger.debug("Asyncio event loop starting")
         self._worker_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._worker_loop)
-        self._worker_ready.set()
 
         async def keep_alive():
             while not self._stop_worker.is_set():
@@ -520,7 +657,6 @@ class AutomaticSpeechRecognition:
                 task.cancel()
             if pending:
                 self._worker_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
-            self._worker_ready.clear()
             self._worker_loop.close()
             self._worker_loop = None
             logger.debug("Asyncio event loop stopped")

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -11,6 +11,7 @@ import threading
 import time
 import wave
 from collections.abc import Generator, Iterator
+from concurrent.futures import CancelledError, Future
 from dataclasses import dataclass
 from typing import ContextManager, Generic, Literal, TypeVar
 
@@ -260,7 +261,7 @@ class AutomaticSpeechRecognition:
             self._source.format_is_packed,
         )
 
-        self._worker_loop: asyncio.AbstractEventLoop | None = None
+        self._worker_loop: Future[asyncio.AbstractEventLoop] = Future()
         self._stop_worker = threading.Event()
 
         self._active_session_lock = threading.Lock()
@@ -270,6 +271,8 @@ class AutomaticSpeechRecognition:
         """Prepare the ASR for transcription. Starts the owned mic if applicable."""
         logger.debug("Starting ASR and preparing resources...")
         self._stop_worker.clear()
+        if self._worker_loop.done():
+            self._worker_loop = Future()
         if self._owns_source:
             self._source.start()
 
@@ -277,6 +280,7 @@ class AutomaticSpeechRecognition:
         """Stop the ASR and clean up resources. Stops the owned mic if applicable."""
         logger.debug("Stopping ASR and cleaning up resources...")
         self._stop_worker.set()
+        self._worker_loop.cancel()
         self.cancel()
         if self._owns_source:
             self._source.stop()
@@ -497,25 +501,25 @@ class AutomaticSpeechRecognition:
     def _asyncio_loop(self):
         """Dedicated thread for the asyncio event loop hosting session coroutines."""
         logger.debug("Asyncio event loop starting")
-        self._worker_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self._worker_loop)
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._worker_loop.set_result(loop)
 
         async def keep_alive():
             while not self._stop_worker.is_set():
                 await asyncio.sleep(0.1)
 
         try:
-            self._worker_loop.run_until_complete(keep_alive())
+            loop.run_until_complete(keep_alive())
         except Exception as e:
             logger.error(f"Event loop error: {e}")
         finally:
-            pending = asyncio.all_tasks(self._worker_loop)
+            pending = asyncio.all_tasks(loop)
             for task in pending:
                 task.cancel()
             if pending:
-                self._worker_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
-            self._worker_loop.close()
-            self._worker_loop = None
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            loop.close()
             logger.debug("Asyncio event loop stopped")
 
     def _ensure_source_started(self) -> None:
@@ -523,10 +527,16 @@ class AutomaticSpeechRecognition:
             raise RuntimeError("Audio source must be started before transcription.")
 
     def _transcribe_stream(self, duration: int = 0, vad_ms: int | None = None) -> Generator[ASREvent, None, None]:
-        if self._worker_loop is None:
-            raise RuntimeError("Worker loop is not initialized. Call start() first.")
         if self._stop_worker.is_set():
-            raise RuntimeError("ASR is stopping or stopped")
+            raise RuntimeError("Brick is stopping or already stopped")
+        try:
+            worker_loop = self._worker_loop.result(timeout=5)
+        except TimeoutError:
+            raise RuntimeError("Worker loop is not initialized. Call start() first.") from None
+        except CancelledError:
+            raise RuntimeError("Brick is stopping or already stopped") from None
+        if self._stop_worker.is_set():
+            raise RuntimeError("Brick is stopping or already stopped")
 
         if not self._active_session_lock.acquire(blocking=False):
             active_id = self._active_session.session_id if self._active_session else "unknown"
@@ -554,7 +564,7 @@ class AutomaticSpeechRecognition:
 
             future = asyncio.run_coroutine_threadsafe(
                 self._transcription_session_handler(session_info),
-                self._worker_loop,
+                worker_loop,
             )
 
             while not future.done():

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -344,11 +344,15 @@ class AutomaticSpeechRecognition:
         """
         Transcribe audio until a sentence boundary is detected or timeout is reached, and return the text.
 
+        For finite sources (WAV/ndarray), if the source is consumed before a
+        sentence boundary is detected, the best-effort partial transcription is
+        returned instead.
+
         Args:
             hangover (int): Time in milliseconds to wait when detecting silence after
                 speech. Tune to allow short pauses within sentences. Default: 700 ms.
             timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
-                Default: ``0``.
+                Ignored for finite sources (WAV/ndarray). Default: ``0``.
 
         Returns:
             str: The transcribed text, or an empty string if no speech was detected.
@@ -414,40 +418,39 @@ class AutomaticSpeechRecognition:
 
         return TranscriptionStream(sentence_gen())
 
-    def transcribe_continuous(self, timeout: int = 0) -> str:
+    def transcribe_continuous(self, timeout: int = 0) -> TranscriptionStream[str]:
         """
-        Transcribe audio indefinitely, returning text whenever cancel() is called.
+        Transcribe audio indefinitely and yield one sentence at a time.
+
+        Each iteration returns a single decoded sentence as a ``str``. Stop by
+        ``break``-ing out of the loop, calling :meth:`cancel`, or — for finite
+        sources (WAV/ndarray) — letting the source exhaust.
 
         Args:
             timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
-                Default: ``0``.
+                Ignored for finite sources (WAV/ndarray). Default: ``0``.
 
-        Returns:
-            str: The transcribed text, or an empty string if no speech was detected.
+        Yields:
+            str: a complete sentence as recognized by the ASR.
 
         Raises:
             ASRBusyError: If this instance already has an active session.
             ASRServiceBusyError: If no more concurrent sessions are available.
             ASRUnavailableError: If the inference service is unreachable or the connection drops mid-session.
             RuntimeError: If the audio source has not been started.
-
         """
-        last_partial = ""
-        final_text = ""
+        self._ensure_source_started()
 
-        with self.transcribe_continuous_stream(timeout=timeout) as stream:
-            for chunk in stream:
-                if chunk.type == "partial_text" and chunk.data.strip():
-                    last_partial = chunk.data
-                elif chunk.type == "full_text" and chunk.data.strip():
-                    final_text += chunk.data
+        def sentence_gen() -> Generator[str, None, None]:
+            inner = self._transcribe_stream(duration=timeout)
+            try:
+                for event in inner:
+                    if event.type == "full_text" and event.data.strip():
+                        yield event.data
+            finally:
+                inner.close()
 
-        if final_text.strip():
-            return final_text
-        if last_partial.strip():
-            logger.warning("ASR returned empty full_text, falling back to last partial_text")
-            return last_partial
-        return ""
+        return TranscriptionStream(sentence_gen())
 
     def transcribe_continuous_stream(self, timeout: int = 0) -> TranscriptionStream[ASREvent]:
         """

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -843,47 +843,11 @@ class AutomaticSpeechRecognition(BaseASR):
 
         return TranscriptionStream(sentence_gen())
 
-    def transcribe_continuous(self, timeout: int = 0) -> TranscriptionStream[str]:
-        """
-        Transcribe audio indefinitely and yield one sentence at a time.
-
-        The stream ends when :meth:`cancel` is called or the timeout elapses.
-
-        Args:
-            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
-                Default: ``0``.
-
-        Yields:
-            str: a complete sentence as recognized by the ASR.
-
-        Raises:
-            ASRBusyError: If this instance already has an active session.
-            ASRServiceBusyError: If no more concurrent sessions are available.
-            ASRUnavailableError: If the inference service is unreachable or the connection drops mid-session.
-            RuntimeError: If the microphone has not been started.
-        """
-        self._ensure_source_started()
-
-        def sentence_gen() -> Generator[str, None, None]:
-            inner = self._transcribe_stream(duration=timeout)
-            try:
-                for event in inner:
-                    if event.type == "full_text" and event.data.strip():
-                        yield event.data
-            finally:
-                inner.close()
-
-        return TranscriptionStream(sentence_gen())
-
-    def transcribe_continuous_stream(self, timeout: int = 0) -> TranscriptionStream[ASREvent]:
+    def transcribe_until_cancelled(self) -> TranscriptionStream[ASREvent]:
         """
         Transcribe audio indefinitely and yield intermediate transcription events.
 
-        The stream ends when :meth:`cancel` is called or the timeout elapses.
-
-        Args:
-            timeout (int): Maximum recording time in seconds. ``0`` means no timeout.
-                Default: ``0``.
+        The stream ends only when :meth:`cancel` is called.
 
         Yields:
             ASREvent: objects representing transcription events.
@@ -896,4 +860,4 @@ class AutomaticSpeechRecognition(BaseASR):
             RuntimeError: If the microphone has not been started.
         """
         self._ensure_source_started()
-        return TranscriptionStream(self._transcribe_stream(duration=timeout))
+        return TranscriptionStream(self._transcribe_stream(duration=0))

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -440,7 +440,7 @@ class AutomaticSpeechRecognition:
     def transcribe_continuous(self, timeout: int = 0) -> TranscriptionStream[str]:
         """
         Transcribe audio indefinitely and yield one sentence at a time.
-        
+
         The stream ends when :meth:`cancel` is called, the timeout elapses, or
         when the source is exhausted.
 

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -182,6 +182,7 @@ class SessionInfo:
     result_queue: queue.Queue[ASREvent]
     chunk_queue: queue.Queue[bytes | object]  # object is for _END_SENTINEL
     cancelled: threading.Event
+    language: str | None = None
     reader_thread: threading.Thread | None = None
 
 
@@ -214,7 +215,9 @@ class AutomaticSpeechRecognition:
                 Default: None.
             language (str): Language code for the ASR model (e.g. "en" for
                 English). This is typically auto-detected by the model,
-                but can be overridden here if needed.
+                but can be overridden here if needed. It is exposed as
+                the public ``language`` attribute and may be reassigned at
+                runtime; the new value takes effect on the next session.
 
         Note:
             Only one transcription can be active per instance at a time. For
@@ -518,7 +521,7 @@ class AutomaticSpeechRecognition:
             raise RuntimeError(f"HTTP status {response.status_code}: {response.text}")
         logger.debug(f"Session {session_id} closed successfully")
 
-    def _create_transcription_session(self, vad_ms: int | None = None) -> str:
+    def _create_transcription_session(self, vad_ms: int | None = None, language: str | None = None) -> str:
         sampling_rate = str(self._source.sample_rate)
         channels = str(self._source.channels)
 
@@ -537,8 +540,8 @@ class AutomaticSpeechRecognition:
                 {"key": "vad", "value": vad_slots},
             ]),
         }
-        if self.language is not None:
-            create_data["language"] = self.language
+        if language is not None:
+            create_data["language"] = language
 
         try:
             response = requests.post(url=create_url, json=create_data, timeout=5)
@@ -592,16 +595,15 @@ class AutomaticSpeechRecognition:
         future = None
 
         try:
-            logger.debug(f"Creating transcription session with model={self.model}, language={self.language}")
-
-            session_id = self._create_transcription_session(vad_ms=vad_ms)
-
+            session_language = self.language  # Snapshot current language for the session
+            session_id = self._create_transcription_session(vad_ms=vad_ms, language=session_language)
             session_info = SessionInfo(
                 session_id=session_id,
                 duration=duration,
                 start_time=time.time(),
                 result_queue=queue.Queue(),
                 chunk_queue=queue.Queue(maxsize=100),
+                language=session_language,
                 cancelled=threading.Event(),
             )
             self._active_session = session_info

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -252,6 +252,11 @@ class AutomaticSpeechRecognition:
         else:
             raise TypeError(f"Unsupported source type: {type(source)!r}")
 
+        self._pcm_format = _dtype_to_pcm_format(
+            self._source.format,
+            self._source.format_is_packed,
+        )
+
         self._worker_loop: asyncio.AbstractEventLoop | None = None
         self._stop_worker = threading.Event()
 
@@ -282,6 +287,15 @@ class AutomaticSpeechRecognition:
             return
         logger.debug(f"Cancelling session {active.session_id}")
         active.cancelled.set()
+
+    def is_transcribing(self) -> bool:
+        """
+        Tells if a transcription session is currently active on this instance.
+
+        Returns:
+            bool: True if a session is active, False otherwise.
+        """
+        return self._active_session is not None
 
     def transcribe(self, duration: int = 0) -> str:
         """
@@ -507,7 +521,6 @@ class AutomaticSpeechRecognition:
     def _create_transcription_session(self, vad_ms: int | None = None) -> str:
         sampling_rate = str(self._source.sample_rate)
         channels = str(self._source.channels)
-        pcm_format = _dtype_to_pcm_format(self._source.format, getattr(self._source, "format_is_packed", False))
 
         # The API expects VAD hangover in 10ms slots, not milliseconds
         hangover_ms = vad_ms if vad_ms is not None else self._DEFAULT_VAD_MS
@@ -520,7 +533,7 @@ class AutomaticSpeechRecognition:
             "parameters": json.dumps([
                 {"key": "sampling_rate", "value": sampling_rate},
                 {"key": "channels", "value": channels},
-                {"key": "format", "value": pcm_format},
+                {"key": "format", "value": self._pcm_format},
                 {"key": "vad", "value": vad_slots},
             ]),
         }

--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -493,90 +493,34 @@ class AutomaticSpeechRecognition:
         self._ensure_source_started()
         return TranscriptionStream(self._transcribe_stream(duration=timeout))
 
+    @brick.execute
+    def _asyncio_loop(self):
+        """Dedicated thread for the asyncio event loop hosting session coroutines."""
+        logger.debug("Asyncio event loop starting")
+        self._worker_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._worker_loop)
+
+        async def keep_alive():
+            while not self._stop_worker.is_set():
+                await asyncio.sleep(0.1)
+
+        try:
+            self._worker_loop.run_until_complete(keep_alive())
+        except Exception as e:
+            logger.error(f"Event loop error: {e}")
+        finally:
+            pending = asyncio.all_tasks(self._worker_loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                self._worker_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            self._worker_loop.close()
+            self._worker_loop = None
+            logger.debug("Asyncio event loop stopped")
+
     def _ensure_source_started(self) -> None:
         if not self._source.is_started():
             raise RuntimeError("Audio source must be started before transcription.")
-
-    def _flush_transcription_session(self, session_id: str) -> None:
-        logger.debug(f"Flushing transcription session {session_id}")
-        url = f"{self.api_base_url}/transcriptions/flush"
-        try:
-            response = requests.post(url, json={"session_id": session_id}, timeout=3)
-        except Exception as e:
-            logger.warning(f"Failed to flush session {session_id}: {e}")
-            return
-        if response.status_code != 200:
-            logger.warning(f"Failed to flush session {session_id}: status {response.status_code}: {response.text}")
-            return
-        logger.debug(f"Session {session_id} flushed successfully")
-
-    def _close_transcription_session(self, session_id: str) -> None:
-        logger.debug(f"Closing transcription session {session_id}")
-        url = f"{self.api_base_url}/transcriptions/close"
-        try:
-            response = requests.post(url, json={"session_id": session_id}, timeout=20)
-        except Exception:
-            raise
-        if response.status_code != 200:
-            raise RuntimeError(f"HTTP status {response.status_code}: {response.text}")
-        logger.debug(f"Session {session_id} closed successfully")
-
-    def _create_transcription_session(self, vad_ms: int | None = None, language: str | None = None) -> str:
-        sampling_rate = str(self._source.sample_rate)
-        channels = str(self._source.channels)
-
-        # The API expects VAD hangover in 10ms slots, not milliseconds
-        hangover_ms = vad_ms if vad_ms is not None else self._DEFAULT_VAD_MS
-        vad_slots = str(hangover_ms // 10)
-
-        create_url = f"{self.api_base_url}/transcriptions/create"
-        create_data = {
-            "model": self.model,
-            "stream": True,
-            "parameters": json.dumps([
-                {"key": "sampling_rate", "value": sampling_rate},
-                {"key": "channels", "value": channels},
-                {"key": "format", "value": self._pcm_format},
-                {"key": "vad", "value": vad_slots},
-            ]),
-        }
-        if language is not None:
-            create_data["language"] = language
-
-        try:
-            response = requests.post(url=create_url, json=create_data, timeout=5)
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
-            raise ASRUnavailableError(f"Inference service unreachable: {e}") from None
-
-        if response.status_code == 400:
-            try:
-                err = response.json().get("error", {})
-                msg = err.get("message", "")
-            except Exception:
-                msg = response.text or ""
-            if "transcription session is already active" in msg:
-                raise ASRServiceBusyError(msg or "Inference server is serving another client")
-            raise ASRError(msg or f"Failed to create transcription session: 400")
-
-        if response.status_code != 200:
-            msg = f"Failed to create transcription session: {response.status_code}"
-            try:
-                err = response.json().get("error", {})
-                msg = err.get("message", msg)
-            except Exception:
-                pass
-            raise ASRError(msg)
-
-        result = response.json()
-        session_id = result.get("session_id")
-        if not session_id:
-            raise ASRError("No session ID returned from transcription API")
-
-        state = result.get("state")
-        if state != "asr_initialized":
-            logger.warning(f"ASR session {session_id} created but not initialized (state={state})")
-
-        return session_id
 
     def _transcribe_stream(self, duration: int = 0, vad_ms: int | None = None) -> Generator[ASREvent, None, None]:
         if self._worker_loop is None:
@@ -654,120 +598,62 @@ class AutomaticSpeechRecognition:
             self._active_session = None
             self._active_session_lock.release()
 
-    @brick.execute
-    def _asyncio_loop(self):
-        """Dedicated thread for the asyncio event loop hosting session coroutines."""
-        logger.debug("Asyncio event loop starting")
-        self._worker_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(self._worker_loop)
+    def _create_transcription_session(self, vad_ms: int | None = None, language: str | None = None) -> str:
+        sampling_rate = str(self._source.sample_rate)
+        channels = str(self._source.channels)
 
-        async def keep_alive():
-            while not self._stop_worker.is_set():
-                await asyncio.sleep(0.1)
+        # The API expects VAD hangover in 10ms slots, not milliseconds
+        hangover_ms = vad_ms if vad_ms is not None else self._DEFAULT_VAD_MS
+        vad_slots = str(hangover_ms // 10)
+
+        create_url = f"{self.api_base_url}/transcriptions/create"
+        create_data = {
+            "model": self.model,
+            "stream": True,
+            "parameters": json.dumps([
+                {"key": "sampling_rate", "value": sampling_rate},
+                {"key": "channels", "value": channels},
+                {"key": "format", "value": self._pcm_format},
+                {"key": "vad", "value": vad_slots},
+            ]),
+        }
+        if language is not None:
+            create_data["language"] = language
 
         try:
-            self._worker_loop.run_until_complete(keep_alive())
-        except Exception as e:
-            logger.error(f"Event loop error: {e}")
-        finally:
-            pending = asyncio.all_tasks(self._worker_loop)
-            for task in pending:
-                task.cancel()
-            if pending:
-                self._worker_loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
-            self._worker_loop.close()
-            self._worker_loop = None
-            logger.debug("Asyncio event loop stopped")
+            response = requests.post(url=create_url, json=create_data, timeout=5)
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            raise ASRUnavailableError(f"Inference service unreachable: {e}") from None
 
-    async def _await_connection_established(self, websocket, label):
-        try:
-            raw = await asyncio.wait_for(websocket.recv(), timeout=5.0)
-        except (asyncio.TimeoutError, ConnectionClosed) as e:
-            raise ASRUnavailableError(f"{label} handshake failed: {e}") from None
-        msg = json.loads(raw)
-        if msg.get("state") != "connection_established":
-            raise RuntimeError(f"{label} expected connection_established, got {msg}")
-
-    async def _periodic_flush(self, session_info: SessionInfo) -> None:
-        session_id = session_info.session_id
-        has_duration = session_info.duration > 0
-        try:
-            while not self._stop_worker.is_set() and not session_info.cancelled.is_set():
-                await asyncio.sleep(self._FLUSH_INTERVAL_SECONDS)
-                if self._stop_worker.is_set() or session_info.cancelled.is_set():
-                    break
-                await asyncio.to_thread(self._flush_transcription_session, session_id)
-                if has_duration:
-                    remaining = session_info.duration - (time.time() - session_info.start_time)
-                    if remaining < self._FLUSH_INTERVAL_SECONDS:
-                        logger.debug(f"No more flushes for session {session_id}: only {remaining:.1f}s remaining")
-                        break
-        except asyncio.CancelledError:
-            logger.debug(f"Periodic flush cancelled for session {session_id}")
-            raise
-
-    def _reader_thread_body(self, session_info: SessionInfo) -> None:
-        session_id = session_info.session_id
-        start_time = session_info.start_time
-        duration = session_info.duration
-        try:
-            while not self._stop_worker.is_set() and not session_info.cancelled.is_set():
-                if duration > 0 and (time.time() - start_time) >= duration:
-                    logger.debug(f"Session {session_id} duration limit reached: {duration}s")
-                    break
-                try:
-                    chunk = self._source.capture()
-                except AudioSourceExhausted:
-                    logger.debug(f"Session {session_id} audio source exhausted")
-                    break
-                except Exception as e:
-                    logger.error(f"Reader thread capture error for session {session_id}: {e}")
-                    break
-                if chunk is None:
-                    continue  # transient (paused/underrun) — keep going
-                try:
-                    session_info.chunk_queue.put_nowait(chunk.tobytes())
-                except queue.Full:
-                    logger.warning(f"Send queue full for session {session_id}, dropping chunk")
-        finally:
+        if response.status_code == 400:
             try:
-                session_info.chunk_queue.put_nowait(_END_SENTINEL)
-            except queue.Full:
+                err = response.json().get("error", {})
+                msg = err.get("message", "")
+            except Exception:
+                msg = response.text or ""
+            if "transcription session is already active" in msg:
+                raise ASRServiceBusyError(msg or "Inference server is serving another client")
+            raise ASRError(msg or f"Failed to create transcription session: 400")
+
+        if response.status_code != 200:
+            msg = f"Failed to create transcription session: {response.status_code}"
+            try:
+                err = response.json().get("error", {})
+                msg = err.get("message", msg)
+            except Exception:
                 pass
-            logger.debug(f"Reader thread exited for session {session_id}")
+            raise ASRError(msg)
 
-    async def _drain_websocket(self, websocket: websockets.ClientConnection, session_info: SessionInfo, label: str) -> None:
-        session_id = session_info.session_id
+        result = response.json()
+        session_id = result.get("session_id")
+        if not session_id:
+            raise ASRError("No session ID returned from transcription API")
 
-        try:
-            while not self._stop_worker.is_set() and not session_info.cancelled.is_set():
-                try:
-                    message = await asyncio.wait_for(websocket.recv(), timeout=1.0)
-                except asyncio.TimeoutError:
-                    continue
+        state = result.get("state")
+        if state != "asr_initialized":
+            logger.warning(f"ASR session {session_id} created but not initialized (state={state})")
 
-                try:
-                    data = json.loads(message)
-                except json.JSONDecodeError:
-                    logger.debug(f"Drained non-JSON WebSocket message from {label}: {message}")
-                    continue
-
-                message_session_id = data.get("session_id")
-                if message_session_id is not None and message_session_id != session_id:
-                    logger.debug(
-                        f"Drained WebSocket message from {label} for session {message_session_id}; current session is {session_id}. Message: {data}"
-                    )
-                    continue
-
-                logger.debug(f"Drained WebSocket message from {label} for session {session_id}: {data}")
-
-        except asyncio.CancelledError:
-            logger.debug(f"Drain task cancelled for {label}, session {session_id}")
-            raise
-        except ConnectionClosedOK:
-            logger.debug(f"WebSocket {label} closed as expected while draining for session {session_id}")
-        except ConnectionClosed as e:
-            logger.debug(f"WebSocket {label} closed while draining for session {session_id}: {e}")
+        return session_id
 
     async def _transcription_session_handler(self, session_info: SessionInfo):
         session_id = session_info.session_id
@@ -850,6 +736,45 @@ class AutomaticSpeechRecognition:
             await asyncio.to_thread(reader.join, join_timeout)
             if reader.is_alive():
                 logger.warning(f"Reader thread for session {session_id} did not exit within {join_timeout}s; leaking as daemon")
+
+    def _reader_thread_body(self, session_info: SessionInfo) -> None:
+        session_id = session_info.session_id
+        start_time = session_info.start_time
+        duration = session_info.duration
+        try:
+            while not self._stop_worker.is_set() and not session_info.cancelled.is_set():
+                if duration > 0 and (time.time() - start_time) >= duration:
+                    logger.debug(f"Session {session_id} duration limit reached: {duration}s")
+                    break
+                try:
+                    chunk = self._source.capture()
+                except AudioSourceExhausted:
+                    logger.debug(f"Session {session_id} audio source exhausted")
+                    break
+                except Exception as e:
+                    logger.error(f"Reader thread capture error for session {session_id}: {e}")
+                    break
+                if chunk is None:
+                    continue  # transient (paused/underrun) — keep going
+                try:
+                    session_info.chunk_queue.put_nowait(chunk.tobytes())
+                except queue.Full:
+                    logger.warning(f"Send queue full for session {session_id}, dropping chunk")
+        finally:
+            try:
+                session_info.chunk_queue.put_nowait(_END_SENTINEL)
+            except queue.Full:
+                pass
+            logger.debug(f"Reader thread exited for session {session_id}")
+
+    async def _await_connection_established(self, websocket, label):
+        try:
+            raw = await asyncio.wait_for(websocket.recv(), timeout=5.0)
+        except (asyncio.TimeoutError, ConnectionClosed) as e:
+            raise ASRUnavailableError(f"{label} handshake failed: {e}") from None
+        msg = json.loads(raw)
+        if msg.get("state") != "connection_established":
+            raise RuntimeError(f"{label} expected connection_established, got {msg}")
 
     async def _send_pcm_stream(self, websocket: websockets.ClientConnection, session_info: SessionInfo) -> int:
         session_id = session_info.session_id
@@ -955,3 +880,78 @@ class AutomaticSpeechRecognition:
             return
         except ConnectionClosed as e:
             raise ASRUnavailableError(f"WebSocket connection lost while receiving for session {session_id}: {e}") from None
+
+    async def _drain_websocket(self, websocket: websockets.ClientConnection, session_info: SessionInfo, label: str) -> None:
+        session_id = session_info.session_id
+
+        try:
+            while not self._stop_worker.is_set() and not session_info.cancelled.is_set():
+                try:
+                    message = await asyncio.wait_for(websocket.recv(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    continue
+
+                try:
+                    data = json.loads(message)
+                except json.JSONDecodeError:
+                    logger.debug(f"Drained non-JSON WebSocket message from {label}: {message}")
+                    continue
+
+                message_session_id = data.get("session_id")
+                if message_session_id is not None and message_session_id != session_id:
+                    logger.debug(
+                        f"Drained WebSocket message from {label} for session {message_session_id}; current session is {session_id}. Message: {data}"
+                    )
+                    continue
+
+                logger.debug(f"Drained WebSocket message from {label} for session {session_id}: {data}")
+
+        except asyncio.CancelledError:
+            logger.debug(f"Drain task cancelled for {label}, session {session_id}")
+            raise
+        except ConnectionClosedOK:
+            logger.debug(f"WebSocket {label} closed as expected while draining for session {session_id}")
+        except ConnectionClosed as e:
+            logger.debug(f"WebSocket {label} closed while draining for session {session_id}: {e}")
+
+    async def _periodic_flush(self, session_info: SessionInfo) -> None:
+        session_id = session_info.session_id
+        has_duration = session_info.duration > 0
+        try:
+            while not self._stop_worker.is_set() and not session_info.cancelled.is_set():
+                await asyncio.sleep(self._FLUSH_INTERVAL_SECONDS)
+                if self._stop_worker.is_set() or session_info.cancelled.is_set():
+                    break
+                await asyncio.to_thread(self._flush_transcription_session, session_id)
+                if has_duration:
+                    remaining = session_info.duration - (time.time() - session_info.start_time)
+                    if remaining < self._FLUSH_INTERVAL_SECONDS:
+                        logger.debug(f"No more flushes for session {session_id}: only {remaining:.1f}s remaining")
+                        break
+        except asyncio.CancelledError:
+            logger.debug(f"Periodic flush cancelled for session {session_id}")
+            raise
+
+    def _flush_transcription_session(self, session_id: str) -> None:
+        logger.debug(f"Flushing transcription session {session_id}")
+        url = f"{self.api_base_url}/transcriptions/flush"
+        try:
+            response = requests.post(url, json={"session_id": session_id}, timeout=3)
+        except Exception as e:
+            logger.warning(f"Failed to flush session {session_id}: {e}")
+            return
+        if response.status_code != 200:
+            logger.warning(f"Failed to flush session {session_id}: status {response.status_code}: {response.text}")
+            return
+        logger.debug(f"Session {session_id} flushed successfully")
+
+    def _close_transcription_session(self, session_id: str) -> None:
+        logger.debug(f"Closing transcription session {session_id}")
+        url = f"{self.api_base_url}/transcriptions/close"
+        try:
+            response = requests.post(url, json={"session_id": session_id}, timeout=20)
+        except Exception:
+            raise
+        if response.status_code != 200:
+            raise RuntimeError(f"HTTP status {response.status_code}: {response.text}")
+        logger.debug(f"Session {session_id} closed successfully")

--- a/src/arduino/app_bricks/asr/local_asr_wav.py
+++ b/src/arduino/app_bricks/asr/local_asr_wav.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import io
+import wave
+
+import numpy as np
+
+from arduino.app_utils import brick
+
+from .local_asr import (
+    ASREvent,
+    AudioSourceExhausted,
+    TranscriptionStream,
+    BaseASR,
+)
+
+
+class InMemoryAudioSource:
+    """
+    Audio source wrapping WAV bytes or a raw PCM ndarray.
+
+    Exposes only the subset of BaseMicrophone attributes/methods that ASR uses,
+    so it can be used uniformly. ``capture()`` raises ``AudioSourceExhausted``
+    when the underlying buffer is drained.
+    """
+
+    _DEFAULT_SAMPLING_RATE = 16000
+    _DEFAULT_CHANNELS = 1
+    _DEFAULT_BUFFER_SIZE = 1024
+
+    def __init__(self, samples: bytes | np.ndarray):
+        if isinstance(samples, (bytes, bytearray)):
+            with wave.open(io.BytesIO(bytes(samples)), "rb") as wf:
+                self.sample_rate = wf.getframerate()
+                self.channels = wf.getnchannels()
+                sample_width = wf.getsampwidth()
+                frames = wf.readframes(wf.getnframes())
+            # Derive numpy dtype from WAV sample width (signed int, little-endian — WAV convention)
+            dtype_map = {1: np.uint8, 2: np.int16, 4: np.int32}
+            if sample_width not in dtype_map:
+                raise ValueError(f"Unsupported WAV sample width: {sample_width}")
+            self.format = np.dtype(dtype_map[sample_width])
+            self._samples = np.frombuffer(frames, dtype=self.format)
+        elif isinstance(samples, np.ndarray):
+            self.sample_rate = self._DEFAULT_SAMPLING_RATE
+            self.channels = self._DEFAULT_CHANNELS
+            self.format = samples.dtype
+            self._samples = samples
+        else:
+            raise TypeError(f"Unsupported in-memory audio source type: {type(samples)!r}")
+
+        self.format_is_packed = False
+        self.buffer_size = self._DEFAULT_BUFFER_SIZE
+        self._started = True  # It's started by default, this is not a real device
+        self._cursor = 0
+
+    def is_started(self) -> bool:
+        return self._started
+
+    def start(self) -> None:
+        self._started = True
+
+    def stop(self) -> None:
+        self._started = False
+
+    def capture(self) -> np.ndarray:
+        step = self.buffer_size * self.channels
+        if self._cursor >= len(self._samples):
+            raise AudioSourceExhausted()
+
+        chunk = self._samples[self._cursor : self._cursor + step]
+        self._cursor += step
+
+        return chunk
+
+
+@brick
+class WAVAutomaticSpeechRecognition(BaseASR):
+    """ASR brick for offline transcription of in-memory audio."""
+
+    def __init__(
+        self,
+        wav: np.ndarray | bytes,
+        language: str | None = None,
+    ):
+        """
+        ASR brick that transcribes a finite in-memory audio buffer.
+
+        Args:
+            wav: WAV data to be used for transcription. One of:
+                np.ndarray: treated as raw PCM samples at 16 kHz mono.
+                bytes: treated as a WAV container.
+            language (str): Language code for the ASR model (e.g. "en" for
+                English). This is typically auto-detected by the model,
+                but can be overridden here if needed. It is exposed as
+                the public ``language`` attribute and may be reassigned at
+                runtime; the new value takes effect on the next session.
+
+        Note:
+            Only one transcription can be active at a time.
+        """
+        super().__init__(source=wav, language=language)  # type: ignore[arg-type]
+
+    def _build_source(self, source) -> tuple:
+        if not isinstance(source, (np.ndarray, bytes, bytearray)):
+            raise TypeError(f"Unsupported source type: {type(source)!r}")
+        return InMemoryAudioSource(source), False
+
+    def transcribe(self) -> str:
+        """
+        Consume the WAV to completion and return the transcribed text.
+
+        Returns:
+            str: The transcribed text, or an empty string if no speech was detected.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the
+                connection drops mid-session.
+        """
+        return self._collect_transcription(self.transcribe_stream())
+
+    def transcribe_stream(self) -> TranscriptionStream[ASREvent]:
+        """
+        Consume the WAV to completion and yield transcription events.
+
+        Yields:
+            ASREvent: objects representing transcription events.
+
+        Raises:
+            ASRBusyError: If this instance already has an active session.
+            ASRServiceBusyError: If no more concurrent sessions are available.
+            ASRUnavailableError: If the inference service is unreachable or the
+                connection drops mid-session.
+        """
+        self._ensure_source_started()
+        return TranscriptionStream(self._transcribe_stream(duration=0))

--- a/src/arduino/app_bricks/tts/local_tts.py
+++ b/src/arduino/app_bricks/tts/local_tts.py
@@ -90,6 +90,7 @@ class TextToSpeech:
     def start(self):
         """Start the TextToSpeech brick by initializing the speaker."""
         self._speaker.start()
+        self._warmup()
 
     def stop(self):
         """Stop the TextToSpeech brick by stopping the speaker."""
@@ -289,6 +290,19 @@ class TextToSpeech:
         logger.debug(f"TTS chunk_text completed in {elapsed_ms:.2f} ms (input_chars={input_chars}, text_chunks={len(chunks)})")
 
         return chunks
+
+    def _warmup(self) -> None:
+        """Best-effort warmup: synthesize a short text so the inference container loads
+        the TTS model before the first real speak()."""
+        started_at = time.perf_counter()
+        try:
+            for _ in self._synthesize_pcm_stream("ok", keep_alive=True):
+                pass
+        except Exception as e:
+            logger.warning(f"TTS warmup failed: {e}")
+            return
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        logger.debug(f"TTS warmup completed in {elapsed_ms:.2f} ms")
 
     def _synthesize_pcm_stream(
         self,

--- a/src/arduino/app_services/genie_audio/service_compose.yaml
+++ b/src/arduino/app_services/genie_audio/service_compose.yaml
@@ -47,7 +47,6 @@ services:
                chmod 666 /dev/dma_heap/* 2>/dev/null || true;               
                chmod -R 777 /var/log/supervisor;
                chmod 666 /proc/1/fd/1 /proc/1/fd/2 2>/dev/null || true;
-               mkdir -p /usr/share/qcom/conf.d;
                cp /etc/fastrpc/hexagon-dsp-binaries.yaml /usr/share/qcom/conf.d/;
                exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf"
     logging:

--- a/src/arduino/app_services/genie_audio/service_compose.yaml
+++ b/src/arduino/app_services/genie_audio/service_compose.yaml
@@ -35,20 +35,20 @@ services:
       - ${BIND_ADDRESS:-127.0.0.1}:8085:8085
     volumes:
       - /var/lib/arduino-app-cli/models/audio-analytics:/mnt/work/models:ro
-      # Mount system libraries from host for DSP access
-      - /usr/lib/aarch64-linux-gnu/libdmabufheap.so.0:/usr/lib/libdmabufheap.so.0:ro
-      - /usr/lib/aarch64-linux-gnu/libcdsprpc.so:/usr/lib/libcdsprpc.so:ro
-      - /usr/lib/aarch64-linux-gnu/libadsprpc.so:/usr/lib/libadsprpc.so:ro
-      - /usr/lib/aarch64-linux-gnu/libatomic.so.1.2.0:/usr/lib/libatomic.so.1:ro
+      # Mount hexagon firmware
+      - /sys/firmware/devicetree/base/model:/run/device-model
+      - /usr/share/qcom:/usr/share/qcom
     # Use tmpfs for uploads to ensure proper permissions
     tmpfs:
       - /app/uploads:rw,size=500m,mode=777
+      - /usr/share/qcom/conf.d
     command: >
       bash -c "chmod 666 /dev/fastrpc* 2>/dev/null || true;
-               chmod 666 /dev/dma_heap/* 2>/dev/null || true;
-               chmod 666 /dev/snd/* 2>/dev/null || true;
+               chmod 666 /dev/dma_heap/* 2>/dev/null || true;               
                chmod -R 777 /var/log/supervisor;
                chmod 666 /proc/1/fd/1 /proc/1/fd/2 2>/dev/null || true;
+               mkdir -p /usr/share/qcom/conf.d;
+               cp /etc/fastrpc/hexagon-dsp-binaries.yaml /usr/share/qcom/conf.d/;
                exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf"
     logging:
       driver: "json-file"

--- a/tests/arduino/app_bricks/asr/conftest.py
+++ b/tests/arduino/app_bricks/asr/conftest.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import io
+import wave
+
+import numpy as np
+import pytest
+
+from arduino.app_peripherals.microphone.base_microphone import BaseMicrophone
+
+
+@pytest.fixture(autouse=True)
+def _patch_brick_lookup(monkeypatch: pytest.MonkeyPatch):
+    """Avoid hitting the real service-discovery."""
+    monkeypatch.setattr("arduino.app_bricks.asr.local_asr.resolve_address", lambda host: "127.0.0.1")
+    monkeypatch.setattr("arduino.app_bricks.asr.local_asr.get_brick_config", lambda cls: {"id": None, "model": "test-model"})
+    monkeypatch.setattr("arduino.app_bricks.asr.local_asr.get_brick_configured_model", lambda _id: None)
+
+
+def _wav_bytes(samples: np.ndarray, sample_rate: int = 16000, channels: int = 1) -> bytes:
+    """Build a WAV-container ``bytes`` payload around the given samples."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(samples.dtype.itemsize)
+        wf.setframerate(sample_rate)
+        wf.writeframes(samples.tobytes())
+    return buf.getvalue()
+
+
+def _mock_transcribe_stream(monkeypatch, asr, events):
+    """
+    Replace ``asr._transcribe_stream`` with a generator yielding ``events``,
+    while recording the kwargs it was called with.
+    """
+    seen: dict = {}
+
+    def fake(duration=0, vad_ms=None):
+        seen["duration"] = duration
+        seen["vad_ms"] = vad_ms
+        yield from events
+
+    monkeypatch.setattr(asr, "_transcribe_stream", fake)
+    return seen
+
+
+class _FakeMic(BaseMicrophone):
+    """Minimal BaseMicrophone that yields nothing, used as an inert source."""
+
+    def __init__(self, sample_rate: int = 16000, channels: int = 1, format=np.int16, buffer_size: int = 1024):
+        super().__init__(
+            sample_rate=sample_rate,
+            channels=channels,
+            format=format,
+            buffer_size=buffer_size,
+            auto_reconnect=False,
+        )
+
+    def _open_microphone(self):  # pragma: no cover - trivial
+        pass
+
+    def _close_microphone(self):  # pragma: no cover - trivial
+        pass
+
+    def _read_audio(self):  # pragma: no cover - trivial
+        return None
+
+
+def _started_mic() -> _FakeMic:
+    """A ``_FakeMic`` that already passes the source-started check."""
+    mic = _FakeMic()
+    mic.start()
+    return mic

--- a/tests/arduino/app_bricks/asr/test_local_asr.py
+++ b/tests/arduino/app_bricks/asr/test_local_asr.py
@@ -1,11 +1,8 @@
-# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
 # SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import io
 import threading
-import wave
 
 import numpy as np
 import pytest
@@ -15,108 +12,13 @@ from arduino.app_bricks.asr import (
     AutomaticSpeechRecognition,
     TranscriptionStream,
 )
-from arduino.app_bricks.asr.local_asr import (
-    AudioSourceExhausted,
-    InMemoryAudioSource,
+
+from conftest import (
+    _FakeMic,
+    _mock_transcribe_stream,
+    _started_mic,
+    _wav_bytes,
 )
-from arduino.app_peripherals.microphone.base_microphone import BaseMicrophone
-
-
-# HELPERS
-
-
-@pytest.fixture(autouse=True)
-def _patch_brick_lookup(monkeypatch: pytest.MonkeyPatch):
-    """Avoid hitting the real service-discovery"""
-    monkeypatch.setattr("arduino.app_bricks.asr.local_asr.resolve_address", lambda host: "127.0.0.1")
-    monkeypatch.setattr("arduino.app_bricks.asr.local_asr.get_brick_config", lambda cls: {"id": None, "model": "test-model"})
-    monkeypatch.setattr("arduino.app_bricks.asr.local_asr.get_brick_configured_model", lambda _id: None)
-
-
-def _wav_bytes(samples: np.ndarray, sample_rate: int = 16000, channels: int = 1) -> bytes:
-    buf = io.BytesIO()
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(channels)
-        wf.setsampwidth(samples.dtype.itemsize)
-        wf.setframerate(sample_rate)
-        wf.writeframes(samples.tobytes())
-    return buf.getvalue()
-
-
-def _mock_transcribe_stream(monkeypatch, asr, events):
-    """Replace asr._transcribe_stream with a generator yielding `events`,
-    while recording the kwargs it was called with."""
-    seen: dict = {}
-
-    def fake(duration=0, vad_ms=None):
-        seen["duration"] = duration
-        seen["vad_ms"] = vad_ms
-        yield from events
-
-    monkeypatch.setattr(asr, "_transcribe_stream", fake)
-    return seen
-
-
-class _FakeMic(BaseMicrophone):
-    """Minimal BaseMicrophone that yields nothing — used as an inert source."""
-
-    def __init__(self, sample_rate: int = 16000, channels: int = 1, format=np.int16, buffer_size: int = 1024):
-        super().__init__(
-            sample_rate=sample_rate,
-            channels=channels,
-            format=format,
-            buffer_size=buffer_size,
-            auto_reconnect=False,
-        )
-
-    def _open_microphone(self):  # pragma: no cover - trivial
-        pass
-
-    def _close_microphone(self):  # pragma: no cover - trivial
-        pass
-
-    def _read_audio(self):  # pragma: no cover - trivial
-        return None
-
-
-# TESTS
-
-
-class TestInMemoryAudioSource:
-    def test_from_wav_bytes_parses_metadata(self):
-        samples = np.arange(1000, dtype=np.int16)
-        src = InMemoryAudioSource(_wav_bytes(samples, sample_rate=22050))
-        assert src.sample_rate == 22050
-        assert src.channels == 1
-        assert src.format == np.dtype(np.int16)
-        assert src.is_started() is True
-
-    def test_from_ndarray_uses_defaults(self):
-        samples = np.zeros(100, dtype=np.int16)
-        src = InMemoryAudioSource(samples)
-        assert src.sample_rate == 16000
-        assert src.channels == 1
-        assert src.format == np.dtype(np.int16)
-
-    def test_capture_yields_then_raises_exhausted(self):
-        # buffer_size defaults to 1024 → expect 2 captures from 2048 samples
-        src = InMemoryAudioSource(np.zeros(2048, dtype=np.int16))
-        assert len(src.capture()) == 1024
-        assert len(src.capture()) == 1024
-        with pytest.raises(AudioSourceExhausted):
-            src.capture()
-
-    def test_start_stop_toggle_state(self):
-        src = InMemoryAudioSource(np.zeros(10, dtype=np.int16))
-        assert src.is_started()
-        src.stop()
-        assert not src.is_started()
-        src.start()
-        assert src.is_started()
-
-    def test_unsupported_source_type_raises(self):
-        with pytest.raises(TypeError):
-            InMemoryAudioSource(42)  # type: ignore[arg-type]
 
 
 class TestTranscriptionStream:
@@ -153,37 +55,36 @@ class TestTranscriptionStream:
 
 
 class TestConstructor:
+    """Constructor semantics of AutomaticSpeechRecognition (mic brick)."""
+
     def test_base_microphone_is_not_owned(self):
         mic = _FakeMic()
-        asr = AutomaticSpeechRecognition(source=mic)
+        asr = AutomaticSpeechRecognition(mic=mic)
         assert asr._source is mic
-        assert asr._owns_source is False
-
-    def test_wav_bytes_are_wrapped(self):
-        asr = AutomaticSpeechRecognition(source=_wav_bytes(np.zeros(10, dtype=np.int16)))
-        assert isinstance(asr._source, InMemoryAudioSource)
-        assert asr._owns_source is False
-
-    def test_ndarray_are_wrapped(self):
-        asr = AutomaticSpeechRecognition(source=np.zeros(100, dtype=np.int16))
-        assert isinstance(asr._source, InMemoryAudioSource)
         assert asr._owns_source is False
 
     def test_invalid_source_type_raises(self):
         with pytest.raises(TypeError):
-            AutomaticSpeechRecognition(source=42)  # type: ignore[arg-type]
+            AutomaticSpeechRecognition(mic=42)  # type: ignore[arg-type]
 
-    def test_unsupported_dtype_raises_at_construction(self):
-        with pytest.raises(ValueError, match="Unsupported numpy dtype"):
-            AutomaticSpeechRecognition(source=np.zeros(4, dtype="<c8"))  # complex
+    def test_bytes_rejected(self):
+        with pytest.raises(TypeError):
+            AutomaticSpeechRecognition(
+                mic=_wav_bytes(np.zeros(10, dtype=np.int16))  # type: ignore[arg-type]
+            )
+
+    def test_ndarray_rejected(self):
+        with pytest.raises(TypeError):
+            AutomaticSpeechRecognition(mic=np.zeros(10, dtype=np.int16))  # type: ignore[arg-type]
 
 
 class TestSourceStartedCheck:
+    """The eager source-started check fires for every public transcribe* method on the mic brick."""
+
     @pytest.fixture
     def stopped_asr(self):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        asr._source.stop()
-        return asr
+        # _FakeMic is created in the un-started state.
+        return AutomaticSpeechRecognition(mic=_FakeMic())
 
     def test_transcribe(self, stopped_asr):
         with pytest.raises(RuntimeError, match="started"):
@@ -211,40 +112,18 @@ class TestSourceStartedCheck:
 
 
 class TestTranscribe:
-    def test_concatenates_full_text(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        _mock_transcribe_stream(
-            monkeypatch,
-            asr,
-            [
-                ASREvent("partial_text", "hel"),
-                ASREvent("full_text", "hello "),
-                ASREvent("full_text", "world"),
-            ],
-        )
-        assert asr.transcribe() == "hello world"
+    """Mic-brick ``transcribe(duration=...)`` forwards the duration to the underlying generator."""
 
-    def test_falls_back_to_last_partial_when_no_full_text(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        _mock_transcribe_stream(
-            monkeypatch,
-            asr,
-            [
-                ASREvent("partial_text", "hi"),
-                ASREvent("partial_text", "hello world"),
-            ],
-        )
-        assert asr.transcribe() == "hello world"
-
-    def test_returns_empty_when_no_speech(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        _mock_transcribe_stream(monkeypatch, asr, [])
-        assert asr.transcribe() == ""
+    def test_duration_passed_through(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(mic=_started_mic())
+        seen = _mock_transcribe_stream(monkeypatch, asr, [ASREvent("full_text", "hi")])
+        assert asr.transcribe(duration=7) == "hi"
+        assert seen["duration"] == 7
 
 
 class TestTranscribeSentence:
     def test_returns_first_full_text_and_stops(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        asr = AutomaticSpeechRecognition(mic=_started_mic())
         consumed = []
 
         def fake(duration=0, vad_ms=None):
@@ -263,7 +142,7 @@ class TestTranscribeSentence:
         assert [e.data for e in consumed] == ["hel", "hello", "hello"]
 
     def test_falls_back_to_last_partial_when_source_exhausts(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        asr = AutomaticSpeechRecognition(mic=_started_mic())
         _mock_transcribe_stream(
             monkeypatch,
             asr,
@@ -274,15 +153,14 @@ class TestTranscribeSentence:
         )
         assert asr.transcribe_sentence() == "hello world"
 
-    def test_passes_hangover_as_vad_ms(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+    def test_timeout_passed_as_duration(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(mic=_started_mic())
         seen = _mock_transcribe_stream(monkeypatch, asr, [ASREvent("full_text", "ok")])
-        asr.transcribe_sentence(hangover=350, timeout=12)
-        assert seen["vad_ms"] == 350
+        asr.transcribe_sentence(timeout=12)
         assert seen["duration"] == 12
 
     def test_empty_full_text_does_not_terminate_stream(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        asr = AutomaticSpeechRecognition(mic=_started_mic())
         _mock_transcribe_stream(
             monkeypatch,
             asr,
@@ -297,7 +175,7 @@ class TestTranscribeSentence:
 
 class TestTranscribeContinuous:
     def test_yields_non_empty_full_text_only(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        asr = AutomaticSpeechRecognition(mic=_started_mic())
         _mock_transcribe_stream(
             monkeypatch,
             asr,
@@ -315,7 +193,7 @@ class TestTranscribeContinuous:
         assert not asr.is_transcribing()
 
     def test_break_closes_underlying_stream(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        asr = AutomaticSpeechRecognition(mic=_started_mic())
         inner_closed = threading.Event()
 
         def fake(duration=0, vad_ms=None):
@@ -334,20 +212,9 @@ class TestTranscribeContinuous:
         assert not asr.is_transcribing()
 
     def test_timeout_passed_as_duration(self, monkeypatch):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        asr = AutomaticSpeechRecognition(mic=_started_mic())
         seen = _mock_transcribe_stream(monkeypatch, asr, [])
         with asr.transcribe_continuous(timeout=42) as sentences:
             list(sentences)
         assert seen["duration"] == 42
         assert not asr.is_transcribing()
-
-
-class TestIdleState:
-    def test_fresh_instance_is_not_transcribing(self):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        assert asr.is_transcribing() is False
-
-    def test_cancel_on_idle_is_noop(self):
-        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        asr.cancel()  # must not raise
-        assert asr.is_transcribing() is False

--- a/tests/arduino/app_bricks/asr/test_local_asr.py
+++ b/tests/arduino/app_bricks/asr/test_local_asr.py
@@ -1,0 +1,332 @@
+# SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import io
+import threading
+import wave
+
+import numpy as np
+import pytest
+
+from arduino.app_bricks.asr import (
+    ASREvent,
+    AutomaticSpeechRecognition,
+    TranscriptionStream,
+)
+from arduino.app_bricks.asr.local_asr import (
+    AudioSourceExhausted,
+    InMemoryAudioSource,
+)
+from arduino.app_peripherals.microphone.base_microphone import BaseMicrophone
+
+
+# HELPERS
+
+
+@pytest.fixture(autouse=True)
+def _patch_brick_lookup(monkeypatch: pytest.MonkeyPatch):
+    """Avoid hitting the real service-discovery"""
+    monkeypatch.setattr("arduino.app_bricks.asr.local_asr.resolve_address", lambda host: "127.0.0.1")
+    monkeypatch.setattr("arduino.app_bricks.asr.local_asr.get_brick_config", lambda cls: {"id": None, "model": "test-model"})
+    monkeypatch.setattr("arduino.app_bricks.asr.local_asr.get_brick_configured_model", lambda _id: None)
+
+
+def _wav_bytes(samples: np.ndarray, sample_rate: int = 16000, channels: int = 1) -> bytes:
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(samples.dtype.itemsize)
+        wf.setframerate(sample_rate)
+        wf.writeframes(samples.tobytes())
+    return buf.getvalue()
+
+
+def _mock_transcribe_stream(monkeypatch, asr, events):
+    """Replace asr._transcribe_stream with a generator yielding `events`,
+    while recording the kwargs it was called with."""
+    seen: dict = {}
+
+    def fake(duration=0, vad_ms=None):
+        seen["duration"] = duration
+        seen["vad_ms"] = vad_ms
+        yield from events
+
+    monkeypatch.setattr(asr, "_transcribe_stream", fake)
+    return seen
+
+
+class _FakeMic(BaseMicrophone):
+    """Minimal BaseMicrophone that yields nothing — used as an inert source."""
+
+    def __init__(self, sample_rate: int = 16000, channels: int = 1, format=np.int16, buffer_size: int = 1024):
+        super().__init__(
+            sample_rate=sample_rate,
+            channels=channels,
+            format=format,
+            buffer_size=buffer_size,
+            auto_reconnect=False,
+        )
+
+    def _open_microphone(self):  # pragma: no cover - trivial
+        pass
+
+    def _close_microphone(self):  # pragma: no cover - trivial
+        pass
+
+    def _read_audio(self):  # pragma: no cover - trivial
+        return None
+
+
+# TESTS
+
+
+class TestInMemoryAudioSource:
+    def test_from_wav_bytes_parses_metadata(self):
+        samples = np.arange(1000, dtype=np.int16)
+        src = InMemoryAudioSource(_wav_bytes(samples, sample_rate=22050))
+        assert src.sample_rate == 22050
+        assert src.channels == 1
+        assert src.format == np.dtype(np.int16)
+        assert src.is_started() is True
+
+    def test_from_ndarray_uses_defaults(self):
+        samples = np.zeros(100, dtype=np.int16)
+        src = InMemoryAudioSource(samples)
+        assert src.sample_rate == 16000
+        assert src.channels == 1
+        assert src.format == np.dtype(np.int16)
+
+    def test_capture_yields_then_raises_exhausted(self):
+        # buffer_size defaults to 1024 → expect 2 captures from 2048 samples
+        src = InMemoryAudioSource(np.zeros(2048, dtype=np.int16))
+        assert len(src.capture()) == 1024
+        assert len(src.capture()) == 1024
+        with pytest.raises(AudioSourceExhausted):
+            src.capture()
+
+    def test_start_stop_toggle_state(self):
+        src = InMemoryAudioSource(np.zeros(10, dtype=np.int16))
+        assert src.is_started()
+        src.stop()
+        assert not src.is_started()
+        src.start()
+        assert src.is_started()
+
+    def test_unsupported_source_type_raises(self):
+        with pytest.raises(TypeError):
+            InMemoryAudioSource(42)  # type: ignore[arg-type]
+
+
+class TestTranscriptionStream:
+    def test_iterates_and_closes_on_context_exit(self):
+        closed = threading.Event()
+
+        def gen():
+            try:
+                yield 1
+                yield 2
+                yield 3
+            finally:
+                closed.set()
+
+        with TranscriptionStream(gen()) as stream:
+            assert next(stream) == 1
+            assert next(stream) == 2
+        assert closed.is_set()
+
+    def test_close_propagates_on_exception(self):
+        closed = threading.Event()
+
+        def gen():
+            try:
+                yield 1
+            finally:
+                closed.set()
+
+        with pytest.raises(RuntimeError, match="oops!"):
+            with TranscriptionStream(gen()) as stream:
+                next(stream)
+                raise RuntimeError("oops!")
+        assert closed.is_set()
+
+
+class TestConstructor:
+    def test_base_microphone_is_not_owned(self):
+        mic = _FakeMic()
+        asr = AutomaticSpeechRecognition(source=mic)
+        assert asr._source is mic
+        assert asr._owns_source is False
+
+    def test_wav_bytes_are_wrapped(self):
+        asr = AutomaticSpeechRecognition(source=_wav_bytes(np.zeros(10, dtype=np.int16)))
+        assert isinstance(asr._source, InMemoryAudioSource)
+        assert asr._owns_source is False
+
+    def test_ndarray_are_wrapped(self):
+        asr = AutomaticSpeechRecognition(source=np.zeros(100, dtype=np.int16))
+        assert isinstance(asr._source, InMemoryAudioSource)
+        assert asr._owns_source is False
+
+    def test_invalid_source_type_raises(self):
+        with pytest.raises(TypeError):
+            AutomaticSpeechRecognition(source=42)  # type: ignore[arg-type]
+    
+    def test_unsupported_dtype_raises_at_construction(self):
+        with pytest.raises(ValueError, match="Unsupported numpy dtype"):
+            AutomaticSpeechRecognition(source=np.zeros(4, dtype="<c8"))  # complex
+
+
+class TestSourceStartedCheck:
+    @pytest.fixture
+    def stopped_asr(self):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        asr._source.stop()
+        return asr
+
+    def test_transcribe(self, stopped_asr):
+        with pytest.raises(RuntimeError, match="started"):
+            stopped_asr.transcribe()
+
+    def test_transcribe_stream(self, stopped_asr):
+        with pytest.raises(RuntimeError, match="started"):
+            stopped_asr.transcribe_stream()
+
+    def test_transcribe_sentence(self, stopped_asr):
+        with pytest.raises(RuntimeError, match="started"):
+            stopped_asr.transcribe_sentence()
+
+    def test_transcribe_sentence_stream(self, stopped_asr):
+        with pytest.raises(RuntimeError, match="started"):
+            stopped_asr.transcribe_sentence_stream()
+
+    def test_transcribe_continuous(self, stopped_asr):
+        with pytest.raises(RuntimeError, match="started"):
+            stopped_asr.transcribe_continuous()
+
+    def test_transcribe_continuous_stream(self, stopped_asr):
+        with pytest.raises(RuntimeError, match="started"):
+            stopped_asr.transcribe_continuous_stream()
+
+
+class TestTranscribe:
+    def test_concatenates_full_text(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        _mock_transcribe_stream(monkeypatch, asr, [
+            ASREvent("partial_text", "hel"),
+            ASREvent("full_text", "hello "),
+            ASREvent("full_text", "world"),
+        ])
+        assert asr.transcribe() == "hello world"
+
+    def test_falls_back_to_last_partial_when_no_full_text(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        _mock_transcribe_stream(monkeypatch, asr, [
+            ASREvent("partial_text", "hi"),
+            ASREvent("partial_text", "hello world"),
+        ])
+        assert asr.transcribe() == "hello world"
+
+    def test_returns_empty_when_no_speech(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        _mock_transcribe_stream(monkeypatch, asr, [])
+        assert asr.transcribe() == ""
+
+
+class TestTranscribeSentence:
+    def test_returns_first_full_text_and_stops(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        consumed = []
+
+        def fake(duration=0, vad_ms=None):
+            for ev in [
+                ASREvent("partial_text", "hel"),
+                ASREvent("partial_text", "hello"),
+                ASREvent("full_text", "hello"),
+                ASREvent("full_text", "world"),  # must not be yielded
+            ]:
+                consumed.append(ev)
+                yield ev
+
+        monkeypatch.setattr(asr, "_transcribe_stream", fake)
+        assert asr.transcribe_sentence() == "hello"
+        # Only the first three events should have been pulled before close.
+        assert [e.data for e in consumed] == ["hel", "hello", "hello"]
+
+    def test_falls_back_to_last_partial_when_source_exhausts(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        _mock_transcribe_stream(monkeypatch, asr, [
+            ASREvent("partial_text", "hello"),
+            ASREvent("partial_text", "hello world"),
+        ])
+        assert asr.transcribe_sentence() == "hello world"
+
+    def test_passes_hangover_as_vad_ms(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        seen = _mock_transcribe_stream(monkeypatch, asr, [ASREvent("full_text", "ok")])
+        asr.transcribe_sentence(hangover=350, timeout=12)
+        assert seen["vad_ms"] == 350
+        assert seen["duration"] == 12
+
+    def test_empty_full_text_does_not_terminate_stream(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        _mock_transcribe_stream(monkeypatch, asr, [
+            ASREvent("full_text", "   "),  # blank — should not stop
+            ASREvent("partial_text", "hi"),
+            ASREvent("full_text", "hi there"),
+        ])
+        assert asr.transcribe_sentence() == "hi there"
+
+
+class TestTranscribeContinuous:
+    def test_yields_non_empty_full_text_only(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        _mock_transcribe_stream(monkeypatch, asr, [
+            ASREvent("partial_text", "hi"),
+            ASREvent("full_text", "hi"),
+            ASREvent("partial_text", "there"),
+            ASREvent("full_text", "   "),  # filtered out
+            ASREvent("full_text", "there"),
+        ])
+        with asr.transcribe_continuous() as sentences:
+            collected = list(sentences)
+        assert collected == ["hi", "there"]
+        assert not asr.is_transcribing()
+
+    def test_break_closes_underlying_stream(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        inner_closed = threading.Event()
+
+        def fake(duration=0, vad_ms=None):
+            try:
+                for ev in [ASREvent("full_text", "one"), ASREvent("full_text", "two")]:
+                    yield ev
+            finally:
+                inner_closed.set()
+
+        monkeypatch.setattr(asr, "_transcribe_stream", fake)
+        with asr.transcribe_continuous() as sentences:
+            for sentence in sentences:
+                assert sentence == "one"
+                break
+        assert inner_closed.is_set()
+        assert not asr.is_transcribing()
+
+    def test_timeout_passed_as_duration(self, monkeypatch):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        seen = _mock_transcribe_stream(monkeypatch, asr, [])
+        with asr.transcribe_continuous(timeout=42) as sentences:
+            list(sentences)
+        assert seen["duration"] == 42
+        assert not asr.is_transcribing()
+
+
+class TestIdleState:
+    def test_fresh_instance_is_not_transcribing(self):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        assert asr.is_transcribing() is False
+
+    def test_cancel_on_idle_is_noop(self):
+        asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
+        asr.cancel()  # must not raise
+        assert asr.is_transcribing() is False

--- a/tests/arduino/app_bricks/asr/test_local_asr.py
+++ b/tests/arduino/app_bricks/asr/test_local_asr.py
@@ -171,7 +171,7 @@ class TestConstructor:
     def test_invalid_source_type_raises(self):
         with pytest.raises(TypeError):
             AutomaticSpeechRecognition(source=42)  # type: ignore[arg-type]
-    
+
     def test_unsupported_dtype_raises_at_construction(self):
         with pytest.raises(ValueError, match="Unsupported numpy dtype"):
             AutomaticSpeechRecognition(source=np.zeros(4, dtype="<c8"))  # complex
@@ -212,19 +212,27 @@ class TestSourceStartedCheck:
 class TestTranscribe:
     def test_concatenates_full_text(self, monkeypatch):
         asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        _mock_transcribe_stream(monkeypatch, asr, [
-            ASREvent("partial_text", "hel"),
-            ASREvent("full_text", "hello "),
-            ASREvent("full_text", "world"),
-        ])
+        _mock_transcribe_stream(
+            monkeypatch,
+            asr,
+            [
+                ASREvent("partial_text", "hel"),
+                ASREvent("full_text", "hello "),
+                ASREvent("full_text", "world"),
+            ],
+        )
         assert asr.transcribe() == "hello world"
 
     def test_falls_back_to_last_partial_when_no_full_text(self, monkeypatch):
         asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        _mock_transcribe_stream(monkeypatch, asr, [
-            ASREvent("partial_text", "hi"),
-            ASREvent("partial_text", "hello world"),
-        ])
+        _mock_transcribe_stream(
+            monkeypatch,
+            asr,
+            [
+                ASREvent("partial_text", "hi"),
+                ASREvent("partial_text", "hello world"),
+            ],
+        )
         assert asr.transcribe() == "hello world"
 
     def test_returns_empty_when_no_speech(self, monkeypatch):
@@ -255,10 +263,14 @@ class TestTranscribeSentence:
 
     def test_falls_back_to_last_partial_when_source_exhausts(self, monkeypatch):
         asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        _mock_transcribe_stream(monkeypatch, asr, [
-            ASREvent("partial_text", "hello"),
-            ASREvent("partial_text", "hello world"),
-        ])
+        _mock_transcribe_stream(
+            monkeypatch,
+            asr,
+            [
+                ASREvent("partial_text", "hello"),
+                ASREvent("partial_text", "hello world"),
+            ],
+        )
         assert asr.transcribe_sentence() == "hello world"
 
     def test_passes_hangover_as_vad_ms(self, monkeypatch):
@@ -270,24 +282,32 @@ class TestTranscribeSentence:
 
     def test_empty_full_text_does_not_terminate_stream(self, monkeypatch):
         asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        _mock_transcribe_stream(monkeypatch, asr, [
-            ASREvent("full_text", "   "),  # blank — should not stop
-            ASREvent("partial_text", "hi"),
-            ASREvent("full_text", "hi there"),
-        ])
+        _mock_transcribe_stream(
+            monkeypatch,
+            asr,
+            [
+                ASREvent("full_text", "   "),  # blank — should not stop
+                ASREvent("partial_text", "hi"),
+                ASREvent("full_text", "hi there"),
+            ],
+        )
         assert asr.transcribe_sentence() == "hi there"
 
 
 class TestTranscribeContinuous:
     def test_yields_non_empty_full_text_only(self, monkeypatch):
         asr = AutomaticSpeechRecognition(source=np.zeros(10, dtype=np.int16))
-        _mock_transcribe_stream(monkeypatch, asr, [
-            ASREvent("partial_text", "hi"),
-            ASREvent("full_text", "hi"),
-            ASREvent("partial_text", "there"),
-            ASREvent("full_text", "   "),  # filtered out
-            ASREvent("full_text", "there"),
-        ])
+        _mock_transcribe_stream(
+            monkeypatch,
+            asr,
+            [
+                ASREvent("partial_text", "hi"),
+                ASREvent("full_text", "hi"),
+                ASREvent("partial_text", "there"),
+                ASREvent("full_text", "   "),  # filtered out
+                ASREvent("full_text", "there"),
+            ],
+        )
         with asr.transcribe_continuous() as sentences:
             collected = list(sentences)
         assert collected == ["hi", "there"]

--- a/tests/arduino/app_bricks/asr/test_local_asr.py
+++ b/tests/arduino/app_bricks/asr/test_local_asr.py
@@ -102,13 +102,9 @@ class TestSourceStartedCheck:
         with pytest.raises(RuntimeError, match="started"):
             stopped_asr.transcribe_sentence_stream()
 
-    def test_transcribe_continuous(self, stopped_asr):
+    def test_transcribe_until_cancelled(self, stopped_asr):
         with pytest.raises(RuntimeError, match="started"):
-            stopped_asr.transcribe_continuous()
-
-    def test_transcribe_continuous_stream(self, stopped_asr):
-        with pytest.raises(RuntimeError, match="started"):
-            stopped_asr.transcribe_continuous_stream()
+            stopped_asr.transcribe_until_cancelled()
 
 
 class TestTranscribe:
@@ -173,23 +169,19 @@ class TestTranscribeSentence:
         assert asr.transcribe_sentence() == "hi there"
 
 
-class TestTranscribeContinuous:
-    def test_yields_non_empty_full_text_only(self, monkeypatch):
+class TestTranscribeUntilCancelled:
+    def test_yields_event_stream(self, monkeypatch):
         asr = AutomaticSpeechRecognition(mic=_started_mic())
-        _mock_transcribe_stream(
-            monkeypatch,
-            asr,
-            [
-                ASREvent("partial_text", "hi"),
-                ASREvent("full_text", "hi"),
-                ASREvent("partial_text", "there"),
-                ASREvent("full_text", "   "),  # filtered out
-                ASREvent("full_text", "there"),
-            ],
-        )
-        with asr.transcribe_continuous() as sentences:
-            collected = list(sentences)
-        assert collected == ["hi", "there"]
+        events = [
+            ASREvent("partial_text", "hi"),
+            ASREvent("full_text", "hi"),
+            ASREvent("partial_text", "there"),
+            ASREvent("full_text", "there"),
+        ]
+        _mock_transcribe_stream(monkeypatch, asr, events)
+        with asr.transcribe_until_cancelled() as stream:
+            collected = list(stream)
+        assert collected == events
         assert not asr.is_transcribing()
 
     def test_break_closes_underlying_stream(self, monkeypatch):
@@ -204,17 +196,17 @@ class TestTranscribeContinuous:
                 inner_closed.set()
 
         monkeypatch.setattr(asr, "_transcribe_stream", fake)
-        with asr.transcribe_continuous() as sentences:
-            for sentence in sentences:
-                assert sentence == "one"
+        with asr.transcribe_until_cancelled() as stream:
+            for event in stream:
+                assert event.data == "one"
                 break
         assert inner_closed.is_set()
         assert not asr.is_transcribing()
 
-    def test_timeout_passed_as_duration(self, monkeypatch):
+    def test_calls_underlying_generator_unbounded(self, monkeypatch):
         asr = AutomaticSpeechRecognition(mic=_started_mic())
         seen = _mock_transcribe_stream(monkeypatch, asr, [])
-        with asr.transcribe_continuous(timeout=42) as sentences:
-            list(sentences)
-        assert seen["duration"] == 42
+        with asr.transcribe_until_cancelled() as stream:
+            list(stream)
+        assert seen["duration"] == 0
         assert not asr.is_transcribing()

--- a/tests/arduino/app_bricks/asr/test_local_asr.py
+++ b/tests/arduino/app_bricks/asr/test_local_asr.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (C) ARDUINO SRL (http://www.arduino.cc)
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
 #
 # SPDX-License-Identifier: MPL-2.0
 

--- a/tests/arduino/app_bricks/asr/test_local_asr_wav.py
+++ b/tests/arduino/app_bricks/asr/test_local_asr_wav.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for the offline (in-memory) ASR brick (``WAVAutomaticSpeechRecognition``)
+and its helper ``InMemoryAudioSource``."""
+
+import numpy as np
+import pytest
+
+from arduino.app_bricks.asr import (
+    ASREvent,
+    WAVAutomaticSpeechRecognition,
+)
+from arduino.app_bricks.asr.local_asr_wav import InMemoryAudioSource
+from arduino.app_bricks.asr.local_asr import AudioSourceExhausted
+
+from conftest import (
+    _FakeMic,
+    _mock_transcribe_stream,
+    _wav_bytes,
+)
+
+
+class TestInMemoryAudioSource:
+    def test_from_wav_bytes_parses_metadata(self):
+        samples = np.arange(1000, dtype=np.int16)
+        src = InMemoryAudioSource(_wav_bytes(samples, sample_rate=22050))
+        assert src.sample_rate == 22050
+        assert src.channels == 1
+        assert src.format == np.dtype(np.int16)
+        assert src.is_started() is True
+
+    def test_from_ndarray_uses_defaults(self):
+        samples = np.zeros(100, dtype=np.int16)
+        src = InMemoryAudioSource(samples)
+        assert src.sample_rate == 16000
+        assert src.channels == 1
+        assert src.format == np.dtype(np.int16)
+
+    def test_capture_yields_then_raises_exhausted(self):
+        # buffer_size defaults to 1024 → expect 2 captures from 2048 samples
+        src = InMemoryAudioSource(np.zeros(2048, dtype=np.int16))
+        assert len(src.capture()) == 1024
+        assert len(src.capture()) == 1024
+        with pytest.raises(AudioSourceExhausted):
+            src.capture()
+
+    def test_start_stop_toggle_state(self):
+        src = InMemoryAudioSource(np.zeros(10, dtype=np.int16))
+        assert src.is_started()
+        src.stop()
+        assert not src.is_started()
+        src.start()
+        assert src.is_started()
+
+    def test_unsupported_source_type_raises(self):
+        with pytest.raises(TypeError):
+            InMemoryAudioSource(42)  # type: ignore[arg-type]
+
+
+class TestConstructor:
+    """Constructor semantics of WAVAutomaticSpeechRecognition."""
+
+    def test_wav_bytes_are_wrapped(self):
+        asr = WAVAutomaticSpeechRecognition(wav=_wav_bytes(np.zeros(10, dtype=np.int16)))
+        assert isinstance(asr._source, InMemoryAudioSource)
+        assert asr._owns_source is False
+
+    def test_ndarray_are_wrapped(self):
+        asr = WAVAutomaticSpeechRecognition(wav=np.zeros(100, dtype=np.int16))
+        assert isinstance(asr._source, InMemoryAudioSource)
+        assert asr._owns_source is False
+
+    def test_invalid_source_type_raises(self):
+        with pytest.raises(TypeError):
+            WAVAutomaticSpeechRecognition(wav=42)  # type: ignore[arg-type]
+
+    def test_microphone_rejected(self):
+        with pytest.raises(TypeError):
+            WAVAutomaticSpeechRecognition(wav=_FakeMic())  # type: ignore[arg-type]
+
+    def test_unsupported_dtype_raises_at_construction(self):
+        with pytest.raises(ValueError, match="Unsupported numpy dtype"):
+            WAVAutomaticSpeechRecognition(wav=np.zeros(4, dtype="<c8"))  # complex
+
+
+class TestSourceStartedCheck:
+    """The eager source-started check fires on the WAV brick's public surface."""
+
+    @pytest.fixture
+    def stopped_asr(self):
+        asr = WAVAutomaticSpeechRecognition(wav=np.zeros(10, dtype=np.int16))
+        asr._source.stop()
+        return asr
+
+    def test_transcribe(self, stopped_asr):
+        with pytest.raises(RuntimeError, match="started"):
+            stopped_asr.transcribe()
+
+    def test_transcribe_stream(self, stopped_asr):
+        with pytest.raises(RuntimeError, match="started"):
+            stopped_asr.transcribe_stream()
+
+
+class TestTranscribe:
+    """Covers the shared ``_collect_transcription`` helper through the WAV brick's no-arg ``transcribe()``."""
+
+    def test_concatenates_full_text(self, monkeypatch):
+        asr = WAVAutomaticSpeechRecognition(wav=np.zeros(10, dtype=np.int16))
+        _mock_transcribe_stream(
+            monkeypatch,
+            asr,
+            [
+                ASREvent("partial_text", "hel"),
+                ASREvent("full_text", "hello "),
+                ASREvent("full_text", "world"),
+            ],
+        )
+        assert asr.transcribe() == "hello world"
+
+    def test_falls_back_to_last_partial_when_no_full_text(self, monkeypatch):
+        asr = WAVAutomaticSpeechRecognition(wav=np.zeros(10, dtype=np.int16))
+        _mock_transcribe_stream(
+            monkeypatch,
+            asr,
+            [
+                ASREvent("partial_text", "hi"),
+                ASREvent("partial_text", "hello world"),
+            ],
+        )
+        assert asr.transcribe() == "hello world"
+
+    def test_returns_empty_when_no_speech(self, monkeypatch):
+        asr = WAVAutomaticSpeechRecognition(wav=np.zeros(10, dtype=np.int16))
+        _mock_transcribe_stream(monkeypatch, asr, [])
+        assert asr.transcribe() == ""
+
+
+class TestIdleState:
+    """Idle-state introspection inherited from ``_ASRBase``."""
+
+    def test_fresh_instance_is_not_transcribing(self):
+        asr = WAVAutomaticSpeechRecognition(wav=np.zeros(10, dtype=np.int16))
+        assert asr.is_transcribing() is False
+
+    def test_cancel_on_idle_is_noop(self):
+        asr = WAVAutomaticSpeechRecognition(wav=np.zeros(10, dtype=np.int16))
+        asr.cancel()  # must not raise
+        assert asr.is_transcribing() is False


### PR DESCRIPTION
  - ASR and TTS bricks pay a cold-start cost on the first call because the inference container loads the model lazily. This PR adds a synchronous best-effort warmup in `start()` so the model is already resident when the user's code makes its first real `transcribe()` / `speak()`.
  - ASR: a single `create` + `close` of a transcription session is enough to trigger the model load on the runner.
  - TTS: synthesizes a short `"ok"` with `keep_alive=True` and discards the PCM stream.
  - Failures during warmup are logged as warnings and never propagate, so `start()` still succeeds if the warmup is not performed.