### PR TITLE
fix(speaker): use stable node.name instead of id

### DIFF
--- a/src/arduino/app_peripherals/speaker/alsa_speaker.py
+++ b/src/arduino/app_peripherals/speaker/alsa_speaker.py
@@ -155,7 +155,7 @@ class ALSASpeaker(BaseSpeaker):
             logger.error(f"Error listing jack speakers: {e}")
             return []
 
-        return [f"pipewire:NODE={builtin_sinks[0]['id']}"] if builtin_sinks else []
+        return [f"pipewire:NODE={builtin_sinks[0]['info']['props']['node.name']}"] if builtin_sinks else []
 
     def _resolve_stable_ref(self, identifier: str | int) -> str:
         """


### PR DESCRIPTION
list_jack_devices() built the pipewire:NODE=<id> reference using the
PipeWire session-scoped numeric node id, but the ALSA pipewire plugin's
playback_node/\$NODE arg resolves via target.object matching against
node.name (or object.serial), not the plain id. A mismatched id fails
target resolution silently -- no error, PCM opens fine -- and the
stream falls back to whatever the current default sink is instead of
the intended built-in jack output.

Confirmed with aplay:
  aplay -D 'pipewire:NODE=57'                     -> lands on default sink
  aplay -D 'pipewire:NODE=<node.name>'             -> lands on correct sink"