### PR TITLE
fix: enhance AppController to support framework-managed lifecycle

### DIFF
--- a/src/arduino/app_utils/app.py
+++ b/src/arduino/app_utils/app.py
@@ -31,6 +31,7 @@ class AppController:
         self._running_queue = deque()
         self._brick_states: dict[any, list[tuple[threading.Thread, threading.Event]]] = {}
         self._app_lock = threading.Lock()
+        self._running = False
 
     def register(self, brick):
         """Registers a brick for being managed automatically by the AppController.
@@ -93,15 +94,55 @@ class AppController:
 
         If a user_loop callable is provided, it will be executed instead of the default infinite loop.
 
+        When running inside a framework that manages the process lifecycle (e.g. Streamlit),
+        bricks are started but the blocking loop is skipped. The framework is responsible for
+        keeping the process alive; brick daemon threads terminate automatically with the process.
+
         Args:
             user_loop (callable, optional): A user-defined function to run instead of the default infinite loop.
         """
+        # Idempotent: if already running (e.g. Streamlit re-runs the script), just return.
+        if self._running:
+            return
+
+        self._running = True
         self._start_managed_bricks()
         logger.info("App started")
+
+        if self._is_framework_managed():
+            logger.info("Running in framework-managed mode (process lifecycle handled externally)")
+            return
+
         self.loop(user_loop)
+        self._shutdown()
+
+    def _shutdown(self):
+        """Performs a clean shutdown of all bricks."""
+        if not self._running:
+            return
         logger.info("App is shutting down")
         self._stop_all_bricks()
+        self._running = False
         print("======== App shutdown completed =====================", flush=True)
+
+    def _is_framework_managed(self) -> bool:
+        """Detect if running inside a framework that manages the process lifecycle.
+
+        Returns True when the script is being executed in a worker thread by a framework
+        like Streamlit, which owns the main thread and the process lifecycle.
+        """
+        if threading.current_thread() is threading.main_thread():
+            return False
+
+        # Explicitly detect Streamlit's ScriptRunContext (definitive signal)
+        try:
+            from streamlit.runtime.scriptrunner import get_script_run_ctx
+            if get_script_run_ctx(suppress_warning=True) is not None:
+                return True
+        except ImportError:
+            pass
+
+        return False
 
     def loop(self, user_loop: callable = None):
         """This method keeps the application running, blocking until a KeyboardInterrupt (Ctrl+C) occurs.
@@ -119,7 +160,8 @@ class AppController:
         def handle_sigterm(signum, frame):
             raise SigtermReceived
 
-        signal.signal(signal.SIGTERM, handle_sigterm)
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGTERM, handle_sigterm)
 
         try:
             if user_loop:

--- a/src/arduino/app_utils/app.py
+++ b/src/arduino/app_utils/app.py
@@ -137,6 +137,7 @@ class AppController:
         # Explicitly detect Streamlit's ScriptRunContext (definitive signal)
         try:
             from streamlit.runtime.scriptrunner import get_script_run_ctx
+
             if get_script_run_ctx(suppress_warning=True) is not None:
                 return True
         except ImportError:


### PR DESCRIPTION
## Make `App.run()` compatible with Streamlit's execution model

### Problem

When using the `streamlit_ui` brick, `streamlit run` takes ownership of the main thread and executes user scripts in worker threads. This caused `App.run()` to crash with:

```
ValueError: signal only works in main thread of the main interpreter
```

Additionally, `App.run()`'s blocking loop would hang the Streamlit script thread indefinitely if the signal issue were bypassed.

### Solution

Add framework-aware lifecycle management to `AppController` without altering the behavior for non-Streamlit apps:

1. **`_is_framework_managed()`** — Explicitly detects Streamlit by checking for `ScriptRunContext` on the current thread. Returns `False` in all other cases (including non-main threads without Streamlit), preserving existing behavior.

2. **Idempotent `run()`** — A `_running` flag prevents duplicate startups when Streamlit re-executes the script on user interaction.

3. **Conditional signal registration** — `signal.signal(SIGTERM, ...)` in `loop()` is only installed when running on the main thread.

4. **No `atexit` needed** — The orchestrator (`docker compose stop --timeout=5`) sends SIGTERM to the container process (Streamlit). All brick threads are daemon threads and terminate automatically with the process.

### Behavior matrix

| Scenario | Behavior |
|----------|----------|
| `python main.py` (normal) | Unchanged: start bricks → blocking loop → SIGTERM → orderly shutdown |
| `streamlit run main.py` (1st run) | Start bricks → detect framework → return immediately |
| `streamlit run main.py` (re-runs) | Idempotent no-op |
| Container shutdown (SIGTERM) | Streamlit exits → daemon threads die with process |

### Changed files

- `src/arduino/app_utils/app.py`
