### PR TITLE
fix: model download cleanup partial files

### DIFF
--- a/containers/models-downloader/src/ai_hub/ai_hub_model_downloader.sh
+++ b/containers/models-downloader/src/ai_hub/ai_hub_model_downloader.sh
@@ -4,10 +4,9 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-
-if [ -d "/models/${model_directory}" ]; then
-    echo "{\"event\": \"info\", \"description\": \"Model exists: ${model_directory}\"}"
-    exit 0
+# Clear any stale/partial download before fetching.
+if [ -n "${model_directory}" ] && [ -d "/models/${model_directory}" ]; then
+    rm -fr "/models/${model_directory}"
 fi
 
 cd /models

--- a/containers/models-downloader/src/edge_impulse/ei_model_downloader.sh
+++ b/containers/models-downloader/src/edge_impulse/ei_model_downloader.sh
@@ -9,6 +9,11 @@ if [ -n "${quantization}" ]; then
     quantization_arg=(--quantization "${quantization}")
 fi
 
+# Clear any stale/partial download before fetching.
+if [ -n "${model_name}" ] && [ -f "/models/${model_name}" ]; then
+    rm -f "/models/${model_name}"
+fi
+
 python /app/edge_impulse/download_ei_build.py \
     --ei-project-id "${ei_project_id}" \
     --impulse-id "${ei_impulse_id}" \

--- a/containers/models-downloader/src/hugging_face/hf_model_downloader.sh
+++ b/containers/models-downloader/src/hugging_face/hf_model_downloader.sh
@@ -4,6 +4,20 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+# Clear any stale/partial download under /models/<repo_id>/ before fetching.
+repo_id=""
+if [ -n "${model_repo_id}" ]; then
+    repo_id="${model_repo_id}"
+elif [ -n "${model_key}" ]; then
+    repo_id="$(echo "${model_key}" | cut -d: -f2)"
+elif [ -n "${model_url}" ]; then
+    repo_id="$(echo "${model_url}" | sed -nE 's#https?://huggingface\.co/([^/]+/[^/]+)/(resolve|blob)/.+#\1#p')"
+fi
+
+if [ -n "${repo_id}" ] && [ -d "/models/${repo_id}" ]; then
+    rm -fr "/models/${repo_id}"
+fi
+
 if [ -n "${model_key}" ]; then
     python /app/hugging_face/hf_downloader.py \
         --model-key "${model_key}" \


### PR DESCRIPTION
Ensure partial files are removed before downloading the model. In this way, the download will always succeed, and we can implement a resume mechanism later.