### PR TITLE
feat: add model warmup for asr and tts on brick start

### DIFF
--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -182,6 +182,7 @@ class BaseASR:
             self._worker_loop = Future()
         if self._owns_source:
             self._source.start()
+        self._warmup()
 
     def stop(self):
         """Stop the ASR and clean up resources. Stops the owned mic if applicable."""
@@ -268,6 +269,25 @@ class BaseASR:
                 loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             loop.close()
             logger.debug("Asyncio event loop stopped")
+
+    def _warmup(self) -> None:
+        """Best-effort warmup: create and immediately close a transcription session so the
+        inference container loads the ASR model before the first real transcription."""
+        if self._stop_worker.is_set():
+            return
+        started_at = time.perf_counter()
+        try:
+            session_id = self._create_transcription_session(language=self.language)
+        except Exception as e:
+            logger.warning(f"ASR warmup failed during session creation: {e}")
+            return
+        try:
+            self._close_transcription_session(session_id)
+        except Exception as e:
+            logger.warning(f"ASR warmup failed during closing session {session_id}: {e}")
+            return
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        logger.debug(f"ASR warmup completed in {elapsed_ms:.2f} ms")
 
     def _transcribe_stream(self, duration: int = 0, vad_ms: int | None = None) -> Generator[ASREvent, None, None]:
         if self._stop_worker.is_set():
@@ -402,7 +422,7 @@ class BaseASR:
 
         state = result.get("state")
         if state != "asr_initialized":
-            logger.warning(f"ASR session {session_id} created but not initialized (state={state})")
+            raise ASRError(f"Unexpected session state: {state}")
 
         return session_id
 

--- a/src/arduino/app_bricks/tts/local_tts.py
+++ b/src/arduino/app_bricks/tts/local_tts.py
@@ -90,6 +90,7 @@ class TextToSpeech:
     def start(self):
         """Start the TextToSpeech brick by initializing the speaker."""
         self._speaker.start()
+        self._warmup()
 
     def stop(self):
         """Stop the TextToSpeech brick by stopping the speaker."""
@@ -289,6 +290,19 @@ class TextToSpeech:
         logger.debug(f"TTS chunk_text completed in {elapsed_ms:.2f} ms (input_chars={input_chars}, text_chunks={len(chunks)})")
 
         return chunks
+
+    def _warmup(self) -> None:
+        """Best-effort warmup: synthesize a short text so the inference container loads
+        the TTS model before the first real speak()."""
+        started_at = time.perf_counter()
+        try:
+            for _ in self._synthesize_pcm_stream("ok", keep_alive=True):
+                pass
+        except Exception as e:
+            logger.warning(f"TTS warmup failed: {e}")
+            return
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        logger.debug(f"TTS warmup completed in {elapsed_ms:.2f} ms")
 
     def _synthesize_pcm_stream(
         self,


### PR DESCRIPTION
  - ASR and TTS bricks pay a cold-start cost on the first call because the inference container loads the model lazily. This PR adds a synchronous best-effort warmup in `start()` so the model is already resident when the user's code makes its first real `transcribe()` / `speak()`.
  - ASR: a single `create` + `close` of a transcription session is enough to trigger the model load on the runner.
  - TTS: synthesizes a short `"ok"` with `keep_alive=True` and discards the PCM stream.
  - Failures during warmup are logged as warnings and never propagate, so `start()` still succeeds if the warmup is not performed.