### PR TITLE
fix: ensure correct provider name for local llm

### DIFF
--- a/src/arduino/app_bricks/llm/local_llm.py
+++ b/src/arduino/app_bricks/llm/local_llm.py
@@ -107,6 +107,7 @@ class LargeLanguageModel(CloudLLM):
 
             base_url = f"http://{host}:{port}/v1"
 
+        local_model_name = model
         if model.startswith(self.GENIE_MODEL) or model.startswith(self.LLAMACPP_MODEL) or model.startswith(self.OLLAMA_MODEL):
             model = model.split(":")[-1]  # Extract model name without provider prefix
 
@@ -127,6 +128,7 @@ class LargeLanguageModel(CloudLLM):
             max_tokens=max_tokens,
             **kwargs,
         )
+        self._model_name = local_model_name
 
         available_models = self.list_models()
         if plain_model_name not in available_models:

--- a/tests/arduino/app_bricks/llm/test_local_llm_stream_logging.py
+++ b/tests/arduino/app_bricks/llm/test_local_llm_stream_logging.py
@@ -7,13 +7,48 @@ from unittest.mock import patch
 
 import pytest
 
+import arduino.app_bricks.cloud_llm.cloud_llm as cloud_llm_module
 import arduino.app_bricks.llm.local_llm as local_llm_module
+from arduino.app_bricks.cloud_llm import CloudLLM
 from arduino.app_bricks.llm.local_llm import LargeLanguageModel
 
 
 class FailingStreamModel:
     def stream(self, *_args, **_kwargs):
         raise ValueError("provider exploded")
+
+
+class EmptyHistory:
+    def get_messages(self):
+        return []
+
+    def add_messages(self, _messages):
+        pass
+
+
+def test_local_llm_logs_local_model_name_while_using_openai_compatible_adapter():
+    captured_model = None
+
+    def fake_cloud_llm_init(self, **kwargs):
+        nonlocal captured_model
+        captured_model = kwargs["model"]
+        self._model_name = kwargs["model"]
+        self._model_loaded = False
+        self._history = EmptyHistory()
+
+    with (
+        patch.object(CloudLLM, "__init__", fake_cloud_llm_init),
+        patch.object(LargeLanguageModel, "list_models", return_value=["qwen3_4b_instruct_2507"]),
+    ):
+        llm = LargeLanguageModel(model="genie:qwen3_4b_instruct_2507")
+
+    assert captured_model == "openai:qwen3_4b_instruct_2507"
+    assert llm._model_name == "genie:qwen3_4b_instruct_2507"
+
+    with patch.object(cloud_llm_module.logger, "info") as log_info:
+        llm._get_message_with_history("hello")
+
+    log_info.assert_called_once_with("Initializing model genie:qwen3_4b_instruct_2507...")
 
 
 def test_local_llm_chat_stream_logs_non_api_errors_raised_during_iteration():


### PR DESCRIPTION
Fixes misleading local LLM startup logs that showed the internal OpenAI-compatible adapter prefix instead of the configured local provider.

The brick still uses the OpenAI-compatible LangChain adapter for local `/v1` endpoints, but now preserves the original local model name, so Genie models are logged as `genie:<model>` instead of `openai:<model>`.