### PR TITLE
fix: robst check in case of not yet finalized model info

### DIFF
--- a/src/arduino/app_bricks/video_imageclassification/__init__.py
+++ b/src/arduino/app_bricks/video_imageclassification/__init__.py
@@ -371,7 +371,11 @@ class VideoImageClassification:
         if not value or not isinstance(value, (int, float)):
             raise TypeError("Invalid types for value.")
 
-        if self._model_info is None or self._model_info.thresholds is None or len(self._model_info.thresholds) == 0:
+        if getattr(self, "_model_info", None) is None:
+            logger.warning("Model information is not available. Cannot override threshold.")
+            return  # Model info is not available, cannot override threshold
+
+        if self._model_info.thresholds is None or len(self._model_info.thresholds) == 0:
             raise RuntimeError("Model information is not available or does not support threshold override.")
 
         # Get first threshold and extract id. Then override it with the new confidence value.

--- a/src/arduino/app_bricks/video_objectdetection/__init__.py
+++ b/src/arduino/app_bricks/video_objectdetection/__init__.py
@@ -426,7 +426,11 @@ class VideoObjectDetection:
         if not value or not isinstance(value, (int, float)):
             raise TypeError("Invalid types for value.")
 
-        if self._model_info is None or self._model_info.thresholds is None or len(self._model_info.thresholds) == 0:
+        if getattr(self, "_model_info", None) is None:
+            logger.warning("Model information is not available. Cannot override threshold.")
+            return  # Model info is not available, cannot override threshold
+
+        if self._model_info.thresholds is None or len(self._model_info.thresholds) == 0:
             raise RuntimeError("Model information is not available or does not support threshold override.")
 
         # Get first threshold and extract id. Then override it with the new confidence value.


### PR DESCRIPTION
to fix issues like:
```
2026-07-31 08:20:01.181 ERROR - [WebUI.execute] WebUI:  Failed to execute callback for 'override_th': 'VideoObjectDetection' object has no attribute '_model_info'
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/arduino/app_bricks/web_ui/web_ui.py", line 355, in run_callback_async
    result = await asyncio.to_thread(callback, sid, data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/asyncio/threads.py", line 26, in to_thread
    return await loop.run_in_executor(None, func_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/app/python/main.py", line 13, in <lambda>
    ui.on_message("override_th", lambda sid, threshold: detection_stream.override_threshold(threshold))
                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/arduino/app_bricks/video_objectdetection/__init__.py", line 413, in override_threshold
    self._override_threshold(ws, value)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/arduino/app_bricks/video_objectdetection/__init__.py", line 429, in _override_threshold
    if self._model_info is None or self._model_info.thresholds is None or len(self._model_info.thresholds) == 0:
```