### PR TITLE
fix: play_wav passing raw bytes to the speaker

### DIFF
--- a/src/arduino/app_bricks/sound_generator/__init__.py
+++ b/src/arduino/app_bricks/sound_generator/__init__.py
@@ -897,13 +897,26 @@ class SoundGenerator(SoundGeneratorStreamer):
     def play_wav(self, wav_file: str, block: bool = False):
         """Play a WAV audio file through the output device.
 
+        Only uncompressed PCM WAV files matching the output device configuration
+        (channels, sample rate, sample width) are supported.
+
         Args:
             wav_file (str): The WAV audio file path.
             block (bool): If True, block until the entire WAV file has been played.
         """
+        import wave
+
         self._ensure_speaker_ready()
-        to_play, duration = super().play_wav(wav_file)
-        self._output_device.play(to_play)
+        file_path = Path(wav_file)
+        if not file_path.exists() or not file_path.is_file():
+            raise FileNotFoundError(f"WAV file not found: {wav_file}")
+
+        with wave.open(wav_file, "rb") as wav:
+            duration = wav.getnframes() / wav.getframerate()
+
+        # Delegate WAV validation and PCM conversion to the output device
+        wav_audio = np.frombuffer(file_path.read_bytes(), dtype=np.uint8)
+        self._output_device.play_wav(wav_audio)
         if block and duration > 0.0:
             time.sleep(duration)
 

--- a/tests/arduino/app_bricks/sound_generator/test_play_wav.py
+++ b/tests/arduino/app_bricks/sound_generator/test_play_wav.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import wave
+
+import numpy as np
+import pytest
+
+from arduino.app_bricks.sound_generator import SoundGenerator
+
+
+class DummySpeaker:
+    sample_rate = 8000
+    buffer_size = 4096
+    shared = True
+
+    def __init__(self):
+        self.played = []
+
+    def play_wav(self, wav_audio):
+        self.played.append(wav_audio)
+
+
+def _write_wav(path, samples, sample_rate=8000):
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(samples.tobytes())
+
+
+def test_play_wav_delegates_wav_file_to_output_device(tmp_path):
+    wav_path = tmp_path / "tone.wav"
+    samples = (np.sin(np.linspace(0, 2 * np.pi * 440, 8000)) * 32767).astype(np.int16)
+    _write_wav(wav_path, samples)
+
+    speaker = DummySpeaker()
+    generator = SoundGenerator(output_device=speaker)
+    generator.play_wav(str(wav_path))
+
+    assert len(speaker.played) == 1
+    wav_audio = speaker.played[0]
+    assert isinstance(wav_audio, np.ndarray)
+    assert wav_audio.dtype == np.uint8
+    assert wav_audio.tobytes() == wav_path.read_bytes()
+
+
+def test_play_wav_missing_file_raises(tmp_path):
+    speaker = DummySpeaker()
+    generator = SoundGenerator(output_device=speaker)
+
+    with pytest.raises(FileNotFoundError):
+        generator.play_wav(str(tmp_path / "missing.wav"))
+
+    assert speaker.played == []


### PR DESCRIPTION
This PR fixes a `SoundGenerator.play_wav` method issue that causes:
```
Traceback (most recent call last):
File "/app/python/main.py", line 11, in <module>
player.play_wav("assets/sample.wav", block=True)
~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.13/site-packages/arduino/app_bricks/sound_generator/__init__.py", line 906, in play_wav
self._output_device.play(to_play)
~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
File "/usr/local/lib/python3.13/site-packages/arduino/app_peripherals/speaker/base_speaker.py", line 199, in play
if audio_chunk.dtype != self.format:
^^^^^^^^^^^^^^^^^
AttributeError: 'bytes' object has no attribute 'dtype'
exited with code 1 
```