### PR TITLE
CI: Examples alignment check

### DIFF
--- a/.github/workflows/check-examples-alignment.yml
+++ b/.github/workflows/check-examples-alignment.yml
@@ -89,13 +89,8 @@ jobs:
       - name: Run pyright against head
         run: python head/scripts/check_examples_alignment.py run --examples-dir examples --library-src head/src --python checkenv/bin/python --out head.json
 
-      - name: Report alignment diff
-        run: python head/scripts/check_examples_alignment.py diff --base base.json --head head.json
-
-      - name: Report bricks example coverage
-        run: python head/scripts/check_examples_alignment.py coverage --examples-dir examples --head-src head/src --base-src base/src
-
       - name: Upload run outputs
+        id: reports
         uses: actions/upload-artifact@v4
         with:
           name: examples-alignment-reports
@@ -103,3 +98,9 @@ jobs:
             base.json
             head.json
           retention-days: 15
+
+      - name: Report alignment diff
+        run: python head/scripts/check_examples_alignment.py diff --base base.json --head head.json --reports-url "${{ steps.reports.outputs.artifact-url }}"
+
+      - name: Report bricks example coverage
+        run: python head/scripts/check_examples_alignment.py coverage --examples-dir examples --head-src head/src --base-src base/src

--- a/.github/workflows/check-examples-alignment.yml
+++ b/.github/workflows/check-examples-alignment.yml
@@ -59,21 +59,26 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install system build dependencies
+        # Headers needed to compile the audio C extensions (pyalsaaudio, pyaudio),
+        # same packages installed by 'task install:deps'.
+        run: sudo apt-get update -q && sudo apt-get install -y -q --no-install-recommends libasound2-dev portaudio19-dev
+
       - name: Build check venv
         run: |
           python -m venv checkenv
-          # Runtime baseline of the app container. Tolerant per-package install:
-          # packages needing system libs may fail on the runner; pyright degrades
-          # the affected types to Unknown instead of producing false errors.
-          while IFS= read -r pkg; do
-            pkg="${pkg%%#*}"
-            [ -z "${pkg// /}" ] && continue
-            ./checkenv/bin/pip install -q "$pkg" || echo "::notice::baseline package not installed: $pkg"
-          done < head/containers/python-base/requirements-base.txt
           # Library dependencies (core + [all] extra), without the library itself:
           # pyright resolves the library from the base/head sources.
           python head/scripts/check_examples_alignment.py deps --pyproject head/pyproject.toml > library-deps.txt
-          ./checkenv/bin/pip install -q -r library-deps.txt
+          # Runtime baseline of the app container + library dependencies.
+          # Tolerant per-package install: a package that still fails to build on
+          # the runner only degrades the affected types to Unknown, it must not
+          # fail the job.
+          cat head/containers/python-base/requirements-base.txt library-deps.txt | while IFS= read -r pkg; do
+            pkg="${pkg%%#*}"
+            [ -z "${pkg// /}" ] && continue
+            ./checkenv/bin/pip install -q "$pkg" || echo "::notice::package not installed in the check venv: $pkg"
+          done
           # Per-example dependencies.
           find examples/bricks examples/core-and-foundational examples/inspirational \
             -path '*/python/requirements.txt' -exec ./checkenv/bin/pip install -q -r {} \;

--- a/.github/workflows/check-examples-alignment.yml
+++ b/.github/workflows/check-examples-alignment.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Report alignment diff
         run: python head/scripts/check_examples_alignment.py diff --base base.json --head head.json
 
+      - name: Report bricks example coverage
+        run: python head/scripts/check_examples_alignment.py coverage --examples-dir examples --head-src head/src --base-src base/src
+
       - name: Upload run outputs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/check-examples-alignment.yml
+++ b/.github/workflows/check-examples-alignment.yml
@@ -1,0 +1,97 @@
+name: Check examples alignment
+
+# Informative, non-blocking check: pyright analyzes the app-bricks-examples
+# Python code twice, resolving the library from the PR base and head sources,
+# and the diff of the two runs is reported in the job summary. New errors mean
+# this PR changes the API contract the published examples rely on.
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "pyproject.toml"
+      - "containers/python-base/requirements-base.txt"
+      - "scripts/check_examples_alignment.py"
+      - ".github/workflows/check-examples-alignment.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: examples-alignment-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.13"
+  NODE_VERSION: "22"
+
+jobs:
+  examples-alignment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: head
+
+      - name: Checkout PR base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: base
+
+      - name: Checkout examples
+        uses: actions/checkout@v4
+        with:
+          repository: arduino/app-bricks-examples
+          ref: main
+          path: examples
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Build check venv
+        run: |
+          python -m venv checkenv
+          # Runtime baseline of the app container. Tolerant per-package install:
+          # packages needing system libs may fail on the runner; pyright degrades
+          # the affected types to Unknown instead of producing false errors.
+          while IFS= read -r pkg; do
+            pkg="${pkg%%#*}"
+            [ -z "${pkg// /}" ] && continue
+            ./checkenv/bin/pip install -q "$pkg" || echo "::notice::baseline package not installed: $pkg"
+          done < head/containers/python-base/requirements-base.txt
+          # Library dependencies (core + [all] extra), without the library itself:
+          # pyright resolves the library from the base/head sources.
+          python head/scripts/check_examples_alignment.py deps --pyproject head/pyproject.toml > library-deps.txt
+          ./checkenv/bin/pip install -q -r library-deps.txt
+          # Per-example dependencies.
+          find examples/bricks examples/core-and-foundational examples/inspirational \
+            -path '*/python/requirements.txt' -exec ./checkenv/bin/pip install -q -r {} \;
+
+      - name: Run pyright against base
+        run: python head/scripts/check_examples_alignment.py run --examples-dir examples --library-src base/src --python checkenv/bin/python --out base.json
+
+      - name: Run pyright against head
+        run: python head/scripts/check_examples_alignment.py run --examples-dir examples --library-src head/src --python checkenv/bin/python --out head.json
+
+      - name: Report alignment diff
+        run: python head/scripts/check_examples_alignment.py diff --base base.json --head head.json
+
+      - name: Upload run outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: examples-alignment-reports
+          path: |
+            base.json
+            head.json
+          retention-days: 15

--- a/.github/workflows/check-examples-alignment.yml
+++ b/.github/workflows/check-examples-alignment.yml
@@ -10,7 +10,7 @@ on:
     paths:
       - "src/**"
       - "pyproject.toml"
-      - "containers/python-base/requirements-base.txt"
+      - "containers/base/python-base/requirements-base.txt"
       - "scripts/check_examples_alignment.py"
       - ".github/workflows/check-examples-alignment.yml"
   workflow_dispatch:
@@ -74,7 +74,7 @@ jobs:
           # Tolerant per-package install: a package that still fails to build on
           # the runner only degrades the affected types to Unknown, it must not
           # fail the job.
-          cat head/containers/python-base/requirements-base.txt library-deps.txt | while IFS= read -r pkg; do
+          cat head/containers/base/python-base/requirements-base.txt library-deps.txt | while IFS= read -r pkg; do
             pkg="${pkg%%#*}"
             [ -z "${pkg// /}" ] && continue
             ./checkenv/bin/pip install -q "$pkg" || echo "::notice::package not installed in the check venv: $pkg"

--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ export DOCKER_PYTHON_BASE_IMAGE=app-bricks/python-apps-base:dev-pose-classificat
 ```
 Development containers are published by the dev CI (`docker-build.yml`) tagged as `dev-<branch-name>` (e.g. branch `pose-classification` → tag `dev-pose-classification`).
 
+## Examples alignment
+
+The published examples live in [app-bricks-examples](https://github.com/arduino/app-bricks-examples). To check whether your changes break the API contract the examples rely on (pyright analyzes their Python sources against your checkout), clone that repository next to this one and run:
+
+```sh
+task check:examples-alignment -- run
+```
+
+To list the bricks that have no examples yet:
+
+```sh
+task check:examples-alignment -- coverage
+```
+
+See `scripts/check_examples_alignment.py --help` for the full options (custom paths, JSON output, PR base/head diff — the mode used by the `check-examples-alignment.yml` workflow).
+
 ## Release
 
 Release is based on tags pushed to `main`. A single workflow (`docker-publish.yml`) handles all container

--- a/README.md
+++ b/README.md
@@ -148,13 +148,13 @@ Development containers are published by the dev CI (`docker-build.yml`) tagged a
 The published examples live in [app-bricks-examples](https://github.com/arduino/app-bricks-examples). To check whether your changes break the API contract the examples rely on (pyright analyzes their Python sources against your checkout), clone that repository next to this one and run:
 
 ```sh
-task check:examples-alignment -- run
+task check:examples-alignment:run
 ```
 
 To list the bricks that have no examples yet:
 
 ```sh
-task check:examples-alignment -- coverage
+task check:examples-alignment:coverage
 ```
 
 See `scripts/check_examples_alignment.py --help` for the full options (custom paths, JSON output, PR base/head diff — the mode used by the `check-examples-alignment.yml` workflow).

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -77,6 +77,16 @@ tasks:
     cmds:
       - python3 scripts/check_examples_alignment.py {{.CLI_ARGS}}
 
+  check:examples-alignment:run:
+    desc: Run pyright over the app-bricks-examples code against this checkout
+    cmds:
+      - python3 scripts/check_examples_alignment.py run {{.CLI_ARGS}}
+
+  check:examples-alignment:coverage:
+    desc: Report the bricks that have no examples in app-bricks-examples
+    cmds:
+      - python3 scripts/check_examples_alignment.py coverage {{.CLI_ARGS}}
+
   fmt:
     desc: Format code
     cmds:

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -72,6 +72,11 @@ tasks:
     cmds:
       - ruff check --fix .
 
+  check:examples-alignment:
+    desc: "Check app-bricks-examples alignment against this library (see scripts/check_examples_alignment.py --help)"
+    cmds:
+      - python3 scripts/check_examples_alignment.py {{.CLI_ARGS}}
+
   fmt:
     desc: Format code
     cmds:

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -21,6 +21,11 @@ Typical PR usage:
   python3 scripts/check_examples_alignment.py run --examples-dir <examples> --library-src base/src --python <venv> --out base.json
   python3 scripts/check_examples_alignment.py run --examples-dir <examples> --library-src head/src --python <venv> --out head.json
   python3 scripts/check_examples_alignment.py diff --base base.json --head head.json
+
+Quick local usage (defaults: examples in ../app-bricks-examples, library in
+src, interpreter from the project .venv, no JSON output, details printed):
+  task check:examples-alignment -- run
+  task check:examples-alignment -- coverage
 """
 
 import argparse
@@ -35,6 +40,8 @@ from pathlib import Path
 
 PYRIGHT_VERSION = "1.1.406"
 EXAMPLES_ROOTS = ["bricks", "core-and-foundational", "inspirational"]
+DEFAULT_EXAMPLES_DIR = "../app-bricks-examples"
+DEFAULT_VENV_PYTHON = ".venv/bin/python"
 SELF_EXTRA_RE = re.compile(r"^arduino[-_]app[-_]bricks\[(.+)\]$")
 
 
@@ -64,6 +71,9 @@ def cmd_deps(args) -> int:
 def cmd_run(args) -> int:
     examples_dir = Path(args.examples_dir).resolve()
     library_src = Path(args.library_src).resolve()
+    if not examples_dir.is_dir():
+        print(f"examples checkout not found in {examples_dir}: clone app-bricks-examples there or pass --examples-dir", file=sys.stderr)
+        return 2
     include = [root for root in EXAMPLES_ROOTS if (examples_dir / root).is_dir()]
     if not include:
         print(f"no examples roots found in {examples_dir}", file=sys.stderr)
@@ -80,9 +90,15 @@ def cmd_run(args) -> int:
         "executionEnvironments": [{"root": ".", "extraPaths": [str(library_src)]}],
     }
 
+    # Default to the project venv interpreter for quick local runs.
+    python = args.python or (DEFAULT_VENV_PYTHON if Path(DEFAULT_VENV_PYTHON).exists() else None)
+    if python and not Path(python).exists():
+        # Pyright would silently fall back to another environment, skewing the results.
+        print(f"python interpreter not found: {python}", file=sys.stderr)
+        return 2
     cmd = ["npx", "-y", f"pyright@{args.pyright_version}", "--project", str(examples_dir), "--outputjson"]
-    if args.python:
-        cmd += ["--pythonpath", str(Path(args.python).resolve())]
+    if python:
+        cmd += ["--pythonpath", str(Path(python).resolve())]
     try:
         config_path.write_text(json.dumps(config))
         proc = subprocess.run(cmd, capture_output=True, text=True)
@@ -97,10 +113,12 @@ def cmd_run(args) -> int:
     data = json.loads(proc.stdout)
     for diag in data.get("generalDiagnostics", []):
         diag["file"] = Path(diag["file"]).resolve().relative_to(examples_dir).as_posix()
-    Path(args.out).write_text(json.dumps(data, indent=2) + "\n")
+    if args.out:
+        Path(args.out).write_text(json.dumps(data, indent=2) + "\n")
     summary = data["summary"]
     print(f"{summary['filesAnalyzed']} files analyzed against {library_src}: {summary['errorCount']} errors, {summary['warningCount']} warnings")
-    if args.details:
+    # Without a JSON output the run is a local one-off: print the details.
+    if args.details or not args.out:
         errors = [diag for diag in data["generalDiagnostics"] if diag["severity"] == "error"]
         for diag in sorted(errors, key=lambda d: (d.get("rule", ""), d["file"], d["range"]["start"]["line"])):
             line = diag["range"]["start"]["line"] + 1
@@ -172,6 +190,9 @@ def library_bricks(library_src: Path) -> set[str]:
 
 def cmd_coverage(args) -> int:
     examples_dir = Path(args.examples_dir).resolve()
+    if not (examples_dir / "bricks").is_dir():
+        print(f"examples checkout not found in {examples_dir}: clone app-bricks-examples there or pass --examples-dir", file=sys.stderr)
+        return 2
     covered = {path.name for path in examples_dir.glob("bricks/*/*") if path.is_dir()}
     head_bricks = library_bricks(Path(args.head_src).resolve())
     base_bricks = library_bricks(Path(args.base_src).resolve()) if args.base_src else head_bricks
@@ -208,11 +229,11 @@ def main() -> int:
     deps.set_defaults(func=cmd_deps)
 
     run = sub.add_parser("run", help="run pyright over the examples against a library source")
-    run.add_argument("--examples-dir", required=True)
-    run.add_argument("--library-src", required=True)
-    run.add_argument("--python", help="python interpreter of the check venv")
+    run.add_argument("--examples-dir", default=DEFAULT_EXAMPLES_DIR)
+    run.add_argument("--library-src", default="src")
+    run.add_argument("--python", help=f"python interpreter of the check venv (defaults to {DEFAULT_VENV_PYTHON} when present)")
     run.add_argument("--pyright-version", default=PYRIGHT_VERSION)
-    run.add_argument("--out", required=True)
+    run.add_argument("--out", help="write the diagnostics as JSON; when omitted, details are printed instead")
     run.add_argument("--details", action="store_true", help="also print the error diagnostics, grouped by rule")
     run.set_defaults(func=cmd_run)
 
@@ -223,8 +244,8 @@ def main() -> int:
     diff.set_defaults(func=cmd_diff)
 
     coverage = sub.add_parser("coverage", help="report library bricks that have no examples")
-    coverage.add_argument("--examples-dir", required=True)
-    coverage.add_argument("--head-src", required=True)
+    coverage.add_argument("--examples-dir", default=DEFAULT_EXAMPLES_DIR)
+    coverage.add_argument("--head-src", default="src")
     coverage.add_argument("--base-src", help="library source of the PR base, to flag bricks introduced by the PR")
     coverage.add_argument("--summary", help="markdown output file (defaults to GITHUB_STEP_SUMMARY)")
     coverage.set_defaults(func=cmd_coverage)

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Check the alignment between app-bricks-examples code and this library.
+
+Pyright analyzes the examples' Python sources resolving the library directly
+from a source checkout (no wheel build needed). Three modes:
+
+  deps  Print the library dependencies (core + recursively expanded extra),
+        so the check venv can be built without building the library itself.
+  run   Run pyright over the examples trees against a library source path and
+        save the diagnostics as JSON.
+  diff  Compare two run outputs (base vs head of a PR) and report new/fixed
+        errors. Always exits 0: the check is informative, not blocking.
+
+Typical PR usage:
+  python3 scripts/check_examples_alignment.py run --examples-dir <examples> --library-src base/src --python <venv> --out base.json
+  python3 scripts/check_examples_alignment.py run --examples-dir <examples> --library-src head/src --python <venv> --out head.json
+  python3 scripts/check_examples_alignment.py diff --base base.json --head head.json
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from collections import Counter
+from pathlib import Path
+
+PYRIGHT_VERSION = "1.1.406"
+EXAMPLES_ROOTS = ["bricks", "core-and-foundational", "inspirational"]
+SELF_EXTRA_RE = re.compile(r"^arduino[-_]app[-_]bricks\[(.+)\]$")
+
+
+def cmd_deps(args) -> int:
+    project = tomllib.loads(Path(args.pyproject).read_text())["project"]
+    optional = project.get("optional-dependencies", {})
+    deps: list[str] = []
+    seen_extras: set[str] = set()
+
+    def expand(entries: list[str]):
+        for entry in entries:
+            match = SELF_EXTRA_RE.match(entry.replace(" ", ""))
+            if match:
+                for extra in match.group(1).split(","):
+                    if extra not in seen_extras:
+                        seen_extras.add(extra)
+                        expand(optional.get(extra, []))
+            elif entry not in deps:
+                deps.append(entry)
+
+    expand(project.get("dependencies", []))
+    expand(optional.get(args.extra, []))
+    print("\n".join(deps))
+    return 0
+
+
+def cmd_run(args) -> int:
+    examples_dir = Path(args.examples_dir).resolve()
+    library_src = Path(args.library_src).resolve()
+    include = [root for root in EXAMPLES_ROOTS if (examples_dir / root).is_dir()]
+    if not include:
+        print(f"no examples roots found in {examples_dir}", file=sys.stderr)
+        return 2
+
+    # Pyright resolves relative paths from the config file location, so the
+    # config is written inside the examples checkout for the duration of the run.
+    config_path = examples_dir / "pyrightconfig.json"
+    if config_path.exists():
+        print(f"{config_path} already exists, refusing to overwrite it", file=sys.stderr)
+        return 2
+    config = {
+        "include": include,
+        "executionEnvironments": [{"root": ".", "extraPaths": [str(library_src)]}],
+    }
+
+    cmd = ["npx", "-y", f"pyright@{args.pyright_version}", "--project", str(examples_dir), "--outputjson"]
+    if args.python:
+        cmd += ["--pythonpath", str(Path(args.python).resolve())]
+    try:
+        config_path.write_text(json.dumps(config))
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    finally:
+        config_path.unlink(missing_ok=True)
+
+    # Pyright exits 0 (clean) or 1 (diagnostics found); anything else is a real failure.
+    if proc.returncode not in (0, 1):
+        sys.stderr.write(proc.stdout + proc.stderr)
+        return proc.returncode
+
+    data = json.loads(proc.stdout)
+    for diag in data.get("generalDiagnostics", []):
+        diag["file"] = Path(diag["file"]).resolve().relative_to(examples_dir).as_posix()
+    Path(args.out).write_text(json.dumps(data, indent=2) + "\n")
+    summary = data["summary"]
+    print(f"{summary['filesAnalyzed']} files analyzed against {library_src}: {summary['errorCount']} errors, {summary['warningCount']} warnings")
+    return 0
+
+
+def error_index(data: dict) -> tuple[Counter, dict]:
+    """Index error diagnostics by a line-shift-tolerant key: (file, rule, message first line)."""
+    counts: Counter = Counter()
+    samples: dict = {}
+    for diag in data.get("generalDiagnostics", []):
+        if diag["severity"] != "error":
+            continue
+        key = (diag["file"], diag.get("rule", ""), diag["message"].splitlines()[0])
+        counts[key] += 1
+        samples.setdefault(key, diag)
+    return counts, samples
+
+
+def cmd_diff(args) -> int:
+    base_counts, _ = error_index(json.loads(Path(args.base).read_text()))
+    head_counts, head_samples = error_index(json.loads(Path(args.head).read_text()))
+
+    new = {key: count - base_counts.get(key, 0) for key, count in head_counts.items() if count > base_counts.get(key, 0)}
+    fixed = {key: count - head_counts.get(key, 0) for key, count in base_counts.items() if count > head_counts.get(key, 0)}
+
+    lines = [
+        "## Examples alignment check",
+        "",
+        f"Errors against the examples ([app-bricks-examples](https://github.com/arduino/app-bricks-examples)@main): "
+        f"base {sum(base_counts.values())} → head {sum(head_counts.values())} "
+        f"(**{sum(new.values())} new**, {sum(fixed.values())} fixed)",
+    ]
+    for title, entries in (("New errors", new), ("Fixed errors", fixed)):
+        if entries:
+            lines += ["", f"### {title}", "", "| Example file | Rule | Message |", "|---|---|---|"]
+            for (file, rule, message), count in sorted(entries.items()):
+                suffix = f" (×{count})" if count > 1 else ""
+                lines.append(f"| `{file}` | {rule} | {message}{suffix} |")
+    if not new and not fixed:
+        lines += ["", "No changes in examples alignment."]
+    report = "\n".join(lines)
+
+    print(report)
+    summary_path = args.summary or os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write(report + "\n")
+    for (file, rule, message), _count in sorted(new.items()):
+        line = head_samples[(file, rule, message)]["range"]["start"]["line"] + 1
+        print(f"::warning::examples alignment: {file}:{line} [{rule}] {message}")
+
+    # Informative check by design: new errors are reported, never blocking.
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    deps = sub.add_parser("deps", help="print library dependencies for the check venv")
+    deps.add_argument("--pyproject", default="pyproject.toml")
+    deps.add_argument("--extra", default="all")
+    deps.set_defaults(func=cmd_deps)
+
+    run = sub.add_parser("run", help="run pyright over the examples against a library source")
+    run.add_argument("--examples-dir", required=True)
+    run.add_argument("--library-src", required=True)
+    run.add_argument("--python", help="python interpreter of the check venv")
+    run.add_argument("--pyright-version", default=PYRIGHT_VERSION)
+    run.add_argument("--out", required=True)
+    run.set_defaults(func=cmd_run)
+
+    diff = sub.add_parser("diff", help="compare two run outputs and report new/fixed errors")
+    diff.add_argument("--base", required=True)
+    diff.add_argument("--head", required=True)
+    diff.add_argument("--summary", help="markdown output file (defaults to GITHUB_STEP_SUMMARY)")
+    diff.set_defaults(func=cmd_diff)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -192,6 +192,9 @@ def cmd_diff(args) -> int:
         lines += ["", "</details>"]
     if args.reports_url:
         lines += ["", f"📥 [Download full pyright JSON report]({args.reports_url})"]
+    # Horizontal rule separating this section from the coverage one, appended
+    # to the same job summary by the next step.
+    lines += ["", "---"]
     report = "\n".join(lines)
 
     print(report)

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -24,8 +24,8 @@ Typical PR usage:
 
 Quick local usage (defaults: examples in ../app-bricks-examples, library in
 src, interpreter from the project .venv, no JSON output, details printed):
-  task check:examples-alignment -- run
-  task check:examples-alignment -- coverage
+  task check:examples-alignment:run
+  task check:examples-alignment:coverage
 """
 
 import argparse

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -177,14 +177,22 @@ def cmd_diff(args) -> int:
 
 
 DISABLED_RE = re.compile(r"^disabled:\s*true\s*$", re.MULTILINE)
+BRICK_ID_RE = re.compile(r"^id:\s*(?:[\w-]+:)?([\w-]+)\s*$", re.MULTILINE)
 
 
 def library_bricks(library_src: Path) -> set[str]:
-    """Names of the non-disabled bricks defined in a library source checkout."""
+    """Names of the non-disabled bricks defined in a library source checkout.
+
+    A brick's name is the one declared in its brick_config.yaml `id` (without
+    the vendor prefix) — the identifier App Lab and the examples manifest use —
+    which for a few bricks differs from the module directory name.
+    """
     bricks = set()
     for config in sorted(library_src.glob("arduino/app_bricks/*/brick_config.yaml")):
-        if not DISABLED_RE.search(config.read_text()):
-            bricks.add(config.parent.name)
+        content = config.read_text()
+        if not DISABLED_RE.search(content):
+            match = BRICK_ID_RE.search(content)
+            bricks.add(match.group(1) if match else config.parent.name)
     return bricks
 
 

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -100,6 +100,11 @@ def cmd_run(args) -> int:
     Path(args.out).write_text(json.dumps(data, indent=2) + "\n")
     summary = data["summary"]
     print(f"{summary['filesAnalyzed']} files analyzed against {library_src}: {summary['errorCount']} errors, {summary['warningCount']} warnings")
+    if args.details:
+        errors = [diag for diag in data["generalDiagnostics"] if diag["severity"] == "error"]
+        for diag in sorted(errors, key=lambda d: (d.get("rule", ""), d["file"], d["range"]["start"]["line"])):
+            line = diag["range"]["start"]["line"] + 1
+            print(f"  [{diag.get('rule', '')}] {diag['file']}:{line}  {diag['message'].splitlines()[0]}")
     return 0
 
 
@@ -208,6 +213,7 @@ def main() -> int:
     run.add_argument("--python", help="python interpreter of the check venv")
     run.add_argument("--pyright-version", default=PYRIGHT_VERSION)
     run.add_argument("--out", required=True)
+    run.add_argument("--details", action="store_true", help="also print the error diagnostics, grouped by rule")
     run.set_defaults(func=cmd_run)
 
     diff = sub.add_parser("diff", help="compare two run outputs and report new/fixed errors")

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -7,12 +7,15 @@
 Pyright analyzes the examples' Python sources resolving the library directly
 from a source checkout (no wheel build needed). Three modes:
 
-  deps  Print the library dependencies (core + recursively expanded extra),
-        so the check venv can be built without building the library itself.
-  run   Run pyright over the examples trees against a library source path and
-        save the diagnostics as JSON.
-  diff  Compare two run outputs (base vs head of a PR) and report new/fixed
-        errors. Always exits 0: the check is informative, not blocking.
+  deps      Print the library dependencies (core + recursively expanded extra),
+            so the check venv can be built without building the library itself.
+  run       Run pyright over the examples trees against a library source path
+            and save the diagnostics as JSON.
+  diff      Compare two run outputs (base vs head of a PR) and report new/fixed
+            errors. Always exits 0: the check is informative, not blocking.
+  coverage  Report the library bricks that have no examples, highlighting the
+            ones introduced by the PR. Informative by design: a new brick may
+            legitimately land before its examples do.
 
 Typical PR usage:
   python3 scripts/check_examples_alignment.py run --examples-dir <examples> --library-src base/src --python <venv> --out base.json
@@ -150,6 +153,46 @@ def cmd_diff(args) -> int:
     return 0
 
 
+DISABLED_RE = re.compile(r"^disabled:\s*true\s*$", re.MULTILINE)
+
+
+def library_bricks(library_src: Path) -> set[str]:
+    """Names of the non-disabled bricks defined in a library source checkout."""
+    bricks = set()
+    for config in sorted(library_src.glob("arduino/app_bricks/*/brick_config.yaml")):
+        if not DISABLED_RE.search(config.read_text()):
+            bricks.add(config.parent.name)
+    return bricks
+
+
+def cmd_coverage(args) -> int:
+    examples_dir = Path(args.examples_dir).resolve()
+    covered = {path.name for path in examples_dir.glob("bricks/*/*") if path.is_dir()}
+    head_bricks = library_bricks(Path(args.head_src).resolve())
+    base_bricks = library_bricks(Path(args.base_src).resolve()) if args.base_src else head_bricks
+
+    uncovered = sorted(head_bricks - covered)
+    introduced = sorted((head_bricks - base_bricks) - covered)
+
+    lines = ["### Bricks without examples", ""]
+    if uncovered:
+        lines.append(f"{len(uncovered)} bricks have no examples in app-bricks-examples:")
+        lines += [f"- `{name}`" + (" — **introduced by this PR**" if name in introduced else "") for name in uncovered]
+        lines += ["", "Informative only: a new brick may legitimately land before its examples do."]
+    else:
+        lines.append("Every non-disabled brick has at least one example.")
+    report = "\n".join(lines)
+
+    print(report)
+    summary_path = args.summary or os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write(report + "\n")
+    for name in introduced:
+        print(f"::notice::examples coverage: this PR introduces the brick '{name}', which has no examples in app-bricks-examples yet")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest="mode", required=True)
@@ -172,6 +215,13 @@ def main() -> int:
     diff.add_argument("--head", required=True)
     diff.add_argument("--summary", help="markdown output file (defaults to GITHUB_STEP_SUMMARY)")
     diff.set_defaults(func=cmd_diff)
+
+    coverage = sub.add_parser("coverage", help="report library bricks that have no examples")
+    coverage.add_argument("--examples-dir", required=True)
+    coverage.add_argument("--head-src", required=True)
+    coverage.add_argument("--base-src", help="library source of the PR base, to flag bricks introduced by the PR")
+    coverage.add_argument("--summary", help="markdown output file (defaults to GITHUB_STEP_SUMMARY)")
+    coverage.set_defaults(func=cmd_coverage)
 
     args = parser.parse_args()
     return args.func(args)

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -139,6 +139,15 @@ def error_index(data: dict) -> tuple[Counter, dict]:
     return counts, samples
 
 
+def error_table(entries: dict) -> list[str]:
+    """Markdown table rows for an error index, with pipes escaped for the cells."""
+    rows = ["| Example file | Rule | Message |", "|---|---|---|"]
+    for (file, rule, message), count in sorted(entries.items()):
+        suffix = f" (×{count})" if count > 1 else ""
+        rows.append(f"| `{file}` | {rule} | {message.replace('|', '\\|')}{suffix} |")
+    return rows
+
+
 def cmd_diff(args) -> int:
     base_counts, _ = error_index(json.loads(Path(args.base).read_text()))
     head_counts, head_samples = error_index(json.loads(Path(args.head).read_text()))
@@ -155,12 +164,17 @@ def cmd_diff(args) -> int:
     ]
     for title, entries in (("New errors", new), ("Fixed errors", fixed)):
         if entries:
-            lines += ["", f"### {title}", "", "| Example file | Rule | Message |", "|---|---|---|"]
-            for (file, rule, message), count in sorted(entries.items()):
-                suffix = f" (×{count})" if count > 1 else ""
-                lines.append(f"| `{file}` | {rule} | {message}{suffix} |")
+            lines += ["", f"### {title}", ""] + error_table(entries)
     if not new and not fixed:
         lines += ["", "No changes in examples alignment."]
+    if head_counts:
+        # Pre-existing errors are part of the story too, but collapsed: the diff
+        # above stays the signal of the PR.
+        lines += ["", "<details>", f"<summary>Full report: {sum(head_counts.values())} errors against head</summary>", ""]
+        lines += error_table(head_counts)
+        lines += ["", "</details>"]
+    if args.reports_url:
+        lines += ["", f"Raw pyright outputs (base/head JSON): [workflow artifact]({args.reports_url})"]
     report = "\n".join(lines)
 
     print(report)
@@ -249,6 +263,7 @@ def main() -> int:
     diff.add_argument("--base", required=True)
     diff.add_argument("--head", required=True)
     diff.add_argument("--summary", help="markdown output file (defaults to GITHUB_STEP_SUMMARY)")
+    diff.add_argument("--reports-url", help="link to the uploaded run outputs, appended to the summary")
     diff.set_defaults(func=cmd_diff)
 
     coverage = sub.add_parser("coverage", help="report library bricks that have no examples")

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -112,7 +112,19 @@ def cmd_run(args) -> int:
 
     data = json.loads(proc.stdout)
     for diag in data.get("generalDiagnostics", []):
-        diag["file"] = Path(diag["file"]).resolve().relative_to(examples_dir).as_posix()
+        # Normalize paths and tag the repository: diagnostics normally land on
+        # the examples files, but pyright may also point inside the library.
+        path = Path(diag["file"]).resolve()
+        try:
+            diag["file"] = path.relative_to(examples_dir).as_posix()
+            diag["repository"] = "app-bricks-examples"
+        except ValueError:
+            try:
+                diag["file"] = path.relative_to(library_src.parent).as_posix()
+                diag["repository"] = "app-bricks-py"
+            except ValueError:
+                diag["file"] = path.as_posix()
+                diag["repository"] = ""
     if args.out:
         Path(args.out).write_text(json.dumps(data, indent=2) + "\n")
     summary = data["summary"]
@@ -127,30 +139,35 @@ def cmd_run(args) -> int:
 
 
 def error_index(data: dict) -> tuple[Counter, dict]:
-    """Index error diagnostics by a line-shift-tolerant key: (file, rule, message first line)."""
+    """Index error diagnostics by a line-shift-tolerant key: (repository, file, rule, message first line).
+
+    Also returns the 1-based lines of the occurrences of each key (informational
+    only: lines are not part of the key, so moved code does not diff as new).
+    """
     counts: Counter = Counter()
-    samples: dict = {}
+    occurrences: dict[tuple, list[int]] = {}
     for diag in data.get("generalDiagnostics", []):
         if diag["severity"] != "error":
             continue
-        key = (diag["file"], diag.get("rule", ""), diag["message"].splitlines()[0])
+        key = (diag.get("repository", ""), diag["file"], diag.get("rule", ""), diag["message"].splitlines()[0])
         counts[key] += 1
-        samples.setdefault(key, diag)
-    return counts, samples
+        occurrences.setdefault(key, []).append(diag["range"]["start"]["line"] + 1)
+    return counts, occurrences
 
 
-def error_table(entries: dict) -> list[str]:
+def error_table(entries: dict, occurrences: dict) -> list[str]:
     """Markdown table rows for an error index, with pipes escaped for the cells."""
-    rows = ["| Example file | Rule | Message |", "|---|---|---|"]
-    for (file, rule, message), count in sorted(entries.items()):
-        suffix = f" (×{count})" if count > 1 else ""
-        rows.append(f"| `{file}` | {rule} | {message.replace('|', '\\|')}{suffix} |")
+    rows = ["| Repository | File | Line(s) | Rule | Message |", "|---|---|---|---|---|"]
+    for key in sorted(entries):
+        repo, file, rule, message = key
+        lines = ", ".join(str(line) for line in sorted(occurrences[key]))
+        rows.append(f"| {repo} | `{file}` | {lines} | {rule} | {message.replace('|', '\\|')} |")
     return rows
 
 
 def cmd_diff(args) -> int:
-    base_counts, _ = error_index(json.loads(Path(args.base).read_text()))
-    head_counts, head_samples = error_index(json.loads(Path(args.head).read_text()))
+    base_counts, base_occurrences = error_index(json.loads(Path(args.base).read_text()))
+    head_counts, head_occurrences = error_index(json.loads(Path(args.head).read_text()))
 
     new = {key: count - base_counts.get(key, 0) for key, count in head_counts.items() if count > base_counts.get(key, 0)}
     fixed = {key: count - head_counts.get(key, 0) for key, count in base_counts.items() if count > head_counts.get(key, 0)}
@@ -162,16 +179,16 @@ def cmd_diff(args) -> int:
         f"base {sum(base_counts.values())} → head {sum(head_counts.values())} "
         f"(**{sum(new.values())} new**, {sum(fixed.values())} fixed)",
     ]
-    for title, entries in (("New errors", new), ("Fixed errors", fixed)):
+    for title, entries, occurrences in (("New errors", new, head_occurrences), ("Fixed errors", fixed, base_occurrences)):
         if entries:
-            lines += ["", f"### {title}", ""] + error_table(entries)
+            lines += ["", f"### {title}", ""] + error_table(entries, occurrences)
     if not new and not fixed:
         lines += ["", "No changes in examples alignment."]
     if head_counts:
         # Pre-existing errors are part of the story too, but collapsed: the diff
         # above stays the signal of the PR.
         lines += ["", "<details>", f"<summary>Full report: {sum(head_counts.values())} errors against head</summary>", ""]
-        lines += error_table(head_counts)
+        lines += error_table(head_counts, head_occurrences)
         lines += ["", "</details>"]
     if args.reports_url:
         lines += ["", f"Raw pyright outputs (base/head JSON): [workflow artifact]({args.reports_url})"]
@@ -182,9 +199,9 @@ def cmd_diff(args) -> int:
     if summary_path:
         with open(summary_path, "a") as f:
             f.write(report + "\n")
-    for (file, rule, message), _count in sorted(new.items()):
-        line = head_samples[(file, rule, message)]["range"]["start"]["line"] + 1
-        print(f"::warning::examples alignment: {file}:{line} [{rule}] {message}")
+    for key in sorted(new):
+        _repo, file, rule, message = key
+        print(f"::warning::examples alignment: {file}:{head_occurrences[key][0]} [{rule}] {message}")
 
     # Informative check by design: new errors are reported, never blocking.
     return 0

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -41,6 +41,7 @@ from pathlib import Path
 PYRIGHT_VERSION = "1.1.406"
 EXAMPLES_ROOTS = ["bricks", "core-and-foundational", "inspirational"]
 DEFAULT_EXAMPLES_DIR = "../app-bricks-examples"
+EXAMPLES_REPO_MD = "[app-bricks-examples](https://github.com/arduino/app-bricks-examples)@main"
 DEFAULT_VENV_PYTHON = ".venv/bin/python"
 SELF_EXTRA_RE = re.compile(r"^arduino[-_]app[-_]bricks\[(.+)\]$")
 
@@ -175,7 +176,7 @@ def cmd_diff(args) -> int:
     lines = [
         "## Examples alignment check",
         "",
-        f"Errors against the examples ([app-bricks-examples](https://github.com/arduino/app-bricks-examples)@main): "
+        f"Errors against the examples ({EXAMPLES_REPO_MD}): "
         f"base {sum(base_counts.values())} → head {sum(head_counts.values())} "
         f"(**{sum(new.values())} new**, {sum(fixed.values())} fixed)",
     ]
@@ -248,7 +249,7 @@ def cmd_coverage(args) -> int:
         lines += [f"- `{name}`" + (" — **introduced by this PR**" if name in introduced else "") for name in uncovered]
         lines += ["", "Informative only: a new brick may legitimately land before its examples do."]
     else:
-        lines.append("Every non-disabled brick has at least one example.")
+        lines.append(f"Every non-disabled brick has at least one example in {EXAMPLES_REPO_MD} repository.")
     report = "\n".join(lines)
 
     print(report)

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -191,7 +191,7 @@ def cmd_diff(args) -> int:
         lines += error_table(head_counts, head_occurrences)
         lines += ["", "</details>"]
     if args.reports_url:
-        lines += ["", f"Raw pyright outputs (base/head JSON): [workflow artifact]({args.reports_url})"]
+        lines += ["", f"[Download full pyright JSON report]({args.reports_url})"]
     report = "\n".join(lines)
 
     print(report)

--- a/scripts/check_examples_alignment.py
+++ b/scripts/check_examples_alignment.py
@@ -183,7 +183,7 @@ def cmd_diff(args) -> int:
         if entries:
             lines += ["", f"### {title}", ""] + error_table(entries, occurrences)
     if not new and not fixed:
-        lines += ["", "No changes in examples alignment."]
+        lines += ["", "No new errors in this PR."]
     if head_counts:
         # Pre-existing errors are part of the story too, but collapsed: the diff
         # above stays the signal of the PR.
@@ -191,7 +191,7 @@ def cmd_diff(args) -> int:
         lines += error_table(head_counts, head_occurrences)
         lines += ["", "</details>"]
     if args.reports_url:
-        lines += ["", f"[Download full pyright JSON report]({args.reports_url})"]
+        lines += ["", f"📥 [Download full pyright JSON report]({args.reports_url})"]
     report = "\n".join(lines)
 
     print(report)


### PR DESCRIPTION
This PR adds an informative CI check that detects when a change to the library breaks the Python code of the published examples ([app-bricks-examples](https://github.com/arduino/app-bricks-examples)), now that examples live in a separate repository.

### How it works

[Pyright](https://microsoft.github.io/pyright) (pinned, run via `npx`) analyzes the examples' Python sources **twice**, resolving the library directly from the PR **base** and **head** source checkouts (`executionEnvironments.extraPaths` — no wheel build needed). The diff of the two runs is what gets reported: **new** errors mean this PR changes the API contract the examples rely on; **fixed** errors mean it repairs a previous mismatch. Being diff-based, any pre-existing baseline noise cancels out.

The check is **informative by design**: it always exits 0. Findings are reported in the job step summary (new/fixed tables) and as `warning` annotations, never as failures.

### What's included

- `scripts/check_examples_alignment.py` (stdlib only), four modes:
  - `deps` — prints the library dependencies from `pyproject.toml` (core + recursively expanded `[all]` extra), so the check venv can be built **without installing the library itself**: the library must resolve from a single source (the checkout under analysis), otherwise class-identity false positives appear;
  - `run` — runs pyright over the three examples roots (`bricks/`, `core-and-foundational/`, `inspirational/`) against a given library source; writes diagnostics as JSON (paths normalized, temporary `pyrightconfig.json` cleaned up); `--details` prints the error list for local usage;
  - `diff` — compares two run outputs on a line-shift-tolerant key `(file, rule, message)`; emits the markdown summary and one `::warning::` per new error;
  - `coverage` — lists the non-`disabled` bricks (from each `brick_config.yaml` under `src/arduino/app_bricks/`) that have no examples in app-bricks-examples, flagging the ones **introduced by the PR** with a `::notice::` annotation. Informative only: a new brick may legitimately land before its examples do (they travel on a parallel PR in the other repo).
- `task check:examples-alignment` in `Taskfile.dist.yml` — passthrough to the script for local usage.
- `.github/workflows/check-examples-alignment.yml` — on `pull_request` (path-filtered on `src/**`, `pyproject.toml`, base requirements, the script and itself): checks out PR base, PR head and `app-bricks-examples@main`; builds the check venv mirroring the app container environment (`containers/python-base/requirements-base.txt` with tolerant per-package install + `[all]` dependencies + per-example requirements); runs base, head, diff and coverage; uploads both JSON outputs as artifacts.

### Notes

- Missing venv packages never produce false errors: pyright degrades the affected types to `Unknown` (weaker checks, documented trade-off).
- Base and head runs are symmetric by construction (twin checkouts, same venv, same examples ref) — a requirement for a clean diff.
- Current coverage snapshot: `mcp_client` is the only brick without examples.

### Local usage

With `app-bricks-examples` cloned next to this repository, the quick one-off run needs no arguments (defaults: examples in `../app-bricks-examples`, library in `src`, interpreter from the project `.venv`; without `--out` the error details are printed directly):

```sh
# photo of the examples against your checkout
task check:examples-alignment -- run

# bricks without examples
task check:examples-alignment -- coverage
```

The section is also documented in the README alongside the other tasks. Custom paths, JSON output and the base/head diff (the CI mode) stay available via the explicit options (`--help`).