### PR TITLE
chore: ad exception handler to properly intercept fatal application errors

### DIFF
--- a/src/arduino/app_bricks/asr/local_asr.py
+++ b/src/arduino/app_bricks/asr/local_asr.py
@@ -21,12 +21,12 @@ from websockets.exceptions import ConnectionClosed, ConnectionClosedOK
 from arduino.app_internal.core import resolve_address
 from arduino.app_internal.core.module import get_brick_config, get_brick_configured_model
 from arduino.app_peripherals.microphone import BaseMicrophone, Microphone
-from arduino.app_utils import Logger, brick
+from arduino.app_utils import AppError, Logger, brick
 
 logger = Logger("ASR")
 
 
-class ASRError(Exception):
+class ASRError(AppError):
     """Base class for ASR errors."""
 
 

--- a/src/arduino/app_bricks/tts/local_tts.py
+++ b/src/arduino/app_bricks/tts/local_tts.py
@@ -14,7 +14,7 @@ import requests
 
 from arduino.app_peripherals.speaker import Speaker, BaseSpeaker
 from arduino.app_internal.core import resolve_address, get_brick_config, get_brick_configured_model
-from arduino.app_utils import brick, Logger
+from arduino.app_utils import brick, AppError, Logger
 
 logger = Logger("TextToSpeech")
 
@@ -24,7 +24,7 @@ TTS_MAX_QUEUE_SIZE = 128
 _SPEECH_QUEUE_STOP = object()
 
 
-class TTSError(Exception):
+class TTSError(AppError):
     """Base class for TTS errors."""
 
 

--- a/src/arduino/app_peripherals/camera/errors.py
+++ b/src/arduino/app_peripherals/camera/errors.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-class CameraError(Exception):
+from arduino.app_utils.errors import AppError
+
+
+class CameraError(AppError):
     """Base exception for camera-related errors."""
 
     pass

--- a/src/arduino/app_peripherals/camera/utils.py
+++ b/src/arduino/app_peripherals/camera/utils.py
@@ -70,7 +70,10 @@ def _nth_plugged_camera(idx: int) -> str:
     if idx - usb_count < csi_count:
         return f"csi:{idx - usb_count}"
 
-    raise CameraOpenError(f"No camera found at index {idx}: only {usb_count + csi_count} camera(s) plugged")
+    raise CameraOpenError(
+        f"No camera found at index {idx}: only {usb_count + csi_count} camera(s) plugged",
+        hint="Connect a camera (or check the camera configuration) and restart the app.",
+    )
 
 
 def resolve_camera_name(i2c_addr: str) -> str:

--- a/src/arduino/app_peripherals/microphone/errors.py
+++ b/src/arduino/app_peripherals/microphone/errors.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-class MicrophoneError(Exception):
+from arduino.app_utils.errors import AppError
+
+
+class MicrophoneError(AppError):
     """Base exception for microphone-related errors."""
 
     pass

--- a/src/arduino/app_peripherals/microphone/utils.py
+++ b/src/arduino/app_peripherals/microphone/utils.py
@@ -71,7 +71,10 @@ def _nth_plugged_microphone(idx: int) -> str:
     if idx - usb_count < jack_count:
         return f"jack:{idx - usb_count + 1}"
 
-    raise MicrophoneOpenError(f"No microphone found at index {idx}: only {usb_count + jack_count} microphone(s) plugged")
+    raise MicrophoneOpenError(
+        f"No microphone found at index {idx}: only {usb_count + jack_count} microphone(s) plugged",
+        hint="Connect a microphone (or check the audio configuration) and restart the app.",
+    )
 
 
 def list_audio_sources() -> tuple[list[dict], list[dict]]:

--- a/src/arduino/app_peripherals/remote_sensor/errors.py
+++ b/src/arduino/app_peripherals/remote_sensor/errors.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-class RemoteSensorError(Exception):
+from arduino.app_utils.errors import AppError
+
+
+class RemoteSensorError(AppError):
     """Base exception for remote sensor-related errors."""
 
     pass

--- a/src/arduino/app_peripherals/speaker/errors.py
+++ b/src/arduino/app_peripherals/speaker/errors.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-class SpeakerError(Exception):
+from arduino.app_utils.errors import AppError
+
+
+class SpeakerError(AppError):
     """Base exception for Speaker-related errors."""
 
     pass

--- a/src/arduino/app_peripherals/speaker/utils.py
+++ b/src/arduino/app_peripherals/speaker/utils.py
@@ -71,7 +71,10 @@ def _nth_plugged_speaker(idx: int) -> str:
     if idx - usb_count < jack_count:
         return f"jack:{idx - usb_count + 1}"
 
-    raise SpeakerOpenError(f"No speaker found at index {idx}: only {usb_count + jack_count} speaker(s) plugged")
+    raise SpeakerOpenError(
+        f"No speaker found at index {idx}: only {usb_count + jack_count} speaker(s) plugged",
+        hint="Connect a speaker (or check the audio configuration) and restart the app.",
+    )
 
 
 def list_audio_sinks() -> tuple[list[dict], list[dict]]:

--- a/src/arduino/app_utils/__init__.py
+++ b/src/arduino/app_utils/__init__.py
@@ -6,6 +6,8 @@ from .app import *
 from .audio import *
 from .brick import *
 from .bridge import *
+from .errors import *
+from .errors import install_excepthook as _install_excepthook
 from .folderwatch import *
 from .httprequest import *
 from .jsonparser import *
@@ -16,6 +18,7 @@ from .leds import *
 
 __all__ = [
     "App",
+    "AppError",
     "brick",
     "Bridge",
     "notify",
@@ -31,3 +34,6 @@ __all__ = [
     "SlidingWindowBuffer",
     "Leds",
 ]
+
+# Report uncaught AppErrors with a user-readable message instead of a bare traceback
+_install_excepthook()

--- a/src/arduino/app_utils/errors.py
+++ b/src/arduino/app_utils/errors.py
@@ -54,20 +54,25 @@ def _find_user_frame(tb) -> traceback.FrameSummary | None:
 
 
 def _app_excepthook(exc_type, exc, tb):
-    if not isinstance(exc, AppError):
+    if not isinstance(exc, Exception):
+        # BaseExceptions like KeyboardInterrupt keep the standard behavior
         _previous_excepthook(exc_type, exc, tb)
         return
 
     out = sys.stderr
     frame = _find_user_frame(tb)
     location = f" in {os.path.basename(frame.filename)}, line {frame.lineno}" if frame else ""
-    message = str(exc) or exc_type.__name__
 
     print(_banner("App failed to start"), file=out)
-    print(f"Error{location}:", file=out)
-    print(f"  {message}", file=out)
-    if exc.hint:
-        print(f"\nHint: {exc.hint}", file=out)
+    if isinstance(exc, AppError):
+        print(f"Error{location}:", file=out)
+        print(f"  {str(exc) or exc_type.__name__}", file=out)
+        if exc.hint:
+            print(f"\nHint: {exc.hint}", file=out)
+    else:
+        detail = f"{exc_type.__name__}: {exc}" if str(exc) else exc_type.__name__
+        print(f"Unexpected error{location}:", file=out)
+        print(f"  {detail}", file=out)
     print("\nTrace:", file=out)
     traceback.print_exception(exc_type, exc, tb, file=out)
     print(_banner(), file=out, flush=True)
@@ -77,10 +82,12 @@ _previous_excepthook = sys.__excepthook__
 
 
 def install_excepthook():
-    """Installs the AppError-aware excepthook. Idempotent.
+    """Installs the global app excepthook. Idempotent.
 
-    Uncaught AppError exceptions are reported with a clean, user-readable
-    message before the traceback; any other exception is handled by the
+    Every uncaught Exception is reported with a clean, user-readable message
+    before the full traceback. AppErrors are shown with their message and
+    optional hint; any other exception is reported as unexpected, with its
+    class name. BaseExceptions (e.g. KeyboardInterrupt) are handled by the
     previously installed hook.
     """
     global _previous_excepthook

--- a/src/arduino/app_utils/errors.py
+++ b/src/arduino/app_utils/errors.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import os
+import sys
+import traceback
+
+__all__ = ["AppError"]
+
+_BANNER_WIDTH = 53
+
+
+class AppError(Exception):
+    """Base class for user-facing application errors.
+
+    These signal environment or configuration problems (missing hardware, invalid
+    settings, unreachable services) rather than programming errors. When one of
+    these reaches the top level uncaught, the app prints a concise, readable
+    report explaining what went wrong, followed by the full traceback.
+
+    Args:
+        *args: Standard Exception arguments, typically the error message.
+        hint (str, optional): A suggestion telling the user how to fix the problem.
+
+    Examples:
+        raise SpeakerOpenError("No speaker found", hint="Connect a speaker and restart the app.")
+    """
+
+    def __init__(self, *args, hint: str | None = None):
+        super().__init__(*args)
+        self.hint = hint
+
+
+def _banner(text: str = "") -> str:
+    if text:
+        return f"======== {text} ".ljust(_BANNER_WIDTH, "=")
+    return "=" * _BANNER_WIDTH
+
+
+def _find_user_frame(tb) -> traceback.FrameSummary | None:
+    """Returns the innermost traceback frame that belongs to user code.
+
+    Frames coming from installed packages (site-packages/dist-packages) or from
+    synthetic sources ("<frozen ...>", "<string>") are skipped, so the reported
+    location points at the user's own script whenever possible.
+    """
+    user_frames = [
+        frame
+        for frame in traceback.extract_tb(tb)
+        if "site-packages" not in frame.filename and "dist-packages" not in frame.filename and not frame.filename.startswith("<")
+    ]
+    return user_frames[-1] if user_frames else None
+
+
+def _app_excepthook(exc_type, exc, tb):
+    if not isinstance(exc, AppError):
+        _previous_excepthook(exc_type, exc, tb)
+        return
+
+    out = sys.stderr
+    frame = _find_user_frame(tb)
+    location = f" in {os.path.basename(frame.filename)}, line {frame.lineno}" if frame else ""
+    message = str(exc) or exc_type.__name__
+
+    print(_banner("App failed to start"), file=out)
+    print(f"Error{location}:", file=out)
+    print(f"  {message}", file=out)
+    if exc.hint:
+        print(f"\nHint: {exc.hint}", file=out)
+    print("\nTrace:", file=out)
+    traceback.print_exception(exc_type, exc, tb, file=out)
+    print(_banner(), file=out, flush=True)
+
+
+_previous_excepthook = sys.__excepthook__
+
+
+def install_excepthook():
+    """Installs the AppError-aware excepthook. Idempotent.
+
+    Uncaught AppError exceptions are reported with a clean, user-readable
+    message before the traceback; any other exception is handled by the
+    previously installed hook.
+    """
+    global _previous_excepthook
+    if sys.excepthook is _app_excepthook:
+        return
+    _previous_excepthook = sys.excepthook
+    sys.excepthook = _app_excepthook

--- a/tests/arduino/app_utils/errors/test_excepthook.py
+++ b/tests/arduino/app_utils/errors/test_excepthook.py
@@ -52,11 +52,27 @@ def test_app_error_subclass_is_reported(capsys):
     assert "device is missing" in err
 
 
-def test_other_exceptions_are_delegated(monkeypatch):
+def test_unexpected_exceptions_are_reported_with_class_name(capsys):
+    exc_info = _capture(ValueError("a user bug"))
+    _app_excepthook(*exc_info)
+
+    err = capsys.readouterr().err
+    assert "======== App failed to start " in err
+    assert "Unexpected error in test_excepthook.py, line" in err
+    assert "  ValueError: a user bug" in err
+    assert "Hint:" not in err
+    assert "Trace:" in err
+    assert "Traceback (most recent call last):" in err
+
+
+def test_base_exceptions_are_delegated(monkeypatch):
     delegated = []
     monkeypatch.setattr(errors, "_previous_excepthook", lambda *args: delegated.append(args))
 
-    exc_info = _capture(ValueError("a user bug"))
+    try:
+        raise KeyboardInterrupt()
+    except KeyboardInterrupt:
+        exc_info = sys.exc_info()
     _app_excepthook(*exc_info)
 
     assert delegated == [exc_info]

--- a/tests/arduino/app_utils/errors/test_excepthook.py
+++ b/tests/arduino/app_utils/errors/test_excepthook.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import sys
+
+import arduino.app_utils.errors as errors
+from arduino.app_utils.errors import AppError, _app_excepthook, install_excepthook
+
+
+def _capture(exc: Exception):
+    """Raises exc and returns its (type, value, traceback) as an excepthook would receive it."""
+    try:
+        raise exc
+    except Exception:
+        return sys.exc_info()
+
+
+def test_app_error_prints_clean_report(capsys):
+    exc_info = _capture(AppError("No speaker found at index 0", hint="Connect a speaker and restart the app."))
+    _app_excepthook(*exc_info)
+
+    err = capsys.readouterr().err
+    assert "======== App failed to start " in err
+    assert "Error in test_excepthook.py, line" in err
+    assert "  No speaker found at index 0" in err
+    assert "Hint: Connect a speaker and restart the app." in err
+    assert "Trace:" in err
+    assert "Traceback (most recent call last):" in err
+    # The clean report comes before the traceback
+    assert err.index("No speaker found") < err.index("Traceback")
+
+
+def test_app_error_without_hint_omits_hint_line(capsys):
+    exc_info = _capture(AppError("something went wrong"))
+    _app_excepthook(*exc_info)
+
+    err = capsys.readouterr().err
+    assert "something went wrong" in err
+    assert "Hint:" not in err
+
+
+def test_app_error_subclass_is_reported(capsys):
+    class FakePeripheralError(AppError):
+        pass
+
+    exc_info = _capture(FakePeripheralError("device is missing"))
+    _app_excepthook(*exc_info)
+
+    err = capsys.readouterr().err
+    assert "======== App failed to start " in err
+    assert "device is missing" in err
+
+
+def test_other_exceptions_are_delegated(monkeypatch):
+    delegated = []
+    monkeypatch.setattr(errors, "_previous_excepthook", lambda *args: delegated.append(args))
+
+    exc_info = _capture(ValueError("a user bug"))
+    _app_excepthook(*exc_info)
+
+    assert delegated == [exc_info]
+
+
+def test_install_excepthook_is_idempotent():
+    saved_hook = sys.excepthook
+    saved_previous = errors._previous_excepthook
+    try:
+        install_excepthook()
+        install_excepthook()
+        assert sys.excepthook is _app_excepthook
+        # A double install must not chain the hook to itself
+        assert errors._previous_excepthook is not _app_excepthook
+    finally:
+        sys.excepthook = saved_hook
+        errors._previous_excepthook = saved_previous


### PR DESCRIPTION
Add an global exception handler to better format and handle application errors and provide a better user facing message

Here is an example of a better formatted log:
```bash
arduino@21q:~$ docker logs 1e554ec57f66
======== App is starting ============================
Hello world!
======== App failed to start ========================
Error in main.py, line 8:
  No speaker found at index 0: only 0 speaker(s) plugged

Hint: Connect a speaker (or check the audio configuration) and restart the app.

Trace:
Traceback (most recent call last):
  File "/app/python/main.py", line 8, in <module>
    tts = TextToSpeech()
  File "/usr/local/lib/python3.13/site-packages/arduino/app_utils/brick.py", line 33, in new_init
    original_init(self, *args, **kwargs)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/arduino/app_bricks/tts/local_tts.py", line 73, in __init__
    self._speaker = speaker or Speaker(0, sample_rate=Speaker.RATE_44K, shared=True)
                               ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/arduino/app_peripherals/speaker/speaker.py", line 185, in __new__
    speaker = _create_speaker(device, sample_rate, channels, format, buffer_size, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/arduino/app_peripherals/speaker/speaker.py", line 301, in _create_speaker
    return ALSASpeaker(
        device=device,
    ...<4 lines>...
        **kwargs,
    )
  File "/usr/local/lib/python3.13/site-packages/arduino/app_peripherals/speaker/alsa_speaker.py", line 80, in __init__
    self.device_stable_ref = self._resolve_stable_ref(device)  # e.g., "plughw:CARD=MySpk,DEV=0"
                             ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/arduino/app_peripherals/speaker/alsa_speaker.py", line 186, in _resolve_stable_ref
    identifier = _nth_plugged_speaker(int(identifier))  # -> "usb:X" / "jack:X"
  File "/usr/local/lib/python3.13/site-packages/arduino/app_peripherals/speaker/utils.py", line 74, in _nth_plugged_speaker
    raise SpeakerOpenError(
    ...<2 lines>...
    )
arduino.app_peripherals.speaker.errors.SpeakerOpenError: No speaker found at index 0: only 0 speaker(s) plugged
=====================================================
```
