### PR TITLE
feat: add persistent memory to llm bricks

### DIFF
--- a/src/arduino/app_bricks/cloud_llm/README.md
+++ b/src/arduino/app_bricks/cloud_llm/README.md
@@ -105,5 +105,5 @@ You can select a model using the `CloudModel` enum or by passing the correspondi
 - **`chat(message)`**: Sends a message and returns the complete response string. Blocks until generation is finished.
 - **`chat_stream(message)`**: Returns a generator yielding response tokens as they arrive.
 - **`stop_stream()`**: Interrupts an active streaming generation.
-- **`with_memory(max_messages)`**: Enables history tracking. `max_messages` defines the context window size.
-- **`clear_memory()`**: Resets the conversation history.
+- **`with_memory(max_messages, persistence=None)`**: Enables history tracking. `max_messages` is the window size sent to the model. `persistence=True` enables persistence with a dedicated default database/thread; pass a `MessagePersistence` (e.g. `SQLMessagePersistence`) for full control.
+- **`clear_memory()`**: Resets the conversation history (also deletes persisted rows for the active thread when a persistence backend is configured).

--- a/src/arduino/app_bricks/cloud_llm/__init__.py
+++ b/src/arduino/app_bricks/cloud_llm/__init__.py
@@ -3,7 +3,16 @@
 # SPDX-License-Identifier: MPL-2.0
 
 from .cloud_llm import CloudLLM
+from .memory import MessagePersistence, SQLMessagePersistence, WindowedChatMessageHistory
 from .models import CloudModel, CloudModelProvider
 from langchain_core.tools import tool
 
-__all__ = ["CloudLLM", "CloudModel", "CloudModelProvider", "tool"]
+__all__ = [
+    "CloudLLM",
+    "CloudModel",
+    "CloudModelProvider",
+    "MessagePersistence",
+    "SQLMessagePersistence",
+    "WindowedChatMessageHistory",
+    "tool",
+]

--- a/src/arduino/app_bricks/cloud_llm/cloud_llm.py
+++ b/src/arduino/app_bricks/cloud_llm/cloud_llm.py
@@ -15,7 +15,7 @@ from arduino.app_utils import brick
 
 from .utils import logger
 from .models import CloudModel, CloudModelProvider
-from .memory import WindowedChatMessageHistory
+from .memory import MessagePersistence, SQLMessagePersistence, WindowedChatMessageHistory
 
 DEFAULT_MEMORY = 10
 
@@ -120,22 +120,41 @@ class CloudLLM:
 
         self._keep_streaming = threading.Event()
 
-    def with_memory(self, max_messages: int = DEFAULT_MEMORY) -> "CloudLLM":
+    def with_memory(
+        self,
+        max_messages: int = DEFAULT_MEMORY,
+        persistence: Union[bool, MessagePersistence, None] = None,
+    ) -> "CloudLLM":
         """Enables conversational memory for this instance.
 
         Configures the Brick to retain a window of previous messages, allowing the
-        AI to maintain context across multiple interactions.
+        AI to maintain context across multiple interactions. An optional persistence
+        backend stores the history so it can resume across restarts.
 
         Args:
-            max_messages (int): The maximum number of messages (user + AI) to keep
-                in history. Older messages are discarded. Set to 0 to disable memory.
-                Defaults to 10.
+            max_messages (int): The maximum number of messages.
+            persistence (bool | MessagePersistence | None): Optional persistence backend.
+                `None` or `False` keep history in memory only (default behavior).
+                `True` instantiates a default `SQLMessagePersistence()`. Pass a
+                `MessagePersistence` implementation directly (e.g.
+                `SQLMessagePersistence(thread_id="user-42")`) for full control.
 
         Returns:
             CloudLLM: The current instance, allowing for method chaining.
         """
+        if persistence is True:
+            store: Optional[MessagePersistence] = SQLMessagePersistence()
+        elif persistence in (False, None):
+            store = None
+        else:
+            store = persistence
+
         self._max_messages = max_messages
-        self._history = WindowedChatMessageHistory(k=self._max_messages, system_message=self._system_prompt)
+        self._history = WindowedChatMessageHistory(
+            k=max_messages,
+            system_message=self._system_prompt,
+            store=store,
+        )
 
         return self
 

--- a/src/arduino/app_bricks/cloud_llm/examples/8_persistent_memory.py
+++ b/src/arduino/app_bricks/cloud_llm/examples/8_persistent_memory.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# EXAMPLE_NAME = "Conversation with persistent memory"
+# EXAMPLE_REQUIRES = "Requires a valid API key to a cloud LLM service and the dbstorage_sqlstore brick."
+
+from arduino.app_bricks.cloud_llm import CloudLLM, SQLMessagePersistence
+from arduino.app_bricks.dbstorage_sqlstore import SQLStore
+from arduino.app_utils import App
+
+# Share a single SQLStore instance across bricks that need it.
+db = SQLStore("chat_history.db")
+db.start()
+
+llm = CloudLLM(
+    api_key="YOUR_API_KEY",  # Replace with your actual API key
+    system_prompt="You are a helpful assistant.",
+).with_memory(
+    max_messages=10,
+    persistence=SQLMessagePersistence(sql_store=db, thread_id="demo-user"),
+)
+
+
+def ask_prompt():
+    prompt = input("Enter your prompt (or 'exit' to quit, 'forget' to clear history): ")
+    if prompt.lower() == "exit":
+        raise StopIteration()
+    if prompt.lower() == "forget":
+        llm.clear_memory()
+        print("Memory cleared for this thread.")
+        return
+    print(llm.chat(prompt))
+
+
+App.run(ask_prompt)

--- a/src/arduino/app_bricks/cloud_llm/memory.py
+++ b/src/arduino/app_bricks/cloud_llm/memory.py
@@ -2,10 +2,119 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-from langchain_core.messages import BaseMessage, SystemMessage, HumanMessage, AIMessage
-from typing import List
+import json
+from typing import List, Optional, Protocol, runtime_checkable
 
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, messages_from_dict, messages_to_dict
+
+from arduino.app_bricks.dbstorage_sqlstore import SQLStore
 from .utils import logger
+
+
+DEFAULT_HISTORY_TABLE = "chat_history"
+DEFAULT_DATABASE = "llm.db"
+DEFAULT_THREAD_ID = "default"
+
+
+@runtime_checkable
+class MessagePersistence(Protocol):
+    """Backend interface for persisting chat messages"""
+
+    def load(self, limit: Optional[int] = None) -> List[BaseMessage]:
+        """Return persisted messages, most-recent last.
+        `limit` caps how many of the most recent ones are returned (None = all)."""
+        ...
+
+    def append(self, messages: List[BaseMessage]) -> None:
+        """Persist `messages` in order."""
+        ...
+
+    def clear(self) -> None:
+        """Remove all persisted messages owned by this store."""
+        ...
+
+
+class SQLMessagePersistence:
+    """Chat message persistence store backed by a SQLite table via the SQLStore brick.
+    Messages are keyed by `thread_id` to track separate conversations.
+    """
+
+    def __init__(
+        self,
+        sql_store: Optional[SQLStore] = None,
+        thread_id: str = DEFAULT_THREAD_ID,
+        table_name: str = DEFAULT_HISTORY_TABLE,
+    ):
+        """Initialize the store backend.
+
+        Args:
+            sql_store (SQLStore | None): An already-instantiated SQLStore brick.
+                If None, a default `SQLStore("llm.db")` is created.
+            thread_id (str): Identifier for the conversation thread. Use distinct values
+                to keep separate conversations in the same database.
+            table_name (str): Name of the table that stores serialized messages.
+        """
+
+        self._sql_store = sql_store if sql_store is not None else SQLStore(DEFAULT_DATABASE)
+        self._sql_store.start()
+        self._thread_id = thread_id
+        self._table_name = table_name
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        self._sql_store.create_table(
+            self._table_name,
+            {
+                "id": "INTEGER PRIMARY KEY AUTOINCREMENT",
+                "thread_id": "TEXT NOT NULL",
+                "message_data": "TEXT NOT NULL",
+            },
+        )
+
+    def load(self, limit: Optional[int] = None) -> List[BaseMessage]:
+        """Return persisted messages in chronological order, capped to the last `limit`."""
+        if limit is not None and limit <= 0:
+            return []
+
+        sql = f"SELECT message_data FROM {self._table_name} WHERE thread_id = ? ORDER BY id DESC"
+        params: tuple = (self._thread_id,)
+        if limit is not None:
+            sql += " LIMIT ?"
+            params = (self._thread_id, limit)
+
+        rows = self._sql_store.execute_sql(sql, params)
+        if not rows:
+            return []
+
+        try:
+            dicts = [json.loads(row["message_data"]) for row in reversed(rows)]
+            return messages_from_dict(dicts)
+        except (json.JSONDecodeError, KeyError, ValueError) as e:
+            logger.error(f"Failed to deserialize persisted messages for thread '{self._thread_id}': {e}")
+            return []
+
+    def append(self, messages: List[BaseMessage]) -> None:
+        if not messages:
+            return
+
+        for message, payload in zip(messages, messages_to_dict(messages)):
+            try:
+                serialized = json.dumps(payload)
+            except (TypeError, ValueError) as e:
+                logger.error(f"Failed to serialize message of type {type(message).__name__}: {e}")
+                continue
+
+            self._sql_store.store(
+                self._table_name,
+                {"thread_id": self._thread_id, "message_data": serialized},
+                create_table=False,
+            )
+
+    def clear(self) -> None:
+        self._sql_store.execute_sql(
+            f"DELETE FROM {self._table_name} WHERE thread_id = ?",
+            (self._thread_id,),
+        )
 
 
 class WindowedChatMessageHistory:
@@ -13,21 +122,23 @@ class WindowedChatMessageHistory:
 
     k: int
 
-    def __init__(self, k: int, system_message: str = ""):
+    def __init__(self, k: int, system_message: str = "", store: Optional[MessagePersistence] = None):
         self.k = k
         self._messages: list[BaseMessage] = []
-        if system_message != "":
-            self._system_message = SystemMessage(content=system_message)
-        else:
-            self._system_message = None
+        self._system_message = SystemMessage(content=system_message) if system_message else None
+        self._store = store
 
-    def add_messages(self, messages: List[BaseMessage]) -> None:
+        if store is not None and k > 0:
+            # Fetch a margin above k so the windowing logic can back up over
+            # tool-call boundaries without dropping context.
+            self._apply_window(store.load(limit=k * 2))
+
+    def _apply_window(self, messages: List[BaseMessage]) -> None:
+        """Append messages to the in-memory cache and enforce the window. No persistence."""
         if self.k == 0:
-            # No memory
             return
 
-        for message in messages:
-            self._messages.append(message)
+        self._messages.extend(messages)
 
         if len(self._messages) > self.k:
             start = len(self._messages) - self.k
@@ -42,20 +153,26 @@ class WindowedChatMessageHistory:
 
             self._messages = self._messages[start:]
 
+    def add_messages(self, messages: List[BaseMessage]) -> None:
+        if self.k == 0:
+            return
+
+        if self._store is not None:
+            self._store.append(messages)
+
+        self._apply_window(messages)
+
     def get_messages(self) -> List[BaseMessage]:
         """Get all messages in the history, including system message if set."""
         if self.k == 0:
-            # No memory
-            if self._system_message:
-                return [self._system_message]
-            else:
-                return []
+            return [self._system_message] if self._system_message else []
 
         if self._system_message:
             return [self._system_message] + self._messages
-        else:
-            return self._messages.copy()
+        return self._messages.copy()
 
     def clear(self) -> None:
-        """Clear the message history."""
+        """Clear the in-memory window and any persisted backend for this history."""
         self._messages = []
+        if self._store is not None:
+            self._store.clear()

--- a/src/arduino/app_bricks/llm/examples/05_persistent_memory.py
+++ b/src/arduino/app_bricks/llm/examples/05_persistent_memory.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# EXAMPLE_NAME = "Local LLM chat with persistent memory"
+# EXAMPLE_REQUIRES = "Local LLM models available and the dbstorage_sqlstore brick."
+
+from arduino.app_bricks.cloud_llm import SQLMessagePersistence
+from arduino.app_bricks.dbstorage_sqlstore import SQLStore
+from arduino.app_bricks.llm import LargeLanguageModel
+from arduino.app_utils import App
+
+db = SQLStore("llm_persistent_demo.db")
+db.start()
+
+llm = LargeLanguageModel(
+    system_prompt="You are a helpful assistant.",
+).with_memory(
+    max_messages=10,
+    persistence=SQLMessagePersistence(sql_store=db, thread_id="llm-demo-conversation"),
+)
+
+
+def ask_prompt():
+    prompt = input("Enter your prompt (or 'exit' to quit, 'forget' to clear history): ")
+    if prompt.lower() == "exit":
+        raise StopIteration()
+    if prompt.lower() == "forget":
+        llm.clear_memory()
+        print("Memory cleared for this thread.")
+        return
+    print(llm.chat(prompt))
+
+
+App.run(ask_prompt)

--- a/src/arduino/app_bricks/llm/local_llm.py
+++ b/src/arduino/app_bricks/llm/local_llm.py
@@ -6,12 +6,13 @@ from langchain_core.language_models import BaseChatModel
 
 from arduino.app_bricks.cloud_llm import CloudLLM, CloudModelProvider
 from arduino.app_bricks.cloud_llm.cloud_llm import DEFAULT_MEMORY
+from arduino.app_bricks.cloud_llm.memory import MessagePersistence
 from arduino.app_utils import Logger, brick
 from arduino.app_internal.core import resolve_address, get_brick_config, get_brick_configured_model
 
 import os
 from openai import OpenAI, APIError, BadRequestError
-from typing import Iterator, List, Optional, Any, Callable
+from typing import Iterator, List, Optional, Any, Callable, Union
 
 logger = Logger("LargeLanguageModel")
 
@@ -152,21 +153,28 @@ class LargeLanguageModel(CloudLLM):
             logger.warning(f"Failed to list models: {e}")
             return []
 
-    def with_memory(self, max_messages: int = DEFAULT_MEMORY) -> "LargeLanguageModel":
+    def with_memory(
+        self,
+        max_messages: int = DEFAULT_MEMORY,
+        persistence: Union[bool, MessagePersistence, None] = None,
+    ) -> "LargeLanguageModel":
         """Enables conversational memory for this instance.
 
         Configures the Brick to retain a window of previous messages, allowing the
-        AI to maintain context across multiple interactions.
+        AI to maintain context across multiple interactions. An optional persistence
+        backend stores the history so it can resume across restarts.
 
         Args:
-            max_messages (int): The maximum number of messages (user + AI) to keep
-                in history. Older messages are discarded. Set to 0 to disable memory.
-                Defaults to 10.
+            max_messages (int): The maximum number of messages.
+            persistence (bool | MessagePersistence | None): Optional persistence backend.
+                `None`/`False` for in-memory only, `True` for a default
+                `SQLMessagePersistence`, or any `MessagePersistence` instance for full
+                control.
 
         Returns:
             LargeLanguageModel: The current instance, allowing for method chaining.
         """
-        return super().with_memory(max_messages=max_messages)
+        return super().with_memory(max_messages=max_messages, persistence=persistence)
 
     def get_client(self) -> BaseChatModel:
         """Returns the underlying LangChain model instance.

--- a/src/arduino/app_bricks/vlm/examples/03_persistent_memory.py
+++ b/src/arduino/app_bricks/vlm/examples/03_persistent_memory.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# EXAMPLE_NAME = "Local VLM chat with persistent memory"
+# EXAMPLE_REQUIRES = "Local VLM models available and the dbstorage_sqlstore brick."
+
+from arduino.app_bricks.cloud_llm import SQLMessagePersistence
+from arduino.app_bricks.dbstorage_sqlstore import SQLStore
+from arduino.app_bricks.vlm import VisionLanguageModel
+from arduino.app_utils import App
+
+db = SQLStore("vlm_persistent_demo.db")
+db.start()
+
+vlm = VisionLanguageModel(
+    system_prompt="You are a helpful visual assistant.",
+).with_memory(
+    max_messages=10,
+    persistence=SQLMessagePersistence(sql_store=db, thread_id="vlm-demo-conversation"),
+)
+
+
+def ask_prompt():
+    prompt = input("Enter your prompt (or 'exit' to quit, 'forget' to clear history, 'image' to include chair.jpg): ")
+    if prompt.lower() == "exit":
+        raise StopIteration()
+    if prompt.lower() == "forget":
+        vlm.clear_memory()
+        print("Memory cleared for this thread.")
+        return
+
+    images = ["chair.jpg"] if prompt.lower() == "image" else None
+    message = "Describe the image and remember relevant visual details." if images else prompt
+    print(vlm.chat(message, images=images))
+
+
+App.run(ask_prompt)

--- a/src/arduino/app_bricks/vlm/local_vlm.py
+++ b/src/arduino/app_bricks/vlm/local_vlm.py
@@ -4,13 +4,14 @@
 
 from langchain_core.language_models import BaseChatModel
 
+from arduino.app_bricks.cloud_llm.memory import MessagePersistence
 from arduino.app_bricks.llm import LargeLanguageModel
 from arduino.app_utils import Logger, brick
 from arduino.app_internal.core import get_brick_config, get_brick_configured_model
 
 import os
 import openai
-from typing import Iterator, List, Optional, Any, Callable
+from typing import Iterator, List, Optional, Any, Callable, Union
 
 logger = Logger("VisionLanguageModel")
 
@@ -149,18 +150,25 @@ class VisionLanguageModel(LargeLanguageModel):
         """
         super().clear_memory()
 
-    def with_memory(self, max_messages: int = 0) -> "VisionLanguageModel":
+    def with_memory(
+        self,
+        max_messages: int = 0,
+        persistence: Union[bool, MessagePersistence, None] = None,
+    ) -> "VisionLanguageModel":
         """Enables conversational memory for this instance.
 
         Configures the Brick to retain a window of previous messages, allowing the
-        AI to maintain context across multiple interactions.
+        AI to maintain context across multiple interactions. An optional persistence
+        backend stores the history so it can resume across restarts.
 
         Args:
-            max_messages (int): The maximum number of messages (user + AI) to keep
-                in history. Older messages are discarded. Set to 0 to disable memory.
-                Defaults to 0.
+            max_messages (int): The maximum number of messages.
+            persistence (bool | MessagePersistence | None): Optional persistence backend.
+                `None` or `False` keep history in memory only (default behavior).
+                `True` instantiates the default SQL-backed store. Pass a
+                `MessagePersistence` implementation directly for full control.
 
         Returns:
             VisionLanguageModel: The current instance, allowing for method chaining.
         """
-        return super().with_memory(max_messages=max_messages)
+        return super().with_memory(max_messages=max_messages, persistence=persistence)

--- a/tests/arduino/app_bricks/cloud_llm/test_persistent_memory.py
+++ b/tests/arduino/app_bricks/cloud_llm/test_persistent_memory.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import gc
+import os
+import tempfile
+import time
+from unittest.mock import patch
+
+import pytest
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+
+from arduino.app_bricks.cloud_llm.memory import (
+    DEFAULT_DATABASE,
+    DEFAULT_HISTORY_TABLE,
+    DEFAULT_THREAD_ID,
+    SQLMessagePersistence,
+    WindowedChatMessageHistory,
+)
+from arduino.app_bricks.dbstorage_sqlstore import SQLStore
+
+
+@pytest.fixture
+def sql_store():
+    """Provide an open SQLStore backed by a temporary file."""
+    with tempfile.TemporaryDirectory() as tmpdir, patch("os.makedirs"):
+        db = SQLStore(database_name="chat_memory_test")
+        db_path = os.path.join(tmpdir, "chat_memory_test.db")
+        db.database_name = db_path
+        db.start()
+        yield db
+        db.stop()
+        gc.collect()
+        for _ in range(30):
+            try:
+                os.remove(db_path)
+                break
+            except (PermissionError, FileNotFoundError):
+                time.sleep(0.1)
+
+
+# --- SQLMessagePersistence -----------------------------------------------------
+
+
+def test_store_append_and_load_round_trip(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="thread-A")
+    store.append([HumanMessage(content="hi"), AIMessage(content="hello")])
+
+    loaded = store.load()
+    assert [type(m).__name__ for m in loaded] == ["HumanMessage", "AIMessage"]
+    assert loaded[0].content == "hi"
+    assert loaded[1].content == "hello"
+
+
+def test_store_default_uses_dedicated_database_and_thread():
+    with patch("arduino.app_bricks.dbstorage_sqlstore.SQLStore") as mock_sql_store:
+        sql_store = mock_sql_store.return_value
+
+        store = SQLMessagePersistence()
+
+        mock_sql_store.assert_called_once_with(DEFAULT_DATABASE)
+        sql_store.start.assert_called_once_with()
+        sql_store.create_table.assert_called_once()
+        assert store._thread_id == DEFAULT_THREAD_ID
+
+
+def test_store_thread_id_isolates_conversations(sql_store):
+    SQLMessagePersistence(sql_store=sql_store, thread_id="alice").append([HumanMessage(content="alice msg")])
+    SQLMessagePersistence(sql_store=sql_store, thread_id="bob").append([HumanMessage(content="bob msg")])
+
+    alice = SQLMessagePersistence(sql_store=sql_store, thread_id="alice").load()
+    bob = SQLMessagePersistence(sql_store=sql_store, thread_id="bob").load()
+
+    assert [m.content for m in alice] == ["alice msg"]
+    assert [m.content for m in bob] == ["bob msg"]
+
+
+def test_store_preserves_tool_calls_round_trip(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="tools")
+    store.append([
+        HumanMessage(content="weather in Turin?"),
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "get_weather", "args": {"city": "Turin"}, "id": "call-1", "type": "tool_call"}],
+        ),
+        ToolMessage(content="sunny, 22C", tool_call_id="call-1"),
+        AIMessage(content="It's sunny and 22C in Turin."),
+    ])
+
+    loaded = store.load()
+    assert len(loaded) == 4
+
+    ai = loaded[1]
+    assert isinstance(ai, AIMessage)
+    assert ai.tool_calls and ai.tool_calls[0]["name"] == "get_weather"
+    assert ai.tool_calls[0]["args"] == {"city": "Turin"}
+
+    tool_msg = loaded[2]
+    assert isinstance(tool_msg, ToolMessage)
+    assert tool_msg.tool_call_id == "call-1"
+    assert tool_msg.content == "sunny, 22C"
+
+
+def test_store_load_with_limit(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="lim")
+    for i in range(10):
+        store.append([HumanMessage(content=f"q{i}")])
+
+    last3 = store.load(limit=3)
+    assert [m.content for m in last3] == ["q7", "q8", "q9"]
+
+
+def test_store_clear_only_affects_thread(sql_store):
+    SQLMessagePersistence(sql_store=sql_store, thread_id="keep").append([HumanMessage(content="keep me")])
+    target = SQLMessagePersistence(sql_store=sql_store, thread_id="wipe")
+    target.append([HumanMessage(content="to be wiped")])
+
+    target.clear()
+
+    assert target.load() == []
+    assert [m.content for m in SQLMessagePersistence(sql_store=sql_store, thread_id="keep").load()] == ["keep me"]
+
+
+def test_store_custom_table_name(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="custom", table_name="alt_chat")
+    store.append([HumanMessage(content="hi")])
+
+    rows = sql_store.execute_sql("SELECT COUNT(*) AS c FROM alt_chat WHERE thread_id = ?", ("custom",))
+    assert rows[0]["c"] == 1
+
+
+# --- WindowedChatMessageHistory with a store --------------------------------
+
+
+def test_history_persists_via_store(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="hist")
+    h1 = WindowedChatMessageHistory(k=10, store=store)
+    h1.add_messages([HumanMessage(content="hi"), AIMessage(content="hello")])
+
+    h2 = WindowedChatMessageHistory(k=10, store=SQLMessagePersistence(sql_store=sql_store, thread_id="hist"))
+    msgs = h2.get_messages()
+
+    assert [type(m).__name__ for m in msgs] == ["HumanMessage", "AIMessage"]
+    assert [m.content for m in msgs] == ["hi", "hello"]
+
+
+def test_history_window_limits_in_memory_but_store_keeps_all(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="window")
+    history = WindowedChatMessageHistory(k=4, store=store)
+    for i in range(8):
+        history.add_messages([HumanMessage(content=f"q{i}"), AIMessage(content=f"a{i}")])
+
+    in_memory = history.get_messages()
+    assert len(in_memory) == 4
+    assert [m.content for m in in_memory] == ["q6", "a6", "q7", "a7"]
+
+    rows = sql_store.execute_sql(
+        f"SELECT COUNT(*) AS c FROM {DEFAULT_HISTORY_TABLE} WHERE thread_id = ?",
+        ("window",),
+    )
+    assert rows[0]["c"] == 16
+
+
+def test_history_reload_respects_window_size(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="reload")
+    seed = WindowedChatMessageHistory(k=100, store=store)
+    for i in range(20):
+        seed.add_messages([HumanMessage(content=f"q{i}"), AIMessage(content=f"a{i}")])
+
+    reloaded = WindowedChatMessageHistory(k=4, store=SQLMessagePersistence(sql_store=sql_store, thread_id="reload"))
+    msgs = reloaded.get_messages()
+    assert len(msgs) == 4
+    assert [m.content for m in msgs] == ["q18", "a18", "q19", "a19"]
+
+
+def test_history_clear_wipes_store(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="wipeme")
+    history = WindowedChatMessageHistory(k=10, store=store)
+    history.add_messages([HumanMessage(content="A"), AIMessage(content="B")])
+
+    history.clear()
+
+    assert history.get_messages() == []
+    assert store.load() == []
+
+
+def test_history_system_prompt_is_not_persisted(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="sysprompt")
+    h = WindowedChatMessageHistory(k=10, system_message="You are an assistant.", store=store)
+    h.add_messages([HumanMessage(content="hi"), AIMessage(content="hello")])
+
+    reloaded = WindowedChatMessageHistory(
+        k=10,
+        system_message="You are an assistant.",
+        store=SQLMessagePersistence(sql_store=sql_store, thread_id="sysprompt"),
+    )
+    msgs = reloaded.get_messages()
+    assert isinstance(msgs[0], SystemMessage)
+    assert sum(isinstance(m, SystemMessage) for m in msgs) == 1
+    assert [type(m).__name__ for m in msgs[1:]] == ["HumanMessage", "AIMessage"]
+
+    rows = sql_store.execute_sql(
+        f"SELECT message_data FROM {DEFAULT_HISTORY_TABLE} WHERE thread_id = ?",
+        ("sysprompt",),
+    )
+    assert all('"type": "system"' not in row["message_data"] for row in rows)
+
+
+def test_history_k_zero_disables_memory_and_persistence(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="off")
+    history = WindowedChatMessageHistory(k=0, store=store)
+    history.add_messages([HumanMessage(content="should not be saved")])
+
+    assert history.get_messages() == []
+    rows = sql_store.execute_sql(
+        f"SELECT COUNT(*) AS c FROM {DEFAULT_HISTORY_TABLE} WHERE thread_id = ?",
+        ("off",),
+    )
+    assert rows[0]["c"] == 0
+
+
+def test_history_without_store_is_in_memory_only():
+    history = WindowedChatMessageHistory(k=10)
+    history.add_messages([HumanMessage(content="hi"), AIMessage(content="hello")])
+    assert [m.content for m in history.get_messages()] == ["hi", "hello"]
+
+
+# --- CloudLLM.with_memory wiring --------------------------------------------
+
+
+def _bare_llm(system_prompt: str = ""):
+    """Build a CloudLLM without going through __init__ (which needs a real API key)."""
+    from arduino.app_bricks.cloud_llm import CloudLLM
+
+    llm = CloudLLM.__new__(CloudLLM)
+    llm._system_prompt = system_prompt
+    llm._max_messages = 0
+    return llm
+
+
+def test_with_memory_default_is_in_memory_only():
+    llm = _bare_llm()
+    llm.with_memory(max_messages=5)
+    assert isinstance(llm._history, WindowedChatMessageHistory)
+    assert llm._history._store is None
+
+
+def test_with_memory_persistence_true_uses_default_sql_backend(sql_store):
+    """persistence=True must instantiate SQLMessagePersistence with default args."""
+    llm = _bare_llm()
+    with patch("arduino.app_bricks.cloud_llm.cloud_llm.SQLMessagePersistence") as mock_store:
+        mock_store.return_value = SQLMessagePersistence(sql_store=sql_store, thread_id=DEFAULT_THREAD_ID)
+        llm.with_memory(max_messages=5, persistence=True)
+        mock_store.assert_called_once_with()
+    assert isinstance(llm._history._store, SQLMessagePersistence)
+
+
+def test_with_memory_accepts_store_instance(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="user-42")
+    llm = _bare_llm(system_prompt="You are helpful.")
+    llm.with_memory(max_messages=10, persistence=store)
+
+    llm._history.add_messages([HumanMessage(content="hi"), AIMessage(content="hello")])
+
+    # New brick session: should reload prior messages from the same thread.
+    llm2 = _bare_llm(system_prompt="You are helpful.")
+    llm2.with_memory(max_messages=10, persistence=SQLMessagePersistence(sql_store=sql_store, thread_id="user-42"))
+
+    msgs: list[BaseMessage] = llm2._history.get_messages()
+    contents = [m.content for m in msgs if not isinstance(m, SystemMessage)]
+    assert contents == ["hi", "hello"]
+    assert any(isinstance(m, SystemMessage) and m.content == "You are helpful." for m in msgs)
+
+
+def test_with_memory_persistence_false_is_treated_as_none():
+    llm = _bare_llm()
+    llm.with_memory(max_messages=5, persistence=False)
+    assert llm._history._store is None

--- a/tests/arduino/app_bricks/vlm/test_persistent_memory.py
+++ b/tests/arduino/app_bricks/vlm/test_persistent_memory.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import gc
+import os
+import tempfile
+import time
+from unittest.mock import patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from arduino.app_bricks.cloud_llm.memory import DEFAULT_THREAD_ID, SQLMessagePersistence, WindowedChatMessageHistory
+from arduino.app_bricks.dbstorage_sqlstore import SQLStore
+from arduino.app_bricks.vlm import VisionLanguageModel
+
+
+@pytest.fixture
+def sql_store():
+    """Provide an open SQLStore backed by a temporary file."""
+    with tempfile.TemporaryDirectory() as tmpdir, patch("os.makedirs"):
+        db = SQLStore(database_name="vlm_memory_test")
+        db_path = os.path.join(tmpdir, "vlm_memory_test.db")
+        db.database_name = db_path
+        db.start()
+        yield db
+        db.stop()
+        gc.collect()
+        for _ in range(30):
+            try:
+                os.remove(db_path)
+                break
+            except (PermissionError, FileNotFoundError):
+                time.sleep(0.1)
+
+
+def _bare_vlm(system_prompt: str = ""):
+    """Build a VisionLanguageModel without going through __init__."""
+    vlm = VisionLanguageModel.__new__(VisionLanguageModel)
+    vlm._system_prompt = system_prompt
+    vlm._max_messages = 0
+    return vlm
+
+
+def test_vlm_with_memory_default_is_in_memory_only():
+    vlm = _bare_vlm()
+    vlm.with_memory(max_messages=5)
+
+    assert isinstance(vlm._history, WindowedChatMessageHistory)
+    assert vlm._history._store is None
+
+
+def test_vlm_with_memory_persistence_true_uses_default_sql_backend(sql_store):
+    vlm = _bare_vlm()
+    with patch("arduino.app_bricks.cloud_llm.cloud_llm.SQLMessagePersistence") as mock_store:
+        mock_store.return_value = SQLMessagePersistence(sql_store=sql_store, thread_id=DEFAULT_THREAD_ID)
+        vlm.with_memory(max_messages=5, persistence=True)
+        mock_store.assert_called_once_with()
+
+    assert isinstance(vlm._history._store, SQLMessagePersistence)
+
+
+def test_vlm_with_memory_accepts_store_instance(sql_store):
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="vision-session")
+    vlm = _bare_vlm(system_prompt="You are a visual assistant.")
+    vlm.with_memory(max_messages=10, persistence=store)
+
+    vlm._history.add_messages([HumanMessage(content="Remember this image."), AIMessage(content="I will remember it.")])
+
+    reloaded = _bare_vlm(system_prompt="You are a visual assistant.")
+    reloaded.with_memory(max_messages=10, persistence=SQLMessagePersistence(sql_store=sql_store, thread_id="vision-session"))
+
+    contents = [m.content for m in reloaded._history.get_messages()]
+    assert "Remember this image." in contents
+    assert "I will remember it." in contents
+
+
+def test_sql_store_preserves_multimodal_image_url_message(sql_store):
+    content = [
+        {"type": "text", "text": "Describe this image."},
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,ZmFrZQ=="}},
+    ]
+    store = SQLMessagePersistence(sql_store=sql_store, thread_id="vision-image")
+
+    store.append([HumanMessage(content=content), AIMessage(content="It looks like a chair.")])
+
+    loaded = store.load()
+    assert loaded[0].content == content
+    assert loaded[1].content == "It looks like a chair."


### PR DESCRIPTION
Add optional persistent conversation memory to the `cloud_llm`, `llm`, and `vlm` bricks via a `MessagePersistence` protocol and a default sql store (SQLMessagePersistence), keyed by thread_id. The windowed history now reloads prior messages on startup, so conversations resume across restarts.
llm and vlm inherit the behavior from cloud_llm.