### PR TITLE
fix: ignore parameters not supported by CSICamera

### DIFF
--- a/src/arduino/app_peripherals/camera/camera.py
+++ b/src/arduino/app_peripherals/camera/camera.py
@@ -2,14 +2,19 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+import inspect
 from collections.abc import Callable
 from urllib.parse import urlparse
 
 import numpy as np
 
+from arduino.app_utils import Logger
+
 from .base_camera import BaseCamera
 from .errors import CameraConfigError
 from .utils import _camera_registry, _claim_first_available_camera, _nth_plugged_camera
+
+logger = Logger("Camera")
 
 
 class Camera:
@@ -64,7 +69,7 @@ class Camera:
             fps (int): Target frames per second. Default: 10.
             adjustments (callable, optional): Function pipeline to adjust frames
                 that takes a numpy array and returns a numpy array. Default: None.
-            **kwargs: Camera-specific configuration parameters grouped by type:
+            **kwargs: Camera-specific configuration parameters grouped by type.
                 V4L Camera Parameters:
                     device (int | str): V4L device. Default: 0.
                     codec (str, optional): Video codec to use (FourCC). Options: "YUVY",
@@ -167,6 +172,30 @@ def _claim_key(camera: BaseCamera) -> str | None:
     return None
 
 
+def _supported_kwargs(camera_cls: type[BaseCamera], kwargs: dict) -> dict:
+    """
+    Keep only the keyword arguments supported by the target camera implementation.
+
+    The factory forwards **kwargs verbatim, so options that only apply to another
+    camera type (e.g. the V4L-only codec) would otherwise break the construction,
+    most notably when auto-selection picks a CSI camera.
+
+    Args:
+        camera_cls (type[BaseCamera]): Camera implementation the arguments are meant for.
+        kwargs (dict): Keyword arguments to forward to camera_cls.
+
+    Returns:
+        dict: The keyword arguments accepted by camera_cls.
+    """
+    supported = inspect.signature(camera_cls.__init__).parameters
+    dropped = sorted(name for name in kwargs if name not in supported)
+    if not dropped:
+        return kwargs
+
+    logger.warning(f"Ignoring argument(s) {', '.join(dropped)}: not supported by {camera_cls.__name__}")
+    return {name: value for name, value in kwargs.items() if name not in dropped}
+
+
 def _create_camera(
     source: str,
     resolution: tuple[int, int],
@@ -185,6 +214,7 @@ def _create_camera(
         from .csi_camera import CSICamera
 
         csi_source = source[4:]  # Remove "csi:" prefix
+        kwargs = _supported_kwargs(CSICamera, kwargs)
         return CSICamera(csi_source, resolution=resolution, fps=fps, adjustments=adjustments, **kwargs)
 
     # All other cases are handled by URL parsing

--- a/tests/arduino/app_peripherals/camera/conftest.py
+++ b/tests/arduino/app_peripherals/camera/conftest.py
@@ -73,6 +73,29 @@ def usb_camera_with_metadata_node(monkeypatch):
     )
 
 
+class _FakeCSIBackend:
+    """Stand-in for a CSI camera stack backend exposing two cameras."""
+
+    @staticmethod
+    def list_camera_ids():
+        return [0, 1]
+
+    @staticmethod
+    def get_camera_identifier(camera_id):
+        return f"CAMERA{camera_id}"
+
+    @staticmethod
+    def gstreamer_source(camera_id):
+        return f"fakesrc camera={camera_id}"
+
+
+@pytest.fixture
+def two_csi_cameras_only(monkeypatch):
+    """Simulate a platform with two CSI cameras (CAMERA0, CAMERA1) and no USB camera."""
+    monkeypatch.setattr("arduino.app_peripherals.camera.v4l_camera.V4LCamera._scan_stable_links", staticmethod(lambda: []))
+    monkeypatch.setattr("arduino.app_peripherals.camera.csi_camera._get_backend", lambda: _FakeCSIBackend)
+
+
 @pytest.fixture(
     params=["/dev/video0", 0, "0", "/dev/v4l/by-path/platform-xhci-hcd.2.auto-usb-0:1.3:1.0-video-index0", "/dev/v4l/by-id/usb-Camera-video-index0"]
 )

--- a/tests/arduino/app_peripherals/camera/test_camera.py
+++ b/tests/arduino/app_peripherals/camera/test_camera.py
@@ -5,9 +5,9 @@
 
 import pytest
 
-from arduino.app_peripherals.camera import Camera, V4LCamera, IPCamera, WebSocketCamera, CameraConfigError, CameraOpenError
+from arduino.app_peripherals.camera import Camera, CSICamera, V4LCamera, IPCamera, WebSocketCamera, CameraConfigError, CameraOpenError
 
-from conftest import two_v4l_cameras, usb_camera_with_metadata_node, v4l_device_argument  # noqa: F401
+from conftest import two_csi_cameras_only, two_v4l_cameras, usb_camera_with_metadata_node, v4l_device_argument  # noqa: F401
 
 
 def test_camera_factory_with_v4l_device(v4l_device_argument):
@@ -83,6 +83,34 @@ def test_explicit_index_selects_nth_plugged_camera(two_v4l_cameras):
 
     cam2 = Camera(1)
     assert cam2.v4l_path == "/dev/v4l/by-id/usb-CamB-video-index0"
+
+
+def test_csi_source_ignores_unsupported_kwargs(two_csi_cameras_only):
+    """A kwarg CSICamera does not support must not break its construction."""
+    camera = Camera("csi:0", resolution=(1280, 960), fps=30, codec="MJPG", bogus=1)
+    assert isinstance(camera, CSICamera)
+    assert not hasattr(camera, "codec")
+    assert not hasattr(camera, "bogus")
+
+
+def test_csi_source_keeps_shared_kwargs(two_csi_cameras_only):
+    """Kwargs supported by both camera types are still forwarded to CSI cameras."""
+    camera = Camera("csi:0", auto_reconnect=False, codec="MJPG")
+    assert isinstance(camera, CSICamera)
+    assert camera.auto_reconnect is False
+
+
+def test_auto_selected_csi_camera_ignores_v4l_only_kwargs(two_csi_cameras_only):
+    """Auto-selection falling back to CSI must tolerate V4L-only kwargs."""
+    camera = Camera(resolution=(1280, 960), fps=30, codec="MJPG")
+    assert isinstance(camera, CSICamera)
+    assert camera.csi_path == "CAMERA0"
+
+
+def test_v4l_source_still_rejects_unknown_kwargs(v4l_device_argument):
+    """Filtering is CSI-specific: a USB camera still rejects unknown kwargs."""
+    with pytest.raises(TypeError):
+        Camera(v4l_device_argument, bogus=1)
 
 
 def test_camera_factory_with_rtsp_url():


### PR DESCRIPTION
In case a "Camera()" is created with a parameter not supported (like codec), drop it