### PR TITLE
fix: missing air quality monitoring brick in bricks' list

### DIFF
--- a/src/arduino/app_bricks/air_quality_monitoring/brick_config.yaml
+++ b/src/arduino/app_bricks/air_quality_monitoring/brick_config.yaml
@@ -1,4 +1,4 @@
 id: arduino:air_quality_monitoring
 name: Air Quality Monitoring
-module_description: "Online air quality monitoring module for Arduino using aqicn.org. Requires an internet connection."
+description: "Online air quality monitoring module for Arduino using aqicn.org. Requires an internet connection."
 category: miscellaneous


### PR DESCRIPTION
This PR fixes the `brick_config.yaml` where description field was obsolete and it caused missing provisioning for the brick itself in App Lab