### PR TITLE
supporting pipewire default syntax

### DIFF
--- a/src/arduino/app_peripherals/microphone/alsa_microphone.py
+++ b/src/arduino/app_peripherals/microphone/alsa_microphone.py
@@ -188,7 +188,7 @@ class ALSAMicrophone(BaseMicrophone):
 
         # Complete device strings are opened as given
         if isinstance(identifier, str):
-            if identifier.startswith("pipewire:"):
+            if identifier.startswith("pipewire"):
                 return identifier
             if identifier.startswith("jack:"):
                 return self._resolve_jack_ref(identifier)
@@ -334,6 +334,8 @@ class ALSAMicrophone(BaseMicrophone):
             MicrophoneOpenError: If the device name can't be resolved
         """
         if isinstance(device_ref, str):
+            if device_ref == "pipewire":
+                return "pipewire"
             if device_ref.startswith("pipewire:"):
                 node_match = re.match(r"^pipewire:NODE=(.+)$", device_ref)
                 if node_match:
@@ -387,7 +389,7 @@ class ALSAMicrophone(BaseMicrophone):
         logger.debug(f"Opening PCM device: {self.device_stable_ref}")
 
         try:
-            direct_match = re.match(r"^pipewire:|^(plughw:|hw:)[^,]+,\d+,\d+$", self.device_stable_ref)
+            direct_match = re.match(r"^pipewire($|:)|^(plughw:|hw:)[^,]+,\d+,\d+$", self.device_stable_ref)
 
             if direct_match:
                 device = self.device_stable_ref
@@ -500,7 +502,7 @@ class ALSAMicrophone(BaseMicrophone):
 
     def _is_device_disconnected(self) -> bool:
         """Check if the device is still in the available devices list."""
-        if self.device_stable_ref.startswith("pipewire:"):
+        if self.device_stable_ref.startswith("pipewire"):
             # Built-in devices are always present
             return False
 

--- a/src/arduino/app_peripherals/microphone/microphone.py
+++ b/src/arduino/app_peripherals/microphone/microphone.py
@@ -166,6 +166,8 @@ class Microphone:
             microphone = Microphone("plughw:CARD=MyCard,DEV=0")
             microphone = Microphone("hw:0,0")
             microphone = Microphone("/dev/snd/by-id/usb-My-Device-00")  # Using device file path
+            microphone = Microphone("pipewire")  # To use default PipeWire microphone (if available)
+            microphone = Microphone("pipewire:NODE=MyPipewireNode")  # Using PipeWire node name
             ```
 
             WebSocket Microphone:

--- a/src/arduino/app_peripherals/speaker/alsa_speaker.py
+++ b/src/arduino/app_peripherals/speaker/alsa_speaker.py
@@ -189,7 +189,7 @@ class ALSASpeaker(BaseSpeaker):
 
         # Complete device strings are opened as given
         if isinstance(identifier, str):
-            if identifier.startswith("pipewire:"):
+            if identifier.startswith("pipewire"):
                 return identifier
             if identifier.startswith("jack:"):
                 return self._resolve_jack_ref(identifier)
@@ -335,6 +335,8 @@ class ALSASpeaker(BaseSpeaker):
             SpeakerOpenError: If the device name can't be resolved
         """
         if isinstance(device_ref, str):
+            if device_ref == "pipewire":
+                return "pipewire"
             if device_ref.startswith("pipewire:"):
                 node_match = re.match(r"^pipewire:NODE=(.+)$", device_ref)
                 if node_match:
@@ -388,7 +390,7 @@ class ALSASpeaker(BaseSpeaker):
         logger.debug(f"Opening PCM device: {self.device_stable_ref}")
 
         try:
-            direct_match = re.match(r"^pipewire:|^(plughw:|hw:)[^,]+,\d+,\d+$", self.device_stable_ref)
+            direct_match = re.match(r"^pipewire($|:)|^(plughw:|hw:)[^,]+,\d+,\d+$", self.device_stable_ref)
 
             if direct_match:
                 device = self.device_stable_ref
@@ -496,7 +498,7 @@ class ALSASpeaker(BaseSpeaker):
 
     def _is_device_disconnected(self) -> bool:
         """Check if the device is still in the available devices list."""
-        if self.device_stable_ref.startswith("pipewire:"):
+        if self.device_stable_ref.startswith("pipewire"):
             # Built-in devices are always present
             return False
 

--- a/src/arduino/app_peripherals/speaker/speaker.py
+++ b/src/arduino/app_peripherals/speaker/speaker.py
@@ -152,6 +152,8 @@ class Speaker:
             speaker = Speaker("plughw:CARD=USB,DEV=0")
             speaker = Speaker("hw:0,0", buffer_size=2048)
             speaker = Speaker("/dev/snd/by-id/usb-My-Device-00")  # Using device file path
+            speaker = Speaker("pipewire")  # To use default PipeWire speaker (if available)
+            speaker = Speaker("pipewire:NODE=MyPipewireNode")  # Using PipeWire node name
             ```
         """
         if not isinstance(device, (str, int)):

--- a/tests/arduino/app_peripherals/microphone/test_alsa_microphone.py
+++ b/tests/arduino/app_peripherals/microphone/test_alsa_microphone.py
@@ -428,3 +428,22 @@ class TestALSAMicrophoneJackResolution:
 
         mic.start()
         assert pcm_registry.get_last_instance().device == "pipewire:NODE=unknown.node"
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            "pipewire",  # Bare default PipeWire device
+            "pipewire:NODE=unknown.node",  # Explicit PipeWire node
+        ],
+    )
+    def test_pipewire_opens_as_direct_device(self, pcm_registry, device):
+        """Both the bare 'pipewire' string and 'pipewire:NODE=...' open as-is without runtime resolution."""
+        mic = ALSAMicrophone(device=device)
+        assert mic.device_stable_ref == device
+
+        mic.start()
+
+        # The stable ref is handed to ALSA verbatim, no plug_card_* remapping.
+        assert pcm_registry.get_last_instance().device == device
+        # PipeWire devices are always considered present.
+        assert mic._is_device_disconnected() is False

--- a/tests/arduino/app_peripherals/speaker/test_alsa_speaker.py
+++ b/tests/arduino/app_peripherals/speaker/test_alsa_speaker.py
@@ -448,3 +448,22 @@ class TestALSASpeakerJackResolution:
 
         spkr.start()
         assert pcm_registry.get_last_instance().device == "pipewire:NODE=unknown.node"
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            "pipewire",  # Bare default PipeWire device
+            "pipewire:NODE=unknown.node",  # Explicit PipeWire node
+        ],
+    )
+    def test_pipewire_opens_as_direct_device(self, pcm_registry, device):
+        """Both the bare 'pipewire' string and 'pipewire:NODE=...' open as-is without runtime resolution."""
+        spkr = ALSASpeaker(device=device)
+        assert spkr.device_stable_ref == device
+
+        spkr.start()
+
+        # The stable ref is handed to ALSA verbatim, no plug_card_* remapping.
+        assert pcm_registry.get_last_instance().device == device
+        # PipeWire devices are always considered present.
+        assert spkr._is_device_disconnected() is False


### PR DESCRIPTION
support "pipewire" default connection string to rely purely on pipewire default devices