### PR TITLE
feat: report model_id and size on the HF download info event

### DIFF
--- a/containers/bricks/models-downloader/src/common/model_metadata.py
+++ b/containers/bricks/models-downloader/src/common/model_metadata.py
@@ -177,7 +177,15 @@ def metadata_payload(handler, inputs=None, identity=None, downloaded_at=None):
     return payload
 
 
-def write_metadata(model_dir, handler, env=None, models_list_path=MODELS_LIST_PATH, extra_input_keys=(), fallback_model_id=None):
+def write_metadata(
+    model_dir,
+    handler,
+    env=None,
+    models_list_path=MODELS_LIST_PATH,
+    extra_input_keys=(),
+    fallback_model_id=None,
+    identity=None,
+):
     """Write ``<model_dir>/.arduino_metadata.yaml`` atomically; return its path or None.
 
     Called after a successful download and *before* clearing the ``.download``
@@ -187,6 +195,10 @@ def write_metadata(model_dir, handler, env=None, models_list_path=MODELS_LIST_PA
 
     *fallback_model_id* names the model when models-list.yaml does not declare it; pass
     one whenever the handler can download something the list has never heard of.
+
+    *identity* is an already-resolved ``identify_model`` result. A handler that reports
+    the id to the host as well as recording it here passes the same dict to both, so the
+    two can never name the model differently; leave it out to have it resolved here.
     """
     path = os.path.join(model_dir, METADATA_NAME)
     tmp = path + ".tmp"
@@ -194,7 +206,7 @@ def write_metadata(model_dir, handler, env=None, models_list_path=MODELS_LIST_PA
         payload = metadata_payload(
             handler,
             inputs=collect_inputs(env, extra_input_keys),
-            identity=identify_model(env, models_list_path, fallback_model_id),
+            identity=identity if identity is not None else identify_model(env, models_list_path, fallback_model_id),
         )
         os.makedirs(model_dir, exist_ok=True)
         with open(tmp, "w") as f:

--- a/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
+++ b/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
@@ -96,7 +96,7 @@ import json
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from common.download_marker import MARKER_NAME, read_marker, write_marker
-from common.model_metadata import is_bookkeeping_name, write_metadata
+from common.model_metadata import identify_model, is_bookkeeping_name, write_metadata
 
 # Quantization used when a model key names only a repository. Q4_0 is the quantization
 # every llama.cpp GGUF repository publishes and the one all curated entries use.
@@ -125,12 +125,28 @@ HF_FILE_MARKERS = ("resolve", "blob")
 URL_FORMAT_HINT = "Expected format: https://huggingface.co/<owner>/<repo>/resolve/<revision>/<file>.gguf (/blob/ also works)"
 
 
-def emit_json_info(description: str, artifacts: list[str] | None = None, downloading: bool | None = None):
+def emit_json_info(
+    description: str,
+    artifacts: list[str] | None = None,
+    downloading: bool | None = None,
+    model_id: str | None = None,
+    size_mb: float | None = None,
+):
+    """Print an ``info`` event.
+
+    ``model_id`` and ``size_mb`` are what the host would otherwise have to re-derive from
+    the artifact filenames or read back with a listing run, so a completed download
+    reports them here instead.
+    """
     data: dict = {"event": "info", "description": description}
     if artifacts is not None:
         data["artifacts"] = artifacts
     if downloading is not None:
         data["downloading"] = downloading
+    if model_id is not None:
+        data["model_id"] = model_id
+    if size_mb is not None:
+        data["size_mb"] = size_mb
     print(json.dumps(data), flush=True)
 
 
@@ -761,6 +777,24 @@ def fallback_model_id(model_type: str, downloaded: list[str]) -> str | None:
     return f"{model_type or 'llamacpp'}:{Path(main_gguf).stem}"
 
 
+def downloaded_size_mb(downloaded: list[str]) -> float | None:
+    """Total size in MB of the files a download wrote, or None if any cannot be read.
+
+    Counts the mmproj file along with the main GGUF, which is what ``list_models.py``
+    reports as ``disk_size_mb`` for the same model, so the size a caller is told on
+    completion matches the one a later listing gives it.
+    """
+    if not downloaded:
+        return None
+    total = 0
+    for path in downloaded:
+        try:
+            total += os.stat(path).st_size
+        except OSError:
+            return None
+    return round(total / 1024 / 1024, 2)
+
+
 def no_match_message(repo_id: str, pattern: str) -> str:
     """Explain that nothing matched *pattern*, listing the GGUF files the repo does have.
 
@@ -1136,22 +1170,30 @@ def main():
         # Generate models.ini file
         generate_models_ini(Path(args.output_dir))
 
-        # Report the absolute path(s) of the downloaded model file(s): the files this
-        # request named, not every quantization the shared repository directory holds —
-        # a sibling was not downloaded now, and must not name this model either.
+        # The absolute path(s) of the downloaded model file(s): the files this request
+        # named, not every quantization the shared repository directory holds — a sibling
+        # was not downloaded now, and must not name this model either.
         downloaded = sorted(str(p.resolve()) for p in matching_files(output_dir, patterns) if p.suffix == ".gguf")
-        emit_json_info(f"Downloaded to: {output_dir}", artifacts=downloaded)
+
+        # Resolved once and used for both the record and the event, so the id the host is
+        # told is the id on disk. Any repository can be downloaded without a
+        # models-list.yaml entry, so name it after the file that arrived rather than
+        # leaving it unidentified.
+        identity = identify_model(metadata_env, fallback_model_id=fallback_model_id(source["model_type"], downloaded))
 
         # Record what was downloaded, then clear the in-progress marker: while the
         # marker is still there the repo directory counts as incomplete, so a crash
         # in between makes the next run retry instead of leaving it unrecorded.
-        write_metadata(
-            output_dir,
-            handler="hf-handler",
-            env=metadata_env,
-            # Any repository can be downloaded without a models-list.yaml entry, so name
-            # it after the file that arrived rather than leaving it unidentified.
-            fallback_model_id=fallback_model_id(source["model_type"], downloaded),
+        recorded = write_metadata(output_dir, handler="hf-handler", env=metadata_env, identity=identity)
+
+        emit_json_info(
+            f"Downloaded to: {output_dir}",
+            artifacts=downloaded,
+            # Named only once the record is on disk. A model no models-list.yaml entry
+            # declares is reconstructed from that record, so without it the model cannot
+            # be listed and reporting an id here would promise one nothing resolves.
+            model_id=identity["model_id"] if recorded else None,
+            size_mb=downloaded_size_mb(downloaded),
         )
 
         marker = Path(output_dir) / MARKER_NAME

--- a/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
+++ b/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
@@ -783,16 +783,21 @@ def downloaded_size_mb(downloaded: list[str]) -> float | None:
     Counts the mmproj file along with the main GGUF, which is what ``list_models.py``
     reports as ``disk_size_mb`` for the same model, so the size a caller is told on
     completion matches the one a later listing gives it.
+
+    Rounded per file and then again on the sum, which is what the listing does. Rounding
+    the byte total once instead differs by up to a hundredth of a megabyte per file - a
+    difference of nothing in itself, but enough to make a caller see the size change the
+    first time a listing runs.
     """
     if not downloaded:
         return None
-    total = 0
+    total = 0.0
     for path in downloaded:
         try:
-            total += os.stat(path).st_size
+            total += round(os.stat(path).st_size / 1024 / 1024, 2)
         except OSError:
             return None
-    return round(total / 1024 / 1024, 2)
+    return round(total, 2)
 
 
 def no_match_message(repo_id: str, pattern: str) -> str:

--- a/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
+++ b/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
@@ -96,7 +96,7 @@ import json
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from common.download_marker import MARKER_NAME, read_marker, write_marker
-from common.model_metadata import identify_model, is_bookkeeping_name, write_metadata
+from common.model_metadata import ORIGIN_BUILTIN, identify_model, is_bookkeeping_name, read_metadata, write_metadata
 
 # Quantization used when a model key names only a repository. Q4_0 is the quantization
 # every llama.cpp GGUF repository publishes and the one all curated entries use.
@@ -1062,13 +1062,39 @@ def main():
         # what it left and retry; absent but the requested files present => complete.
         # Marker first, files second — the reverse of --check, because the leftovers of
         # the interrupted run have to go before the directory can be judged.
+        # The model directory is the repo id: the download always lands in
+        # <output_dir>/<repo_id>. models-list.yaml usually spells it out, but it is
+        # redundant — repo_id is a substring of the model URL (and of the model key),
+        # so derive it when the variable is not set rather than recording nothing.
+        model_directory = os.environ.get("model_directory") or repo_id
+        # Environment the metadata record is built from, with model_directory filled
+        # in: it feeds both the "inputs" block and the models-list.yaml lookup that
+        # identifies the model. ChainMap rather than {**os.environ, ...} because on
+        # Windows os.environ upper-cases its keys when copied, which would drop every
+        # lowercase download variable; chaining delegates the lookup instead.
+        metadata_env = ChainMap({"model_directory": model_directory}, os.environ)
+
         marker = Path(output_dir) / MARKER_NAME
         if marker.is_file():
             emit_json_info(f"Removing incomplete previous download: {repo_id}")
             discard_incomplete_download(output_dir, args.output_dir, interrupted_patterns(marker))
         if is_installed(output_dir, patterns):
-            installed = ", ".join(p.name for p in matching_files(output_dir, patterns))
-            emit_json_info(f"Model exists: {repo_id} ({installed})")
+            present = sorted(str(p.resolve()) for p in matching_files(output_dir, patterns) if p.suffix == ".gguf")
+            installed = ", ".join(Path(p).name for p in present)
+            # Named here as well as after a transfer: a caller asking for a model by URL
+            # gets its id back whether this run had to fetch anything or not. Derived from
+            # the files this request matched, the same way the download path derives it, so
+            # the two cannot disagree about a repository holding several quantizations.
+            identity = identify_model(metadata_env, fallback_model_id=fallback_model_id(source["model_type"], present))
+            # An undeclared model is listed only through its record, so name it only when
+            # that record is on disk - again the rule the download path applies.
+            named = identity["model_origin"] == ORIGIN_BUILTIN or read_metadata(output_dir) is not None
+            emit_json_info(
+                f"Model exists: {repo_id} ({installed})",
+                artifacts=present,
+                model_id=identity["model_id"] if named else None,
+                size_mb=downloaded_size_mb(present),
+            )
             return
         if os.path.isdir(output_dir) and not has_model_content(output_dir):
             # Bookkeeping-only leftover (e.g. killed between makedirs and the marker
@@ -1081,18 +1107,6 @@ def main():
         # Nothing has been written yet, and the model URL or key comes from the host
         # configuration: check what it points at before creating a directory for it.
         validate_hub_source_or_exit(source, args.hf_token)
-
-        # The model directory is the repo id: the download always lands in
-        # <output_dir>/<repo_id>. models-list.yaml usually spells it out, but it is
-        # redundant — repo_id is a substring of the model URL (and of the model key),
-        # so derive it when the variable is not set rather than recording nothing.
-        model_directory = os.environ.get("model_directory") or repo_id
-        # Environment the metadata record is built from, with model_directory filled
-        # in: it feeds both the "inputs" block and the models-list.yaml lookup that
-        # identifies the model. ChainMap rather than {**os.environ, ...} because on
-        # Windows os.environ upper-cases its keys when copied, which would drop every
-        # lowercase download variable; chaining delegates the lookup instead.
-        metadata_env = ChainMap({"model_directory": model_directory}, os.environ)
 
         os.makedirs(output_dir, exist_ok=True)
         write_marker(

--- a/containers/bricks/models-downloader/tests/test_hf_downloader.py
+++ b/containers/bricks/models-downloader/tests/test_hf_downloader.py
@@ -1059,14 +1059,18 @@ def test_downloaded_size_mb_when_a_file_cannot_be_read(tmp_path):
 
 
 def test_downloaded_size_mb_matches_what_the_listing_reports(tmp_path):
-    """A caller must not see the size change just because a listing ran."""
+    """A caller must not see the size change just because a listing ran.
+
+    Sizes deliberately not whole megabytes: rounding the byte total once instead of per
+    file agrees with the listing on round numbers and drifts on everything else.
+    """
     import list_models
 
     gguf = tmp_path / "llamacpp" / "org" / "repo" / "model-Q4_0.gguf"
     gguf.parent.mkdir(parents=True)
-    gguf.write_bytes(b"\0" * (1024 * 1024))
+    gguf.write_bytes(b"\0" * (1024 * 1024 + 5243))
     mmproj = gguf.parent / "mmproj-BF16.gguf"
-    mmproj.write_bytes(b"\0" * (512 * 1024))
+    mmproj.write_bytes(b"\0" * (512 * 1024 + 5243))
 
     listed = list_models.find_llamacpp_models(str(tmp_path))
     assert len(listed) == 1

--- a/containers/bricks/models-downloader/tests/test_hf_downloader.py
+++ b/containers/bricks/models-downloader/tests/test_hf_downloader.py
@@ -33,6 +33,8 @@ from hugging_face.hf_downloader import (
     delete_matched_files,
     discard_incomplete_download,
     download_matched_files,
+    downloaded_size_mb,
+    emit_json_info,
     fallback_model_id,
     gguf_pattern,
     has_model_content,
@@ -1031,3 +1033,64 @@ def test_check_answers_for_the_requested_quantization_only(tmp_path, monkeypatch
     with pytest.raises(SystemExit):
         _run_main(monkeypatch, "--check", "--model-url", "unsloth/Qwen3-0.6B-GGUF:Q3_K_S", "--output-dir", str(models_dir))
     assert read_events(capsys)[-1] == {"event": "error", "description": "Model does not exist: *Q3_K_S*.gguf", "downloading": False}
+
+
+# --------------------------------------------------------------------------- #
+# downloaded_size_mb
+# --------------------------------------------------------------------------- #
+def test_downloaded_size_mb_sums_the_files(tmp_path):
+    main = tmp_path / "model-Q4_0.gguf"
+    main.write_bytes(b"\0" * (2 * 1024 * 1024))
+    mmproj = tmp_path / "mmproj-BF16.gguf"
+    mmproj.write_bytes(b"\0" * (1024 * 1024))
+
+    assert downloaded_size_mb([str(main), str(mmproj)]) == 3.0
+
+
+def test_downloaded_size_mb_without_files():
+    assert downloaded_size_mb([]) is None
+
+
+def test_downloaded_size_mb_when_a_file_cannot_be_read(tmp_path):
+    """Better no size than a total that silently omits part of the model."""
+    present = tmp_path / "model-Q4_0.gguf"
+    present.write_bytes(b"\0")
+    assert downloaded_size_mb([str(present), str(tmp_path / "gone.gguf")]) is None
+
+
+def test_downloaded_size_mb_matches_what_the_listing_reports(tmp_path):
+    """A caller must not see the size change just because a listing ran."""
+    import list_models
+
+    gguf = tmp_path / "llamacpp" / "org" / "repo" / "model-Q4_0.gguf"
+    gguf.parent.mkdir(parents=True)
+    gguf.write_bytes(b"\0" * (1024 * 1024))
+    mmproj = gguf.parent / "mmproj-BF16.gguf"
+    mmproj.write_bytes(b"\0" * (512 * 1024))
+
+    listed = list_models.find_llamacpp_models(str(tmp_path))
+    assert len(listed) == 1
+    assert downloaded_size_mb([str(gguf), str(mmproj)]) == listed[0]["disk_size_mb"]
+
+
+# --------------------------------------------------------------------------- #
+# emit_json_info
+# --------------------------------------------------------------------------- #
+def test_emit_json_info_reports_the_model_id_and_size(capsys):
+    emit_json_info("Downloaded to: /models", artifacts=["/models/m.gguf"], model_id="llamacpp:m", size_mb=12.5)
+
+    assert read_events(capsys) == [
+        {
+            "event": "info",
+            "description": "Downloaded to: /models",
+            "artifacts": ["/models/m.gguf"],
+            "model_id": "llamacpp:m",
+            "size_mb": 12.5,
+        }
+    ]
+
+
+def test_emit_json_info_omits_what_it_was_not_given(capsys):
+    """A plain progress message must not grow null fields the host would have to skip."""
+    emit_json_info("Downloading")
+    assert read_events(capsys) == [{"event": "info", "description": "Downloading"}]

--- a/containers/bricks/models-downloader/tests/test_model_metadata.py
+++ b/containers/bricks/models-downloader/tests/test_model_metadata.py
@@ -12,6 +12,7 @@ import yaml
 
 from common.model_metadata import (
     METADATA_NAME,
+    ORIGIN_USER_CONFIGURED,
     collect_inputs,
     identify_model,
     is_bookkeeping_name,
@@ -420,3 +421,18 @@ def test_written_file_is_plain_safe_yaml(tmp_path):
     text = (tmp_path / METADATA_NAME).read_text()
     assert "!!python" not in text
     assert yaml.safe_load(text)["inputs"] == HF_ENV
+
+
+def test_write_uses_a_passed_identity(tmp_path):
+    """A handler reporting the id to the host records the same one, without re-resolving."""
+    identity = {"model_id": "llamacpp:from-caller", "model_origin": ORIGIN_USER_CONFIGURED}
+    write_metadata(str(tmp_path), "hf-handler", env=HF_ENV, models_list_path="", identity=identity)
+
+    data = read_metadata(str(tmp_path))
+    assert data["model_id"] == "llamacpp:from-caller"
+    assert data["model_origin"] == ORIGIN_USER_CONFIGURED
+
+
+def test_write_resolves_the_identity_when_none_is_passed(tmp_path):
+    write_metadata(str(tmp_path), "hf-handler", env=HF_ENV, models_list_path="", fallback_model_id="llamacpp:derived")
+    assert read_metadata(str(tmp_path))["model_id"] == "llamacpp:derived"


### PR DESCRIPTION
## Problem

A Hugging Face download that no `models-list.yaml` entry declares gets its id from the file that arrived. The handler already computes that id — `fallback_model_id` — and writes it into `.arduino_metadata.yaml`, but never tells the caller. So the host has to either re-derive it from the artifact filenames, re-implementing the naming rule a third time, or run the list action to read it back: a container start immediately after a multi-GB transfer.

The same goes for the size, which the host currently learns only from a later listing.

## Change

Resolve the identity once, record it, and report it on the same `info` event that already carries the artifacts, together with the total size of the files written.

```
{"event":"info","description":"Downloaded to: /models/llamacpp/unsloth/SmolLM2-135M-Instruct-GGUF",
 "artifacts":["/models/.../SmolLM2-135M-Instruct-Q4_K_M.gguf"],
 "model_id":"llamacpp:SmolLM2-135M-Instruct-Q4_K_M","size_mb":105.4}
```

Both fields are omitted when absent, so an ordinary progress message is unchanged and an older host ignores them.

`write_metadata` gains an optional `identity` argument. Passing the resolved dict to both the record and the event is what makes it impossible for the two to name the model differently — the previous shape would have meant calling `identify_model` twice.

`model_id` is reported **only when the record was written**. An undeclared model is reconstructed from that record, so if the write failed the model cannot be listed at all and naming it here would promise an id that no later request resolves. `write_metadata` still never fails a download.

`size_mb` counts the mmproj file with the main GGUF, matching what `list_models.py` reports as `disk_size_mb`, so the number does not change once a listing runs. A file that cannot be stat'd yields no size rather than a total that silently omits part of the model.

