### PR TITLE
fix(docs): correct default brightness_levels in Frame docstring

### DIFF
--- a/src/arduino/app_utils/ledmatrix.py
+++ b/src/arduino/app_utils/ledmatrix.py
@@ -19,7 +19,7 @@ class Frame:
 
         Args:
             arr (numpy.ndarray): numpy array of shape (8, 13) with integer values
-            brightness_levels (int): number of brightness levels (default 255)
+            brightness_levels (int): number of brightness levels (default 256)
         """
         self.height = 8
         self.width = 13


### PR DESCRIPTION
## Summary
Fixes a small inconsistency in the `Frame.__init__` docstring where the default value for `brightness_levels` was documented as `255` instead of `256`.

## Details
* The parameter definition defaults to `256` (`brightness_levels: int = 256`).
* The internal logic handles brightness levels in the range `2..256`.
* Updated the docstring text `(default 255)` to `(default 256)` to align with the actual implementation.