### PR TITLE
Prevent same-named GGUFs from different owners from sharing the same model id

### DIFF
--- a/.github/workflows/_build-containers-dev.yml
+++ b/.github/workflows/_build-containers-dev.yml
@@ -134,7 +134,7 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
 
       - name: Copy models-list.yaml into build context
-        if: matrix.container == 'models-downloader'
+        if: contains(fromJSON('["models-downloader", "llamacpp-runner", "llamacpp-npu-runner"]'), matrix.container)
         run: cp models/models-list.yaml ${{ steps.dir.outputs.path }}/models-list.yaml
 
       - name: Build and push Docker image

--- a/.github/workflows/_build-containers-release.yml
+++ b/.github/workflows/_build-containers-release.yml
@@ -211,7 +211,7 @@ jobs:
             org.opencontainers.image.url=${{ env.GH_DESTINATION_REPO }}
 
       - name: Copy models-list.yaml into build context
-        if: steps.rebuild_check.outputs.needs_build == 'true' && matrix.container == 'models-downloader'
+        if: steps.rebuild_check.outputs.needs_build == 'true' && contains(fromJSON('["models-downloader", "llamacpp-runner", "llamacpp-npu-runner"]'), matrix.container)
         run: cp models/models-list.yaml ${{ steps.dir.outputs.path }}/models-list.yaml
 
       - name: Build and push Docker image

--- a/containers/ai/llamacpp-npu-runner/Dockerfile
+++ b/containers/ai/llamacpp-npu-runner/Dockerfile
@@ -14,8 +14,11 @@ ARG LLAMA_CPP_DIGEST
 ADD --checksum=${LLAMA_CPP_DIGEST} ${LLAMA_CPP_URL} /tmp/llamacpp.tar.gz
 
 COPY ./scripts/* /
+COPY ./models-list.yaml /models-list.yaml
 
 RUN set -ex; \
+    # pyyaml: configure-llamacpp.py parses /models-list.yaml
+    pip install --no-cache-dir pyyaml; \
     tar -xzf /tmp/llamacpp.tar.gz -C /opt; \
     rm /tmp/llamacpp.tar.gz; \
     chown -R arduino:arduino /opt/pkg-snapdragon; \

--- a/containers/ai/llamacpp-npu-runner/ci.json
+++ b/containers/ai/llamacpp-npu-runner/ci.json
@@ -1,5 +1,5 @@
 {
-  "watch_paths": ["containers/ai/llamacpp-npu-runner/"],
+  "watch_paths": ["containers/ai/llamacpp-npu-runner/", "models/"],
   "tag_latest": false,
   "build_whl": false,
   "update_compose": true,

--- a/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
@@ -19,7 +19,6 @@ Usage:
 import argparse
 import configparser
 import sys
-from collections import Counter
 from pathlib import Path
 from typing import NamedTuple
 
@@ -188,12 +187,81 @@ def detect_hexagon_ndev(models, ctx_size: int) -> int:
 # --------------------------------------------------------------------------- #
 
 
-def find_models(models_dir: Path):
+# The curated catalog, baked into the image, decides the served model names
+MODELS_LIST_PATH = "/models-list.yaml"
+
+
+def curated_declarations(models_list_path):
+    """The (model_directory, filename) locations that models-list.yaml declares for llamacpp.
+    A GGUF at a declared location is a curated model and keeps its file stem as the served
+    name; every other file is ad-hoc and is named by its path.
+
+    ``filename`` is None when the entry's model_url pins no file (a compact key naming
+    a quantization); any GGUF inside the directory then counts as declared.
+
+    An unreadable catalog degrades to no declarations: every model is then named by its path,
+    and curated models fail instead of being served under an ambiguous stem.
+
+    Mirrors the models-downloader's common/gguf_naming.py, keep the two in sync. This code
+    is duplicated in the llamacpp-runner and llamacpp-npu-runner images.
+    """
+    try:
+        import yaml
+
+        with open(models_list_path) as f:
+            entries = (yaml.safe_load(f) or {}).get("models", [])
+    except Exception:
+        return []
+
+    declarations = []
+    for entry in entries if isinstance(entries, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        for model_data in entry.values():
+            if not isinstance(model_data, dict):
+                continue
+            deployment = model_data.get("deployment")
+            platforms = deployment.get("platforms") if isinstance(deployment, dict) else None
+            for platform_entry in platforms or []:
+                if not isinstance(platform_entry, dict):
+                    continue
+                for platform_config in platform_entry.values():
+                    variables = platform_config.get("variables") if isinstance(platform_config, dict) else None
+                    if not isinstance(variables, dict):
+                        continue
+                    repository = str(variables.get("models_repository") or "")
+                    if repository.rsplit("/models/", 1)[-1].removeprefix("models/") != "llamacpp":
+                        continue
+                    directory = str(variables.get("model_directory") or "").strip("/")
+                    if not directory:
+                        continue
+                    url = str(variables.get("model_url") or "")
+                    base = url.split("?")[0].rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+                    declaration = (directory, base if base.endswith(".gguf") else None)
+                    if declaration not in declarations:
+                        declarations.append(declaration)
+    return declarations
+
+
+def gguf_model_name(gguf_file: Path, models_dir: Path, declarations) -> str:
+    """The name llama-server serves this file under (see curated_declarations)."""
+    rel = gguf_file.relative_to(models_dir)
+    rel_dir = rel.parent.as_posix()
+    rel_dir = "" if rel_dir == "." else rel_dir
+    for directory, filename in declarations:
+        if rel_dir != directory and not rel_dir.startswith(directory + "/"):
+            continue
+        if filename is None or filename == gguf_file.name:
+            return gguf_file.stem
+    return rel.with_suffix("").as_posix()
+
+
+def find_models(models_dir: Path, models_list_path: str = MODELS_LIST_PATH):
     """Return {model name: {"model": path, "mmproj": path}} for every model in models_dir."""
     models = {}
+    declarations = curated_declarations(models_list_path)
 
     gguf_files = [p for p in sorted(models_dir.rglob("*.gguf")) if "mmproj" not in p.name]
-    stems = Counter(p.stem for p in gguf_files)
     for gguf_file in gguf_files:
         entry = {"model": gguf_file.as_posix()}
 
@@ -202,19 +270,15 @@ def find_models(models_dir: Path):
         if mmproj_files:
             entry["mmproj"] = mmproj_files[0].as_posix()
 
-        if stems[gguf_file.stem] == 1:
-            name = gguf_file.stem
-        else:
-            name = gguf_file.relative_to(models_dir).with_suffix("").as_posix()
-        models[name] = entry
+        models[gguf_model_name(gguf_file, models_dir, declarations)] = entry
 
     return models
 
 
-def generate_models_ini(models_dir: Path):
+def generate_models_ini(models_dir: Path, models_list_path: str = MODELS_LIST_PATH):
     """Write the models.ini preset indexing every model in models_dir."""
     config = configparser.ConfigParser()
-    config.read_dict(find_models(models_dir))
+    config.read_dict(find_models(models_dir, models_list_path))
 
     output_path = models_dir / "models.ini"
     with open(output_path, "w") as f:
@@ -248,6 +312,11 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--models-list",
+        default=MODELS_LIST_PATH,
+        help=f"Path to the curated models-list.yaml (default: {MODELS_LIST_PATH})",
+    )
+    parser.add_argument(
         "--ctx",
         type=int,
         default=0,
@@ -266,13 +335,13 @@ def main():
 
     if args.print_ctx:
         print(f"Scanning installed models to check they hold a {args.ctx} token context...", file=sys.stderr)
-        print(detect_ctx_size(find_models(args.models_dir), args.ctx))
+        print(detect_ctx_size(find_models(args.models_dir, args.models_list), args.ctx))
     elif args.print_ndev:
         scope = f"a {args.ctx} token context" if args.ctx > 0 else "the default context"
         print(f"Scanning installed models to size the Hexagon sessions for {scope}...", file=sys.stderr)
-        print(detect_hexagon_ndev(find_models(args.models_dir), args.ctx))
+        print(detect_hexagon_ndev(find_models(args.models_dir, args.models_list), args.ctx))
     else:
-        generate_models_ini(args.models_dir)
+        generate_models_ini(args.models_dir, args.models_list)
 
 
 if __name__ == "__main__":

--- a/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
@@ -19,6 +19,7 @@ Usage:
 import argparse
 import configparser
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import NamedTuple
 
@@ -191,10 +192,9 @@ def find_models(models_dir: Path):
     """Return {model name: {"model": path, "mmproj": path}} for every model in models_dir."""
     models = {}
 
-    for gguf_file in sorted(models_dir.rglob("*.gguf")):
-        if "mmproj" in gguf_file.name:
-            continue
-
+    gguf_files = [p for p in sorted(models_dir.rglob("*.gguf")) if "mmproj" not in p.name]
+    stems = Counter(p.stem for p in gguf_files)
+    for gguf_file in gguf_files:
         entry = {"model": gguf_file.as_posix()}
 
         # Look for mmproj file in the same directory
@@ -202,7 +202,11 @@ def find_models(models_dir: Path):
         if mmproj_files:
             entry["mmproj"] = mmproj_files[0].as_posix()
 
-        models[gguf_file.stem] = entry
+        if stems[gguf_file.stem] == 1:
+            name = gguf_file.stem
+        else:
+            name = gguf_file.relative_to(models_dir).with_suffix("").as_posix()
+        models[name] = entry
 
     return models
 

--- a/containers/ai/llamacpp-runner/Dockerfile
+++ b/containers/ai/llamacpp-runner/Dockerfile
@@ -13,11 +13,14 @@ ARG LLAMA_CPP_DIGEST
 ADD --checksum=${LLAMA_CPP_DIGEST} ${LLAMA_CPP_URL} /tmp/llamacpp.tar.gz
 
 COPY ./scripts/* /
+COPY ./models-list.yaml /models-list.yaml
 
 RUN set -x; \
     apt-get update -y; \
     apt-get install -y --no-install-recommends --no-install-suggests libgomp1; \
     apt-get dist-clean; \
+    # pyyaml: configure-llamacpp.py parses /models-list.yaml
+    pip install --no-cache-dir pyyaml; \
     tar -xzf /tmp/llamacpp.tar.gz -C /opt; \
     rm /tmp/llamacpp.tar.gz; \
     chown -R arduino:arduino /opt/pkg-cpu; \

--- a/containers/ai/llamacpp-runner/ci.json
+++ b/containers/ai/llamacpp-runner/ci.json
@@ -1,5 +1,5 @@
 {
-  "watch_paths": ["containers/ai/llamacpp-runner/"],
+  "watch_paths": ["containers/ai/llamacpp-runner/", "models/"],
   "tag_latest": false,
   "build_whl": false,
   "update_compose": true,

--- a/containers/ai/llamacpp-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-runner/scripts/configure-llamacpp.py
@@ -4,17 +4,20 @@
 
 import argparse
 import configparser
+from collections import Counter
 from pathlib import Path
 
 
 def generate_models_ini(models_dir: Path):
     config = configparser.ConfigParser()
 
-    for gguf_file in sorted(models_dir.rglob("*.gguf")):
-        if "mmproj" in gguf_file.name:
-            continue
-
-        section = gguf_file.stem
+    gguf_files = [p for p in sorted(models_dir.rglob("*.gguf")) if "mmproj" not in p.name]
+    stems = Counter(p.stem for p in gguf_files)
+    for gguf_file in gguf_files:
+        if stems[gguf_file.stem] == 1:
+            section = gguf_file.stem
+        else:
+            section = gguf_file.relative_to(models_dir).with_suffix("").as_posix()
         config[section] = {}
         config[section]["model"] = str(gguf_file.as_posix())
 

--- a/containers/ai/llamacpp-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-runner/scripts/configure-llamacpp.py
@@ -4,20 +4,84 @@
 
 import argparse
 import configparser
-from collections import Counter
 from pathlib import Path
 
+# The curated catalog, baked into the image, decides the served model names
+MODELS_LIST_PATH = "/models-list.yaml"
 
-def generate_models_ini(models_dir: Path):
+
+def curated_declarations(models_list_path):
+    """The (model_directory, filename) locations that models-list.yaml declares for llamacpp.
+    A GGUF at a declared location is a curated model and keeps its file stem as the served
+    name; every other file is ad-hoc and is named by its path.
+
+    ``filename`` is None when the entry's model_url pins no file (a compact key naming
+    a quantization); any GGUF inside the directory then counts as declared.
+
+    An unreadable catalog degrades to no declarations: every model is then named by its path,
+    and curated models fail instead of being served under an ambiguous stem.
+
+    Mirrors the models-downloader's common/gguf_naming.py, keep the two in sync. This code
+    is duplicated in the llamacpp-runner and llamacpp-npu-runner images.
+    """
+    try:
+        import yaml
+
+        with open(models_list_path) as f:
+            entries = (yaml.safe_load(f) or {}).get("models", [])
+    except Exception:
+        return []
+
+    declarations = []
+    for entry in entries if isinstance(entries, list) else []:
+        if not isinstance(entry, dict):
+            continue
+        for model_data in entry.values():
+            if not isinstance(model_data, dict):
+                continue
+            deployment = model_data.get("deployment")
+            platforms = deployment.get("platforms") if isinstance(deployment, dict) else None
+            for platform_entry in platforms or []:
+                if not isinstance(platform_entry, dict):
+                    continue
+                for platform_config in platform_entry.values():
+                    variables = platform_config.get("variables") if isinstance(platform_config, dict) else None
+                    if not isinstance(variables, dict):
+                        continue
+                    repository = str(variables.get("models_repository") or "")
+                    if repository.rsplit("/models/", 1)[-1].removeprefix("models/") != "llamacpp":
+                        continue
+                    directory = str(variables.get("model_directory") or "").strip("/")
+                    if not directory:
+                        continue
+                    url = str(variables.get("model_url") or "")
+                    base = url.split("?")[0].rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+                    declaration = (directory, base if base.endswith(".gguf") else None)
+                    if declaration not in declarations:
+                        declarations.append(declaration)
+    return declarations
+
+
+def gguf_model_name(gguf_file: Path, models_dir: Path, declarations) -> str:
+    """The name llama-server serves this file under (see curated_declarations)."""
+    rel = gguf_file.relative_to(models_dir)
+    rel_dir = rel.parent.as_posix()
+    rel_dir = "" if rel_dir == "." else rel_dir
+    for directory, filename in declarations:
+        if rel_dir != directory and not rel_dir.startswith(directory + "/"):
+            continue
+        if filename is None or filename == gguf_file.name:
+            return gguf_file.stem
+    return rel.with_suffix("").as_posix()
+
+
+def generate_models_ini(models_dir: Path, models_list_path: str):
     config = configparser.ConfigParser()
+    declarations = curated_declarations(models_list_path)
 
     gguf_files = [p for p in sorted(models_dir.rglob("*.gguf")) if "mmproj" not in p.name]
-    stems = Counter(p.stem for p in gguf_files)
     for gguf_file in gguf_files:
-        if stems[gguf_file.stem] == 1:
-            section = gguf_file.stem
-        else:
-            section = gguf_file.relative_to(models_dir).with_suffix("").as_posix()
+        section = gguf_model_name(gguf_file, models_dir, declarations)
         config[section] = {}
         config[section]["model"] = str(gguf_file.as_posix())
 
@@ -36,9 +100,14 @@ def generate_models_ini(models_dir: Path):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate models.ini from a models directory")
     parser.add_argument("models_dir", type=Path, help="Path to the models directory")
+    parser.add_argument(
+        "--models-list",
+        default=MODELS_LIST_PATH,
+        help=f"Path to the curated models-list.yaml (default: {MODELS_LIST_PATH})",
+    )
     args = parser.parse_args()
 
     if not args.models_dir.is_dir():
         raise SystemExit(f"Error: {args.models_dir} is not a directory")
 
-    generate_models_ini(args.models_dir)
+    generate_models_ini(args.models_dir, args.models_list)

--- a/containers/bricks/models-downloader/src/common/gguf_naming.py
+++ b/containers/bricks/models-downloader/src/common/gguf_naming.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unique names for the GGUF models sharing one directory tree.
+
+Different Hugging Face repositories can publish identically named GGUF files, so a
+model cannot be named after its file alone: two separate downloads would share one
+name — one listing id, one models.ini section — and delete, status and size would all
+act on whichever file happened to win.
+
+``gguf_model_names`` gives every file in the tree a distinct name: the file stem when
+no other file shares it (the historical name, so existing references keep resolving),
+the tree-relative path without its extension otherwise (which carries the repository,
+e.g. "unsloth/SmolLM2-135M-Instruct-GGUF/SmolLM2-135M-Instruct-Q4_K_M").
+
+The same map must name a model everywhere it appears: the listing id
+(``llamacpp:<name>``), the models.ini section (``<name>``) and the fallback metadata
+id. The LLM brick resolves ``llamacpp:<name>`` to the model llama-server serves under
+the section ``<name>``, so these may never drift apart. The runners' standalone
+configure-llamacpp.py scripts replicate this naming and must be kept in sync.
+"""
+
+from collections import Counter
+
+GGUF_SUFFIX = ".gguf"
+
+
+def gguf_model_names(rel_paths):
+    """Map each tree-relative GGUF path (posix separators) to its model name.
+
+    Callers pass only main model files — mmproj companions belong to the model in the
+    same directory and never name one.
+    """
+    stems = Counter(_stem(path) for path in rel_paths)
+    return {path: _stem(path) if stems[_stem(path)] == 1 else path[: -len(GGUF_SUFFIX)] for path in rel_paths}
+
+
+def _stem(rel_path):
+    name = rel_path.rsplit("/", 1)[-1]
+    return name[: -len(GGUF_SUFFIX)] if name.endswith(GGUF_SUFFIX) else name

--- a/containers/bricks/models-downloader/src/common/gguf_naming.py
+++ b/containers/bricks/models-downloader/src/common/gguf_naming.py
@@ -2,40 +2,108 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-"""Unique names for the GGUF models sharing one directory tree.
+"""Names for the GGUF models of the llamacpp tree, decided by the curated catalog.
 
 Different Hugging Face repositories can publish identically named GGUF files, so a
 model cannot be named after its file alone: two separate downloads would share one
 name — one listing id, one models.ini section — and delete, status and size would all
 act on whichever file happened to win.
 
-``gguf_model_names`` gives every file in the tree a distinct name: the file stem when
-no other file shares it (the historical name, so existing references keep resolving),
-the tree-relative path without its extension otherwise (which carries the repository,
-e.g. "unsloth/SmolLM2-135M-Instruct-GGUF/SmolLM2-135M-Instruct-Q4_K_M").
+``gguf_model_name`` names a file by whether models-list.yaml declares it:
 
-The same map must name a model everywhere it appears: the listing id
+- A **curated** file (its location matches a catalog declaration) keeps the file stem.
+  Curated ids are fixed ``llamacpp:<stem>`` keys in models-list.yaml, referenced from
+  installed apps, so their names are backward compatible forever.
+- An **ad-hoc** file is named by its tree-relative path without the extension, which
+  carries the repository (e.g. "unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M"). The name is
+  unique by construction and stable for the whole life of the install — it never
+  changes when a same-named file is downloaded from another repository, and an
+  impostor named like a curated model can never answer to the curated name.
+
+The same rule must name a model everywhere it appears: the listing id
 (``llamacpp:<name>``), the models.ini section (``<name>``) and the fallback metadata
 id. The LLM brick resolves ``llamacpp:<name>`` to the model llama-server serves under
 the section ``<name>``, so these may never drift apart. The runners' standalone
 configure-llamacpp.py scripts replicate this naming and must be kept in sync.
+
+The catalog is baked into every image that names models (the models-downloader and
+both llamacpp runners), so a missing or unreadable copy is a build defect: it degrades
+to "no declarations", which names every file by its path and makes curated models fail
+loudly instead of serving under an ambiguous stem.
 """
 
-from collections import Counter
+from common.models_list import MODELS_LIST_PATH, _iter_platform_variables, get_model_subdir, load_models_list
 
 GGUF_SUFFIX = ".gguf"
 
+# The subdirectory of the models mount that holds GGUF models, and the id namespace
+# derived from it. The declarations below are relative to this directory.
+LLAMACPP_SUBDIR = "llamacpp"
 
-def gguf_model_names(rel_paths):
-    """Map each tree-relative GGUF path (posix separators) to its model name.
 
-    Callers pass only main model files — mmproj companions belong to the model in the
-    same directory and never name one.
+def gguf_basename(model_url):
+    """The GGUF file name *model_url* pins, or None when it does not pin one.
+
+    Works on both syntaxes hf_downloader accepts: the basename of a file URL, or a
+    compact key whose quantization field is a full file name
+    ("org/repo:model-Q4_0.gguf"). A key naming only a quantization pins no file.
     """
-    stems = Counter(_stem(path) for path in rel_paths)
-    return {path: _stem(path) if stems[_stem(path)] == 1 else path[: -len(GGUF_SUFFIX)] for path in rel_paths}
+    base = (model_url or "").split("?")[0].rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+    return base if base.endswith(GGUF_SUFFIX) else None
 
 
-def _stem(rel_path):
-    name = rel_path.rsplit("/", 1)[-1]
-    return name[: -len(GGUF_SUFFIX)] if name.endswith(GGUF_SUFFIX) else name
+def declared_gguf_files(models):
+    """The file location every llamacpp-backed models-list.yaml entry declares.
+
+    Returns:
+        ``(model_directory, filename, model_id)`` tuples, deduplicated across the
+        per-board platform repeats. ``filename`` is None when the entry's model_url
+        pins no file (a compact key naming a quantization); any GGUF inside the
+        directory then counts as declared.
+    """
+    declarations = []
+    for model_id, _model_data, _platform, variables in _iter_platform_variables(models):
+        if get_model_subdir(variables.get("models_repository", "")) != LLAMACPP_SUBDIR:
+            continue
+        directory = (variables.get("model_directory") or "").strip("/")
+        if not directory:
+            continue
+        declaration = (directory, gguf_basename(variables.get("model_url", "")), model_id)
+        if declaration not in declarations:
+            declarations.append(declaration)
+    return declarations
+
+
+def catalog_gguf_declarations(models_list_path=MODELS_LIST_PATH):
+    """``declared_gguf_files`` of the catalog baked into the image; () when unusable."""
+    try:
+        return declared_gguf_files(load_models_list(models_list_path))
+    except Exception:  # noqa: BLE001 - see the module docstring: degrade, never crash
+        return ()
+
+
+def declaration_covers(directory, declared_name, rel_dir, filename):
+    """Whether a declaration covers the GGUF at *rel_dir*/*filename*.
+
+    The file may sit below the declared directory (some repositories nest their
+    files in per-quantization folders). A declaration that pins no file name covers
+    any GGUF in its directory; an unknown *filename* (a pending download whose
+    marker names no file) is only covered by those.
+    """
+    if rel_dir != directory and not rel_dir.startswith(directory + "/"):
+        return False
+    return declared_name is None or declared_name == filename
+
+
+def gguf_model_name(rel_path, declarations):
+    """The name identifying the GGUF at *rel_path* (tree-relative, posix separators).
+
+    The file stem when *declarations* covers the file — see the module docstring —
+    the relative path without its extension otherwise. Callers pass only main model
+    files: mmproj companions belong to the model in the same directory and never
+    name one.
+    """
+    rel_dir, _, filename = rel_path.rpartition("/")
+    if any(declaration_covers(directory, declared_name, rel_dir, filename) for directory, declared_name, _model_id in declarations):
+        return filename[: -len(GGUF_SUFFIX)]
+    return rel_path[: -len(GGUF_SUFFIX)]

--- a/containers/bricks/models-downloader/src/common/model_metadata.py
+++ b/containers/bricks/models-downloader/src/common/model_metadata.py
@@ -37,10 +37,10 @@ Contracts callers must honour:
 - ``model_id`` is always set for a model that downloaded successfully, curated or not.
   A user-configured model has no entry key to borrow, so the handler supplies a
   ``fallback_model_id`` derived from what it fetched, matching the id the listing
-  reports for the same files. That id is a snapshot: if a same-named file is later
-  downloaded from another repository, the listing path-qualifies both ids (see
-  ``common/gguf_naming.py``) and the recorded one goes stale. The listing, derived
-  from the filesystem, is the authority.
+  reports for the same files (``common/gguf_naming.py``). That id is a snapshot: if
+  the model is later added to the curated catalog its listing name changes to the
+  entry's stem-form id and the recorded one goes stale. The listing, derived from
+  the filesystem and the catalog, is the authority.
 - Nothing else is copied out of models-list.yaml. ``model_id`` points back at the
   entry, and every other field of it (name, description, source, model_size_mb, ...)
   is read from models-list.yaml itself rather than duplicated — and left to go stale —

--- a/containers/bricks/models-downloader/src/common/model_metadata.py
+++ b/containers/bricks/models-downloader/src/common/model_metadata.py
@@ -37,7 +37,10 @@ Contracts callers must honour:
 - ``model_id`` is always set for a model that downloaded successfully, curated or not.
   A user-configured model has no entry key to borrow, so the handler supplies a
   ``fallback_model_id`` derived from what it fetched, matching the id the listing
-  reports for the same files.
+  reports for the same files. That id is a snapshot: if a same-named file is later
+  downloaded from another repository, the listing path-qualifies both ids (see
+  ``common/gguf_naming.py``) and the recorded one goes stale. The listing, derived
+  from the filesystem, is the authority.
 - Nothing else is copied out of models-list.yaml. ``model_id`` points back at the
   entry, and every other field of it (name, description, source, model_size_mb, ...)
   is read from models-list.yaml itself rather than duplicated — and left to go stale —

--- a/containers/bricks/models-downloader/src/common/model_metadata.py
+++ b/containers/bricks/models-downloader/src/common/model_metadata.py
@@ -21,12 +21,25 @@ the model directory after a successful download and stays there:
 
 Contracts callers must honour:
 
-- ``write_metadata`` never raises and never fails a download. Bookkeeping must not
-  turn a completed multi-GB transfer into a failure, so a write error is reported as
-  an ``info`` event (not ``error``, which the host would read as a failed download)
-  and the function returns None.
-- The file is therefore **optional**. Its absence means "unknown / legacy install",
-  never "up to date": models downloaded before this file existed have none.
+- ``write_metadata`` never raises: a write error is reported as an ``info`` event and
+  the function returns None. Whether that fails the download is the caller's decision,
+  and the two kinds of handler decide it differently:
+
+  * The Hugging Face handler treats None as **fatal** — it keeps the ".download"
+    marker (so the next run discards and retries) and exits non-zero. This reverses
+    the original "bookkeeping must never fail a completed multi-GB transfer" stance,
+    deliberately: an ad-hoc model is deleted through the API by the ``inputs``
+    recorded here, so an installed-but-unrecorded ad-hoc model would be permanently
+    unmanageable, while a lost transfer can simply be repeated. The reversal happened
+    before ad-hoc models went GA, which is what makes the next bullet possible.
+  * The AI Hub and Edge Impulse handlers keep it best-effort: their models are all
+    declared in models-list.yaml, so the host can always manage them from the
+    declaration alone and the record only feeds outdated-detection.
+
+- For **readers** the file stays optional — installs made before it existed, or by a
+  best-effort handler, have none, and its absence means "unknown / legacy install",
+  never "up to date". But every ad-hoc model installed by a current downloader is
+  guaranteed to carry one.
 - ``model_origin`` says where the model comes from, not where its id was read from:
   ``builtin`` for a model models-list.yaml declares, ``user_configured`` for one
   downloaded ad hoc. Any Hugging Face repository can be fetched by putting its URL or

--- a/containers/bricks/models-downloader/src/common/models_list.py
+++ b/containers/bricks/models-downloader/src/common/models_list.py
@@ -17,6 +17,27 @@ def load_models_list(yaml_path):
     return data.get("models", [])
 
 
+def get_model_subdir(models_repository):
+    """Extract the relative subfolder from a models_repository path.
+
+    e.g. "/var/lib/arduino-app-cli/models/audio-analytics/tts" -> "audio-analytics/tts"
+         "/var/lib/arduino-app-cli/models/genai" -> "genai"
+         "models/genai" -> "genai"
+         "models/audio-analytics/asr" -> "audio-analytics/asr"
+    """
+    marker = "/models/"
+    idx = models_repository.rfind(marker)
+    if idx != -1:
+        return models_repository[idx + len(marker) :]
+    # Handle relative paths like "models/genai" or "models/audio-analytics/asr"
+    if models_repository.startswith("models/"):
+        return models_repository[len("models/") :]
+    # Bare repository name (e.g. "edge-impulse", "genai") => use as-is
+    if models_repository:
+        return models_repository
+    return ""
+
+
 def _iter_platform_variables(models):
     """Yield ``(model_id, model_data, platform_name, variables)`` for every deployment platform."""
     for entry in models:

--- a/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
+++ b/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
@@ -96,6 +96,7 @@ import json
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from common.download_marker import MARKER_NAME, read_marker, write_marker
+from common.gguf_naming import gguf_model_names
 from common.model_metadata import is_bookkeeping_name, write_metadata
 
 # Quantization used when a model key names only a repository. Q4_0 is the quantization
@@ -745,20 +746,26 @@ def validate_hub_source(source: dict, token: str | None = None) -> None:
             raise ValueError(missing_file_message(repo_id, filename, file_revision, present))
 
 
-def fallback_model_id(model_type: str, downloaded: list[str]) -> str | None:
+def fallback_model_id(model_type: str, downloaded: list[str], models_dir: str) -> str | None:
     """Name a model that no models-list.yaml entry declares, from the files fetched.
 
-    Built as ``<namespace>:<gguf stem>`` to be the *same* id ``list_models.py`` derives
-    for those files when it scans the filesystem, so the record and the listing agree on
-    what to call an ad-hoc download. mmproj files belong to the main GGUF and never name
-    the model.
+    Built as ``<namespace>:<model name>`` with the naming ``list_models.py`` and
+    models.ini share, so the record and the listing agree on what to call an ad-hoc
+    download. mmproj files belong to the main GGUF and never name the model.
     """
     main_gguf = next((p for p in sorted(downloaded) if "mmproj" not in os.path.basename(p)), None)
     if not main_gguf:
         return None
+    base = Path(models_dir).resolve()
+    all_ggufs = [p for p in sorted(base.rglob("*.gguf")) if "mmproj" not in p.name]
+    names = gguf_model_names([p.relative_to(base).as_posix() for p in all_ggufs])
+    try:
+        name = names[Path(main_gguf).resolve().relative_to(base).as_posix()]
+    except (KeyError, ValueError):  # not under models_dir: name it by its stem alone
+        name = Path(main_gguf).stem
     # The key's model_type is the namespace when given; llamacpp is where GGUF models
     # live, and the prefix list_models.py uses (see its LLAMACPP_SUBDIR).
-    return f"{model_type or 'llamacpp'}:{Path(main_gguf).stem}"
+    return f"{model_type or 'llamacpp'}:{name}"
 
 
 def no_match_message(repo_id: str, pattern: str) -> str:
@@ -826,7 +833,7 @@ def delete_matched_files(output_dir: str, models_base: str, allow_pattern: str, 
         f.unlink()
     # Remove empty subdirectories (deepest first), but never output_dir itself
     for d in sorted(dirs_to_check, key=lambda p: len(p.parts), reverse=True):
-        if d == models_base:
+        if d == models_base_path:
             continue
         if d.exists() and not any(d.iterdir()):
             if verbose:
@@ -841,13 +848,19 @@ def delete_matched_files(output_dir: str, models_base: str, allow_pattern: str, 
 
 
 def generate_models_ini(models_dir: Path):
+    """Write the models.ini indexing every GGUF under *models_dir*.
+
+    Sections are the names ``gguf_model_names`` assigns — the file stem, or the
+    models_dir-relative path when two repositories publish the same file name — so
+    every file keeps its own section instead of one silently shadowing the other,
+    and each section matches the listing id of the same file.
+    """
     config = configparser.ConfigParser()
 
-    for gguf_file in sorted(models_dir.rglob("*.gguf")):
-        if "mmproj" in gguf_file.name:
-            continue
-
-        section = gguf_file.stem
+    gguf_files = [p for p in sorted(models_dir.rglob("*.gguf")) if "mmproj" not in p.name]
+    names = gguf_model_names([p.relative_to(models_dir).as_posix() for p in gguf_files])
+    for gguf_file in gguf_files:
+        section = names[gguf_file.relative_to(models_dir).as_posix()]
         config[section] = {}
         config[section]["model"] = str(gguf_file.as_posix())
 
@@ -1151,7 +1164,7 @@ def main():
             env=metadata_env,
             # Any repository can be downloaded without a models-list.yaml entry, so name
             # it after the file that arrived rather than leaving it unidentified.
-            fallback_model_id=fallback_model_id(source["model_type"], downloaded),
+            fallback_model_id=fallback_model_id(source["model_type"], downloaded, args.output_dir),
         )
 
         marker = Path(output_dir) / MARKER_NAME

--- a/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
+++ b/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
@@ -1161,7 +1161,7 @@ def main():
         # Record what was downloaded, then clear the in-progress marker: while the
         # marker is still there the repo directory counts as incomplete, so a crash
         # in between makes the next run retry instead of leaving it unrecorded.
-        write_metadata(
+        recorded = write_metadata(
             output_dir,
             handler="hf-handler",
             env=metadata_env,
@@ -1169,6 +1169,13 @@ def main():
             # it after the file that arrived rather than leaving it unidentified.
             fallback_model_id=fallback_model_id(source["model_type"], downloaded, args.output_dir),
         )
+        if recorded is None:
+            # The record is required, not best-effort: the host deletes an ad-hoc model
+            # by the inputs recorded here, so an installed-but-unrecorded model could
+            # never be removed through the API. Keeping the marker makes the next
+            # run discard and retry.
+            emit_json_error(f"Downloaded {repo_id}, but its metadata record could not be written; the download will be retried")
+            raise SystemExit(1)
 
         marker = Path(output_dir) / MARKER_NAME
         if marker.exists():

--- a/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
+++ b/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
@@ -68,7 +68,9 @@ interrupted or failed download only discards the files it was fetching, never a 
 quantization that finished earlier.
 
 After all files are downloaded, ``models.ini`` is written to ``<output-dir>``
-mapping each model stem to its GGUF path (and mmproj path where present).
+mapping each model name to its GGUF path (and mmproj path where present); names
+follow ``common/gguf_naming.py`` — the file stem for models the curated catalog
+declares, the output-dir-relative path for ad-hoc downloads.
 """
 
 import fnmatch
@@ -96,7 +98,7 @@ import json
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from common.download_marker import MARKER_NAME, read_marker, write_marker
-from common.gguf_naming import gguf_model_names
+from common.gguf_naming import catalog_gguf_declarations, gguf_model_name
 from common.model_metadata import is_bookkeeping_name, write_metadata
 
 # Quantization used when a model key names only a repository. Q4_0 is the quantization
@@ -750,21 +752,20 @@ def fallback_model_id(model_type: str, downloaded: list[str], models_dir: str) -
     """Name a model that no models-list.yaml entry declares, from the files fetched.
 
     Built as ``<namespace>:<model name>`` with the naming ``list_models.py`` and
-    models.ini share, so the record and the listing agree on what to call an ad-hoc
-    download. mmproj files belong to the main GGUF and never name the model.
+    models.ini share (``gguf_model_name`` against the catalog baked into the image),
+    so the record and the listing agree on what to call an ad-hoc download. mmproj
+    files belong to the main GGUF and never name the model.
     """
     main_gguf = next((p for p in sorted(downloaded) if "mmproj" not in os.path.basename(p)), None)
     if not main_gguf:
         return None
-    base = Path(models_dir).resolve()
-    all_ggufs = [p for p in sorted(base.rglob("*.gguf")) if "mmproj" not in p.name]
-    names = gguf_model_names([p.relative_to(base).as_posix() for p in all_ggufs])
     try:
-        name = names[Path(main_gguf).resolve().relative_to(base).as_posix()]
-    except (KeyError, ValueError):  # not under models_dir: name it by its stem alone
+        rel = Path(main_gguf).resolve().relative_to(Path(models_dir).resolve()).as_posix()
+        name = gguf_model_name(rel, catalog_gguf_declarations())
+    except ValueError:  # not under models_dir: name it by its stem alone
         name = Path(main_gguf).stem
     # The key's model_type is the namespace when given; llamacpp is where GGUF models
-    # live, and the prefix list_models.py uses (see its LLAMACPP_SUBDIR).
+    # live, and the prefix list_models.py uses (see common/gguf_naming.py).
     return f"{model_type or 'llamacpp'}:{name}"
 
 
@@ -847,20 +848,22 @@ def delete_matched_files(output_dir: str, models_base: str, allow_pattern: str, 
             d.rmdir()
 
 
-def generate_models_ini(models_dir: Path):
+def generate_models_ini(models_dir: Path, declarations=None):
     """Write the models.ini indexing every GGUF under *models_dir*.
 
-    Sections are the names ``gguf_model_names`` assigns — the file stem, or the
-    models_dir-relative path when two repositories publish the same file name — so
-    every file keeps its own section instead of one silently shadowing the other,
-    and each section matches the listing id of the same file.
+    Sections are the names ``gguf_model_name`` assigns — the file stem for a model
+    the curated catalog declares, the models_dir-relative path for an ad-hoc one —
+    so every file keeps its own section instead of one silently shadowing the
+    other, and each section matches the listing id of the same file. *declarations*
+    defaults to the catalog baked into the image.
     """
+    if declarations is None:
+        declarations = catalog_gguf_declarations()
     config = configparser.ConfigParser()
 
     gguf_files = [p for p in sorted(models_dir.rglob("*.gguf")) if "mmproj" not in p.name]
-    names = gguf_model_names([p.relative_to(models_dir).as_posix() for p in gguf_files])
     for gguf_file in gguf_files:
-        section = names[gguf_file.relative_to(models_dir).as_posix()]
+        section = gguf_model_name(gguf_file.relative_to(models_dir).as_posix(), declarations)
         config[section] = {}
         config[section]["model"] = str(gguf_file.as_posix())
 

--- a/containers/bricks/models-downloader/src/list_models.py
+++ b/containers/bricks/models-downloader/src/list_models.py
@@ -99,8 +99,8 @@ def get_model_info(model_entry):
                         "model_size_mb": model_size_mb,
                         "pre_loaded": False,
                         "supported_boards": supported_boards,
-                        # Kept for the outdated check; never part of the output.
-                        "variables": variables,
+                        "platform": platform_name,  # Kept for the per-board dedup; never part of the output.
+                        "variables": variables,  # Kept for the outdated check; never part of the output.
                     })
 
     return results
@@ -481,6 +481,15 @@ def main():
     # Filter by supported board
     if args.supported_board:
         all_models = [m for m in all_models if not m["supported_boards"] or args.supported_board in m["supported_boards"]]
+
+    # Keep the platform of the board being listed (its variables drive the outdated check); the first one otherwise
+    board = args.supported_board or os.environ.get("BOARD_NAME", "")
+    deduped = {}
+    for info in all_models:
+        current = deduped.get(info["id"])
+        if current is None or (board and info.get("platform") == board and current.get("platform") != board):
+            deduped[info["id"]] = info
+    all_models = list(deduped.values())
 
     results = []
     for model_info in all_models:

--- a/containers/bricks/models-downloader/src/list_models.py
+++ b/containers/bricks/models-downloader/src/list_models.py
@@ -26,6 +26,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.download_marker import read_marker
+from common.gguf_naming import gguf_model_names
 from common.model_metadata import METADATA_NAME, ORIGIN_BUILTIN, ORIGIN_USER_CONFIGURED, is_bookkeeping_name, read_metadata
 from common.models_list import load_models_list, MODELS_LIST_PATH
 
@@ -324,6 +325,17 @@ def llamacpp_name_from_marker(marker, root):
     return os.path.basename(root.rstrip(os.sep))
 
 
+def gguf_basename(model_url):
+    """The GGUF file name *model_url* pins, or None when it does not pin one.
+
+    Works on both syntaxes hf_downloader accepts: the basename of a file URL, or a
+    compact key whose quantization field is a full file name
+    ("org/repo:model-Q4_0.gguf"). A key naming only a quantization pins no file.
+    """
+    base = (model_url or "").split("?")[0].rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
+    return base if base.endswith(".gguf") else None
+
+
 def marker_covers_file(marker, filename):
     """True when *marker* describes an in-progress download of *filename*.
 
@@ -347,6 +359,11 @@ def find_llamacpp_models(models_base_dir):
     files are not standalone models but the multimodal projection belonging to
     the main GGUF in the same directory, so they are not listed separately.
 
+    Models are named with ``gguf_model_names``, mirroring the models.ini sections: the
+    file stem, path-qualified when two repositories publish the same file name — each
+    file is one model with its own id, path and size, never merged with a same-named
+    stranger.
+
     A download with no GGUF on disk yet (only a ".download" marker) is still surfaced,
     using the marker info for the entry — including when the directory does hold other
     GGUFs, since those are other quantizations rather than the pending model.
@@ -356,10 +373,23 @@ def find_llamacpp_models(models_base_dir):
     if not os.path.isdir(llamacpp_dir):
         return results
 
+    # First pass over the whole tree, so a file name two repositories share is seen
+    # and both models get path-qualified names.
+    found = []
+    rel_paths = []
     for root, _dirs, files in os.walk(llamacpp_dir):
         gguf_files = sorted(f for f in files if f.endswith(".gguf"))
-        mmproj_files = [f for f in gguf_files if "mmproj" in f]
         marker = read_marker(os.path.join(root, ".download"))
+        if not gguf_files and marker is None:
+            continue
+        rel_dir = os.path.relpath(root, llamacpp_dir).replace(os.sep, "/")
+        rel_dir = "" if rel_dir == "." else rel_dir
+        found.append((root, rel_dir, gguf_files, marker))
+        rel_paths.extend(f"{rel_dir}/{f}" if rel_dir else f for f in gguf_files if "mmproj" not in f)
+    names = gguf_model_names(rel_paths)
+
+    for root, rel_dir, gguf_files, marker in found:
+        mmproj_files = [f for f in gguf_files if "mmproj" in f]
         metadata = read_metadata(os.path.join(root, METADATA_NAME))
 
         # Whether the marker was accounted for by a GGUF listed below; if it was not, the
@@ -371,7 +401,7 @@ def find_llamacpp_models(models_base_dir):
             downloading = marker is not None and marker_covers_file(marker, f)
             marker_listed = marker_listed or downloading
             full_path = os.path.join(root, f)
-            model_name = os.path.splitext(f)[0]
+            model_name = names[f"{rel_dir}/{f}" if rel_dir else f]
             disk_size_mb = get_dir_size_mb(full_path)
             # The mmproj file in the same directory is part of this model.
             if mmproj_files:
@@ -389,6 +419,8 @@ def find_llamacpp_models(models_base_dir):
                 "installed": not downloading,
                 "downloading": downloading,
                 "disk_size_mb": disk_size_mb,
+                "_rel_dir": rel_dir,
+                "_filename": f,
             }
             if mmproj_files:
                 entry["mmproj"] = os.path.join(root, mmproj_files[0])
@@ -408,11 +440,48 @@ def find_llamacpp_models(models_base_dir):
                 "path": root,
                 "installed": False,
                 "downloading": True,
+                "_rel_dir": rel_dir,
+                "_filename": gguf_basename(marker.get("model_url")),
             }
             if metadata is not None:
                 entry["download_metadata"] = metadata
             results.append(entry)
     return results
+
+
+def curated_gguf_declarations(all_models, models_base_dir):
+    """The file location each llamacpp-backed models-list.yaml entry declares.
+
+    Returns:
+        ``(model_directory, filename, model_id)`` tuples, deduplicated across the
+        per-board platform repeats. ``filename`` is None when the entry's model_url
+        pins no file (a compact key naming a quantization); any GGUF inside the
+        directory then counts as the model.
+    """
+    llamacpp_dir = os.path.normpath(os.path.join(models_base_dir, LLAMACPP_SUBDIR))
+    declarations = []
+    for info in all_models:
+        if info.get("pre_loaded") or not info.get("model_directory"):
+            continue
+        if os.path.normpath(model_search_dir(info, models_base_dir)) != llamacpp_dir:
+            continue
+        filename = gguf_basename((info.get("variables") or {}).get("model_url", ""))
+        declaration = (info["model_directory"].strip("/"), filename, info["id"])
+        if declaration not in declarations:
+            declarations.append(declaration)
+    return declarations
+
+
+def declared_model_id(declarations, rel_dir, filename, taken):
+    """The id of the models-list.yaml entry declaring the GGUF at *rel_dir*/*filename*."""
+    for directory, declared_name, model_id in declarations:
+        if model_id in taken:
+            continue
+        if rel_dir != directory and not rel_dir.startswith(directory + "/"):
+            continue
+        if declared_name is None or declared_name == filename:
+            return model_id
+    return None
 
 
 def main():
@@ -509,17 +578,24 @@ def main():
 
         results.append(entry)
 
-    # Scan for llamacpp .gguf models on the filesystem. These may correspond to
-    # a models-list.yaml entry (same id) whose nested model_directory the YAML
-    # path check couldn't resolve; merge filesystem status into that entry
-    # instead of listing the model twice. Otherwise add it as a new entry.
+    # Scan for llamacpp .gguf models on the filesystem. A scanned file may be the one
+    # a models-list.yaml entry declares — matched by its location, since the entry's
+    # nested model_directory the YAML path check couldn't resolve — and then its
+    # filesystem status is merged into that entry instead of listing the model twice.
+    # Anything else is an ad-hoc download and is listed as its own entry.
     by_id = {entry["id"]: entry for entry in results}
+    declarations = curated_gguf_declarations(all_models, args.models_dir)
+    merged_ids = set()
     for m in find_llamacpp_models(args.models_dir):
-        existing = by_id.get(m["id"])
+        rel_dir = m.pop("_rel_dir")
+        filename = m.pop("_filename")
+        declared_id = declared_model_id(declarations, rel_dir, filename, merged_ids)
+        existing = by_id.get(declared_id) if declared_id else None
         if existing is not None:
-            # Keep the canonical YAML name/handler/model_size_mb/model_origin (the id
-            # is declared, so it is not user-configured); take the filesystem-derived
-            # status and on-disk details.
+            merged_ids.add(declared_id)
+            # Keep the canonical YAML name/handler/model_size_mb/model_origin (the
+            # model is declared, so it is not user-configured); take the
+            # filesystem-derived status and on-disk details.
             existing["installed"] = m["installed"]
             existing["downloading"] = m["downloading"]
             if "path" in m:
@@ -531,6 +607,11 @@ def main():
             if "download_metadata" in m and "download_metadata" not in existing:
                 existing["download_metadata"] = m["download_metadata"]
         else:
+            if m["id"] in by_id:
+                # Same name as a model this file is not: qualify the id by location
+                qualified = f"{rel_dir}/{m['name']}" if rel_dir else m["name"]
+                m["id"] = f"llamacpp:{qualified}"
+                m["name"] = qualified
             results.append(m)
             by_id[m["id"]] = m
 

--- a/containers/bricks/models-downloader/src/list_models.py
+++ b/containers/bricks/models-downloader/src/list_models.py
@@ -26,9 +26,9 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from common.download_marker import read_marker
-from common.gguf_naming import gguf_model_names
+from common.gguf_naming import LLAMACPP_SUBDIR, declaration_covers, declared_gguf_files, gguf_basename, gguf_model_name
 from common.model_metadata import METADATA_NAME, ORIGIN_BUILTIN, ORIGIN_USER_CONFIGURED, is_bookkeeping_name, read_metadata
-from common.models_list import load_models_list, MODELS_LIST_PATH
+from common.models_list import get_model_subdir, load_models_list, MODELS_LIST_PATH
 
 
 MODELS_BASE_DIR = "/models"
@@ -104,27 +104,6 @@ def get_model_info(model_entry):
                     })
 
     return results
-
-
-def get_model_subdir(models_repository):
-    """Extract the relative subfolder from models_repository path.
-
-    e.g. "/var/lib/arduino-app-cli/models/audio-analytics/tts" -> "audio-analytics/tts"
-         "/var/lib/arduino-app-cli/models/genai" -> "genai"
-         "models/genai" -> "genai"
-         "models/audio-analytics/asr" -> "audio-analytics/asr"
-    """
-    marker = "/models/"
-    idx = models_repository.rfind(marker)
-    if idx != -1:
-        return models_repository[idx + len(marker) :]
-    # Handle relative paths like "models/genai" or "models/audio-analytics/asr"
-    if models_repository.startswith("models/"):
-        return models_repository[len("models/") :]
-    # Bare repository name (e.g. "edge-impulse", "genai") => use as-is
-    if models_repository:
-        return models_repository
-    return ""
 
 
 def build_model_directory(variables):
@@ -302,9 +281,6 @@ def outdated_fields(model_info, metadata):
     return sorted(key for key, value in variables.items() if str(value) != inputs.get(key))
 
 
-LLAMACPP_SUBDIR = "llamacpp"
-
-
 def llamacpp_name_from_marker(marker, root):
     """Derive a model name for an in-progress llamacpp download from its marker.
 
@@ -325,17 +301,6 @@ def llamacpp_name_from_marker(marker, root):
     return os.path.basename(root.rstrip(os.sep))
 
 
-def gguf_basename(model_url):
-    """The GGUF file name *model_url* pins, or None when it does not pin one.
-
-    Works on both syntaxes hf_downloader accepts: the basename of a file URL, or a
-    compact key whose quantization field is a full file name
-    ("org/repo:model-Q4_0.gguf"). A key naming only a quantization pins no file.
-    """
-    base = (model_url or "").split("?")[0].rstrip("/").rsplit("/", 1)[-1].rsplit(":", 1)[-1]
-    return base if base.endswith(".gguf") else None
-
-
 def marker_covers_file(marker, filename):
     """True when *marker* describes an in-progress download of *filename*.
 
@@ -352,31 +317,31 @@ def marker_covers_file(marker, filename):
     return any(isinstance(p, str) and fnmatch.fnmatch(filename, p) for p in patterns)
 
 
-def find_llamacpp_models(models_base_dir):
+def find_llamacpp_models(models_base_dir, declarations=()):
     """Scan for .gguf models under the llamacpp directory.
 
     Mirrors the grouping used when generating models.ini: ``*mmproj*.gguf``
     files are not standalone models but the multimodal projection belonging to
     the main GGUF in the same directory, so they are not listed separately.
 
-    Models are named with ``gguf_model_names``, mirroring the models.ini sections: the
-    file stem, path-qualified when two repositories publish the same file name — each
-    file is one model with its own id, path and size, never merged with a same-named
-    stranger.
+    Models are named with ``gguf_model_name`` against *declarations*
+    (``declared_gguf_files`` of models-list.yaml), mirroring the models.ini sections:
+    the file stem for a declared file, the path-qualified name for an ad-hoc one —
+    each file is one model with its own id, path and size, never merged with a
+    same-named stranger.
 
     A download with no GGUF on disk yet (only a ".download" marker) is still surfaced,
     using the marker info for the entry — including when the directory does hold other
     GGUFs, since those are other quantizations rather than the pending model.
+
+    Every entry carries the private ``_rel_dir``/``_filename`` location keys main()
+    matches against the models-list.yaml declarations and strips before output.
     """
     llamacpp_dir = os.path.join(models_base_dir, LLAMACPP_SUBDIR)
     results = []
     if not os.path.isdir(llamacpp_dir):
         return results
 
-    # First pass over the whole tree, so a file name two repositories share is seen
-    # and both models get path-qualified names.
-    found = []
-    rel_paths = []
     for root, _dirs, files in os.walk(llamacpp_dir):
         gguf_files = sorted(f for f in files if f.endswith(".gguf"))
         marker = read_marker(os.path.join(root, ".download"))
@@ -384,11 +349,6 @@ def find_llamacpp_models(models_base_dir):
             continue
         rel_dir = os.path.relpath(root, llamacpp_dir).replace(os.sep, "/")
         rel_dir = "" if rel_dir == "." else rel_dir
-        found.append((root, rel_dir, gguf_files, marker))
-        rel_paths.extend(f"{rel_dir}/{f}" if rel_dir else f for f in gguf_files if "mmproj" not in f)
-    names = gguf_model_names(rel_paths)
-
-    for root, rel_dir, gguf_files, marker in found:
         mmproj_files = [f for f in gguf_files if "mmproj" in f]
         metadata = read_metadata(os.path.join(root, METADATA_NAME))
 
@@ -401,7 +361,7 @@ def find_llamacpp_models(models_base_dir):
             downloading = marker is not None and marker_covers_file(marker, f)
             marker_listed = marker_listed or downloading
             full_path = os.path.join(root, f)
-            model_name = names[f"{rel_dir}/{f}" if rel_dir else f]
+            model_name = gguf_model_name(f"{rel_dir}/{f}" if rel_dir else f, declarations)
             disk_size_mb = get_dir_size_mb(full_path)
             # The mmproj file in the same directory is part of this model.
             if mmproj_files:
@@ -432,6 +392,12 @@ def find_llamacpp_models(models_base_dir):
         # pending model from the marker so it still shows up in the listing.
         if marker is not None and not marker_listed:
             model_name = llamacpp_name_from_marker(marker, root)
+            filename = gguf_basename(marker.get("model_url"))
+            # Same naming as an installed file: declared downloads keep the marker
+            # name (main() merges them into their entry), ad-hoc ones are qualified
+            # by location so the id matches the one the finished install will get.
+            if not any(declaration_covers(d, n, rel_dir, filename) for d, n, _mid in declarations):
+                model_name = f"{rel_dir}/{model_name}" if rel_dir else model_name
             entry = {
                 "id": f"llamacpp:{model_name}",
                 "name": model_name,
@@ -441,7 +407,7 @@ def find_llamacpp_models(models_base_dir):
                 "installed": False,
                 "downloading": True,
                 "_rel_dir": rel_dir,
-                "_filename": gguf_basename(marker.get("model_url")),
+                "_filename": filename,
             }
             if metadata is not None:
                 entry["download_metadata"] = metadata
@@ -449,37 +415,18 @@ def find_llamacpp_models(models_base_dir):
     return results
 
 
-def curated_gguf_declarations(all_models, models_base_dir):
-    """The file location each llamacpp-backed models-list.yaml entry declares.
-
-    Returns:
-        ``(model_directory, filename, model_id)`` tuples, deduplicated across the
-        per-board platform repeats. ``filename`` is None when the entry's model_url
-        pins no file (a compact key naming a quantization); any GGUF inside the
-        directory then counts as the model.
-    """
-    llamacpp_dir = os.path.normpath(os.path.join(models_base_dir, LLAMACPP_SUBDIR))
-    declarations = []
-    for info in all_models:
-        if info.get("pre_loaded") or not info.get("model_directory"):
-            continue
-        if os.path.normpath(model_search_dir(info, models_base_dir)) != llamacpp_dir:
-            continue
-        filename = gguf_basename((info.get("variables") or {}).get("model_url", ""))
-        declaration = (info["model_directory"].strip("/"), filename, info["id"])
-        if declaration not in declarations:
-            declarations.append(declaration)
-    return declarations
-
-
 def declared_model_id(declarations, rel_dir, filename, taken):
-    """The id of the models-list.yaml entry declaring the GGUF at *rel_dir*/*filename*."""
+    """The id of the models-list.yaml entry declaring the GGUF at *rel_dir*/*filename*.
+
+    A declaration matches at most one file per listing — *taken* holds the ids
+    already matched — so a directory-level declaration cannot absorb every
+    quantization sharing the repository directory. None when no entry declares the
+    file: an ad-hoc download.
+    """
     for directory, declared_name, model_id in declarations:
         if model_id in taken:
             continue
-        if rel_dir != directory and not rel_dir.startswith(directory + "/"):
-            continue
-        if declared_name is None or declared_name == filename:
+        if declaration_covers(directory, declared_name, rel_dir, filename):
             return model_id
     return None
 
@@ -584,9 +531,9 @@ def main():
     # filesystem status is merged into that entry instead of listing the model twice.
     # Anything else is an ad-hoc download and is listed as its own entry.
     by_id = {entry["id"]: entry for entry in results}
-    declarations = curated_gguf_declarations(all_models, args.models_dir)
+    declarations = declared_gguf_files(models_list)
     merged_ids = set()
-    for m in find_llamacpp_models(args.models_dir):
+    for m in find_llamacpp_models(args.models_dir, declarations):
         rel_dir = m.pop("_rel_dir")
         filename = m.pop("_filename")
         declared_id = declared_model_id(declarations, rel_dir, filename, merged_ids)

--- a/containers/bricks/models-downloader/tests/test_gguf_naming.py
+++ b/containers/bricks/models-downloader/tests/test_gguf_naming.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for ``common/gguf_naming.py``."""
+
+from common.gguf_naming import catalog_gguf_declarations, declared_gguf_files, gguf_model_name
+
+GEMMA_URL = "https://huggingface.co/google/gemma-gguf/blob/abc123/gemma-Q4_0.gguf"
+
+MODELS = [
+    {
+        "llamacpp:gemma-Q4_0": {
+            "name": "Gemma",
+            "deployment": {
+                "handler": "hf-handler",
+                "platforms": [
+                    {"ventunoq": {"variables": {"model_url": GEMMA_URL, "models_repository": "llamacpp", "model_directory": "google/gemma-gguf"}}},
+                    # A second board with the same variables must not duplicate the declaration.
+                    {"unoq": {"variables": {"model_url": GEMMA_URL, "models_repository": "llamacpp", "model_directory": "google/gemma-gguf"}}},
+                ],
+            },
+        }
+    },
+    {
+        "llamacpp:qwen-by-key": {
+            "name": "Qwen via compact key",
+            "deployment": {
+                "handler": "hf-handler",
+                "platforms": [
+                    {
+                        "unoq": {
+                            "variables": {
+                                "model_url": "llamacpp:unsloth/Qwen-GGUF:Q4_0",
+                                "models_repository": "llamacpp",
+                                "model_directory": "unsloth/Qwen-GGUF",
+                            }
+                        }
+                    }
+                ],
+            },
+        }
+    },
+    # Another handler's entry: not under the llamacpp tree, never a declaration.
+    {
+        "ei:some-model": {
+            "name": "EI",
+            "deployment": {
+                "handler": "ei-handler",
+                "platforms": [{"unoq": {"variables": {"models_repository": "models/edge-impulse", "model_directory": "some-model"}}}],
+            },
+        }
+    },
+    # Pre-loaded entry: no platforms, nothing to declare.
+    {"builtin:asr": {"name": "ASR", "deployment": {"handler": "asr-handler", "pre-loaded": True}}},
+]
+
+
+def test_declared_gguf_files_extracts_llamacpp_locations():
+    assert declared_gguf_files(MODELS) == [
+        ("google/gemma-gguf", "gemma-Q4_0.gguf", "llamacpp:gemma-Q4_0"),
+        # A compact key naming only a quantization pins no file.
+        ("unsloth/Qwen-GGUF", None, "llamacpp:qwen-by-key"),
+    ]
+
+
+def test_gguf_model_name_declared_files_keep_the_stem():
+    declarations = declared_gguf_files(MODELS)
+    assert gguf_model_name("google/gemma-gguf/gemma-Q4_0.gguf", declarations) == "gemma-Q4_0"
+    # A dir-level declaration (no pinned file) covers any GGUF in its directory.
+    assert gguf_model_name("unsloth/Qwen-GGUF/Qwen-Q4_0.gguf", declarations) == "Qwen-Q4_0"
+    # Nested per-quantization folders still belong to the declaring repository.
+    assert gguf_model_name("unsloth/Qwen-GGUF/Q4_0/Qwen-Q4_0.gguf", declarations) == "Qwen-Q4_0"
+
+
+def test_gguf_model_name_ad_hoc_files_are_path_qualified():
+    declarations = declared_gguf_files(MODELS)
+    # Same file name as a curated model, different repository: not that model.
+    assert gguf_model_name("bartowski/gemma-clone/gemma-Q4_0.gguf", declarations) == "bartowski/gemma-clone/gemma-Q4_0"
+    assert gguf_model_name("TheBloke/Mistral-GGUF/mistral.Q4_0.gguf", declarations) == "TheBloke/Mistral-GGUF/mistral.Q4_0"
+    # No declarations at all (unreadable catalog): everything is path-qualified.
+    assert gguf_model_name("google/gemma-gguf/gemma-Q4_0.gguf", ()) == "google/gemma-gguf/gemma-Q4_0"
+
+
+def test_catalog_gguf_declarations_degrades_to_empty(tmp_path):
+    assert catalog_gguf_declarations(str(tmp_path / "missing.yaml")) == ()
+    broken = tmp_path / "broken.yaml"
+    broken.write_text("models: [a: b: c")
+    assert catalog_gguf_declarations(str(broken)) == ()
+
+
+def test_catalog_gguf_declarations_reads_a_models_list(tmp_path):
+    yaml_path = tmp_path / "models-list.yaml"
+    yaml_path.write_text(
+        "models:\n"
+        ' - "llamacpp:gemma-Q4_0":\n'
+        "    name: Gemma\n"
+        "    deployment:\n"
+        "      handler: hf-handler\n"
+        "      platforms:\n"
+        "        - unoq:\n"
+        "            variables:\n"
+        f'              model_url: "{GEMMA_URL}"\n'
+        '              models_repository: "llamacpp"\n'
+        '              model_directory: "google/gemma-gguf"\n'
+    )
+    assert catalog_gguf_declarations(str(yaml_path)) == [("google/gemma-gguf", "gemma-Q4_0.gguf", "llamacpp:gemma-Q4_0")]

--- a/containers/bricks/models-downloader/tests/test_hf_downloader.py
+++ b/containers/bricks/models-downloader/tests/test_hf_downloader.py
@@ -34,6 +34,7 @@ from hugging_face.hf_downloader import (
     discard_incomplete_download,
     download_matched_files,
     fallback_model_id,
+    generate_models_ini,
     gguf_pattern,
     has_model_content,
     interrupted_patterns,
@@ -635,36 +636,118 @@ def test_public_repo_files_returns_the_repo_listing(monkeypatch):
 # --------------------------------------------------------------------------- #
 # fallback_model_id
 # --------------------------------------------------------------------------- #
-def test_fallback_model_id_from_the_downloaded_gguf():
-    assert fallback_model_id("", ["/models/llamacpp/TheBloke/Mistral-GGUF/mistral.Q4_0.gguf"]) == "llamacpp:mistral.Q4_0"
+def _place_gguf(models_dir, rel_path):
+    """Create an empty GGUF at models_dir/rel_path and return its absolute path."""
+    path = models_dir / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\0")
+    return str(path)
 
 
-def test_fallback_model_id_uses_the_key_model_type_as_namespace():
-    assert fallback_model_id("llamacpp", ["/models/llamacpp/org/repo/m-Q8_0.gguf"]) == "llamacpp:m-Q8_0"
+def test_fallback_model_id_from_the_downloaded_gguf(tmp_path):
+    gguf = _place_gguf(tmp_path, "TheBloke/Mistral-GGUF/mistral.Q4_0.gguf")
+    assert fallback_model_id("", [gguf], str(tmp_path)) == "llamacpp:mistral.Q4_0"
 
 
-def test_fallback_model_id_ignores_mmproj():
+def test_fallback_model_id_uses_the_key_model_type_as_namespace(tmp_path):
+    gguf = _place_gguf(tmp_path, "org/repo/m-Q8_0.gguf")
+    assert fallback_model_id("llamacpp", [gguf], str(tmp_path)) == "llamacpp:m-Q8_0"
+
+
+def test_fallback_model_id_ignores_mmproj(tmp_path):
     """The mmproj belongs to the main GGUF and must never name the model."""
-    files = ["/models/llamacpp/org/repo/mmproj-BF16.gguf", "/models/llamacpp/org/repo/model-Q4_0.gguf"]
-    assert fallback_model_id("", files) == "llamacpp:model-Q4_0"
+    files = [
+        _place_gguf(tmp_path, "org/repo/mmproj-BF16.gguf"),
+        _place_gguf(tmp_path, "org/repo/model-Q4_0.gguf"),
+    ]
+    assert fallback_model_id("", files, str(tmp_path)) == "llamacpp:model-Q4_0"
 
 
-def test_fallback_model_id_without_any_gguf():
-    assert fallback_model_id("", []) is None
-    assert fallback_model_id("", ["/models/llamacpp/org/repo/mmproj-BF16.gguf"]) is None
+def test_fallback_model_id_without_any_gguf(tmp_path):
+    assert fallback_model_id("", [], str(tmp_path)) is None
+    mmproj = _place_gguf(tmp_path, "org/repo/mmproj-BF16.gguf")
+    assert fallback_model_id("", [mmproj], str(tmp_path)) is None
+
+
+def test_fallback_model_id_qualifies_a_file_name_another_repository_also_uses(tmp_path):
+    """Two repositories publishing the same file name must never share one id."""
+    _place_gguf(tmp_path, "unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
+    gguf = _place_gguf(tmp_path, "bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
+    assert fallback_model_id("", [gguf], str(tmp_path)) == "llamacpp:bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M"
 
 
 def test_fallback_model_id_matches_what_the_listing_derives(tmp_path):
-    """The record and the listing must agree on what to call an ad-hoc download."""
+    """The record and the listing must agree on what to call an ad-hoc download.
+
+    Including when two repositories publish the same file name: the downloader sees
+    the llamacpp directory as its models root, the listing sees its parent.
+    """
     import list_models
 
-    gguf = tmp_path / "llamacpp" / "TheBloke" / "Mistral-GGUF" / "mistral.Q4_0.gguf"
-    gguf.parent.mkdir(parents=True)
-    gguf.write_bytes(b"\0")
+    models_dir = tmp_path / "llamacpp"
+    first = _place_gguf(models_dir, "TheBloke/Mistral-GGUF/mistral.Q4_0.gguf")
 
     listed = list_models.find_llamacpp_models(str(tmp_path))
     assert len(listed) == 1
-    assert fallback_model_id("", [str(gguf)]) == listed[0]["id"]
+    assert fallback_model_id("", [first], str(models_dir)) == listed[0]["id"]
+
+    second = _place_gguf(models_dir, "bartowski/Mistral-GGUF/mistral.Q4_0.gguf")
+    listed = {entry["path"]: entry["id"] for entry in list_models.find_llamacpp_models(str(tmp_path))}
+    assert fallback_model_id("", [first], str(models_dir)) == listed[first]
+    assert fallback_model_id("", [second], str(models_dir)) == listed[second]
+
+
+# --------------------------------------------------------------------------- #
+# generate_models_ini
+# --------------------------------------------------------------------------- #
+def _read_models_ini(models_dir):
+    import configparser
+
+    config = configparser.ConfigParser()
+    config.read(models_dir / "models.ini")
+    return config
+
+
+def test_models_ini_sections_are_the_file_stems(tmp_path, capsys):
+    _place_gguf(tmp_path, "unsloth/Qwen3-GGUF/Qwen3-Q4_0.gguf")
+    _place_gguf(tmp_path, "moondream/moondream2-gguf/moondream2-f16.gguf")
+    _place_gguf(tmp_path, "moondream/moondream2-gguf/moondream2-mmproj-f16.gguf")
+
+    generate_models_ini(tmp_path)
+
+    config = _read_models_ini(tmp_path)
+    assert sorted(config.sections()) == ["Qwen3-Q4_0", "moondream2-f16"]
+    assert config["moondream2-f16"]["model"].endswith("moondream2-f16.gguf")
+    assert config["moondream2-f16"]["mmproj"].endswith("moondream2-mmproj-f16.gguf")
+
+
+def test_models_ini_keeps_a_section_per_repository_for_a_shared_file_name(tmp_path, capsys):
+    """Two repositories publishing the same file name: neither may shadow the other."""
+    _place_gguf(tmp_path, "unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
+    _place_gguf(tmp_path, "bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
+
+    generate_models_ini(tmp_path)
+
+    config = _read_models_ini(tmp_path)
+    assert sorted(config.sections()) == [
+        "bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M",
+        "unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M",
+    ]
+    for section in config.sections():
+        assert config[section]["model"].endswith(f"{section}.gguf")
+
+
+def test_models_ini_returns_to_the_stem_once_the_duplicate_is_gone(tmp_path, capsys):
+    """models.ini is regenerated on every download and delete; names must follow."""
+    _place_gguf(tmp_path, "unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
+    duplicate = tmp_path / "bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf"
+    _place_gguf(tmp_path, "bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
+
+    generate_models_ini(tmp_path)
+    duplicate.unlink()
+    generate_models_ini(tmp_path)
+
+    assert _read_models_ini(tmp_path).sections() == ["SmolLM2-Q4_K_M"]
 
 
 # --------------------------------------------------------------------------- #

--- a/containers/bricks/models-downloader/tests/test_hf_downloader.py
+++ b/containers/bricks/models-downloader/tests/test_hf_downloader.py
@@ -1135,3 +1135,34 @@ def test_check_answers_for_the_requested_quantization_only(tmp_path, monkeypatch
     with pytest.raises(SystemExit):
         _run_main(monkeypatch, "--check", "--model-url", "unsloth/Qwen3-0.6B-GGUF:Q3_K_S", "--output-dir", str(models_dir))
     assert read_events(capsys)[-1] == {"event": "error", "description": "Model does not exist: *Q3_K_S*.gguf", "downloading": False}
+
+
+# --------------------------------------------------------------------------- #
+# main(): the metadata record is required for an installed model
+# --------------------------------------------------------------------------- #
+def test_download_writes_the_metadata_record(tmp_path, monkeypatch, stub_download):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+
+    _run_main(monkeypatch, "--model-url", "unsloth/Qwen3-0.6B-GGUF:Q4_0", "--output-dir", str(models_dir))
+
+    repo = models_dir / "unsloth" / "Qwen3-0.6B-GGUF"
+    assert (repo / METADATA_NAME).is_file()
+    assert not (repo / MARKER_NAME).exists()
+
+
+def test_download_fails_when_the_record_cannot_be_written(tmp_path, monkeypatch, stub_download, capsys):
+    """The host deletes an ad-hoc model by the recorded inputs, so a download whose
+    record cannot be written must fail and be retried, never leave an unmanageable
+    install. The kept ".download" marker is what makes the next run discard and retry.
+    """
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    monkeypatch.setattr(hf_downloader, "write_metadata", lambda *args, **kwargs: None)
+
+    with pytest.raises(SystemExit) as exc:
+        _run_main(monkeypatch, "--model-url", "unsloth/Qwen3-0.6B-GGUF:Q4_0", "--output-dir", str(models_dir))
+
+    assert exc.value.code == 1
+    assert read_events(capsys)[-1]["event"] == "error"
+    assert (models_dir / "unsloth" / "Qwen3-0.6B-GGUF" / MARKER_NAME).is_file()

--- a/containers/bricks/models-downloader/tests/test_hf_downloader.py
+++ b/containers/bricks/models-downloader/tests/test_hf_downloader.py
@@ -644,14 +644,19 @@ def _place_gguf(models_dir, rel_path):
     return str(path)
 
 
-def test_fallback_model_id_from_the_downloaded_gguf(tmp_path):
+def test_fallback_model_id_is_the_path_qualified_name(tmp_path):
+    """An ad-hoc download is named by its repository-qualified path, from birth.
+
+    Stable for the whole life of the install, and never shared with a same-named
+    file from another repository.
+    """
     gguf = _place_gguf(tmp_path, "TheBloke/Mistral-GGUF/mistral.Q4_0.gguf")
-    assert fallback_model_id("", [gguf], str(tmp_path)) == "llamacpp:mistral.Q4_0"
+    assert fallback_model_id("", [gguf], str(tmp_path)) == "llamacpp:TheBloke/Mistral-GGUF/mistral.Q4_0"
 
 
 def test_fallback_model_id_uses_the_key_model_type_as_namespace(tmp_path):
     gguf = _place_gguf(tmp_path, "org/repo/m-Q8_0.gguf")
-    assert fallback_model_id("llamacpp", [gguf], str(tmp_path)) == "llamacpp:m-Q8_0"
+    assert fallback_model_id("llamacpp", [gguf], str(tmp_path)) == "llamacpp:org/repo/m-Q8_0"
 
 
 def test_fallback_model_id_ignores_mmproj(tmp_path):
@@ -660,7 +665,7 @@ def test_fallback_model_id_ignores_mmproj(tmp_path):
         _place_gguf(tmp_path, "org/repo/mmproj-BF16.gguf"),
         _place_gguf(tmp_path, "org/repo/model-Q4_0.gguf"),
     ]
-    assert fallback_model_id("", files, str(tmp_path)) == "llamacpp:model-Q4_0"
+    assert fallback_model_id("", files, str(tmp_path)) == "llamacpp:org/repo/model-Q4_0"
 
 
 def test_fallback_model_id_without_any_gguf(tmp_path):
@@ -669,11 +674,11 @@ def test_fallback_model_id_without_any_gguf(tmp_path):
     assert fallback_model_id("", [mmproj], str(tmp_path)) is None
 
 
-def test_fallback_model_id_qualifies_a_file_name_another_repository_also_uses(tmp_path):
-    """Two repositories publishing the same file name must never share one id."""
-    _place_gguf(tmp_path, "unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
-    gguf = _place_gguf(tmp_path, "bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
-    assert fallback_model_id("", [gguf], str(tmp_path)) == "llamacpp:bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M"
+def test_fallback_model_id_keeps_the_stem_for_a_catalog_declared_file(tmp_path, monkeypatch):
+    """A file downloaded at the location the baked catalog declares is that curated model."""
+    monkeypatch.setattr(hf_downloader, "catalog_gguf_declarations", lambda: [("org/repo", "model-Q4_0.gguf", "llamacpp:model-Q4_0")])
+    gguf = _place_gguf(tmp_path, "org/repo/model-Q4_0.gguf")
+    assert fallback_model_id("", [gguf], str(tmp_path)) == "llamacpp:model-Q4_0"
 
 
 def test_fallback_model_id_matches_what_the_listing_derives(tmp_path):
@@ -708,15 +713,17 @@ def _read_models_ini(models_dir):
     return config
 
 
-def test_models_ini_sections_are_the_file_stems(tmp_path, capsys):
-    _place_gguf(tmp_path, "unsloth/Qwen3-GGUF/Qwen3-Q4_0.gguf")
+def test_models_ini_names_declared_files_by_stem_and_ad_hoc_files_by_path(tmp_path, capsys):
+    """Curated files serve under the stem their fixed id uses; ad-hoc under their path."""
     _place_gguf(tmp_path, "moondream/moondream2-gguf/moondream2-f16.gguf")
     _place_gguf(tmp_path, "moondream/moondream2-gguf/moondream2-mmproj-f16.gguf")
+    _place_gguf(tmp_path, "unsloth/Qwen3-GGUF/Qwen3-Q4_0.gguf")
+    declarations = [("moondream/moondream2-gguf", "moondream2-f16.gguf", "llamacpp:moondream2-f16")]
 
-    generate_models_ini(tmp_path)
+    generate_models_ini(tmp_path, declarations)
 
     config = _read_models_ini(tmp_path)
-    assert sorted(config.sections()) == ["Qwen3-Q4_0", "moondream2-f16"]
+    assert sorted(config.sections()) == ["moondream2-f16", "unsloth/Qwen3-GGUF/Qwen3-Q4_0"]
     assert config["moondream2-f16"]["model"].endswith("moondream2-f16.gguf")
     assert config["moondream2-f16"]["mmproj"].endswith("moondream2-mmproj-f16.gguf")
 
@@ -737,8 +744,22 @@ def test_models_ini_keeps_a_section_per_repository_for_a_shared_file_name(tmp_pa
         assert config[section]["model"].endswith(f"{section}.gguf")
 
 
-def test_models_ini_returns_to_the_stem_once_the_duplicate_is_gone(tmp_path, capsys):
-    """models.ini is regenerated on every download and delete; names must follow."""
+def test_models_ini_keeps_the_curated_stem_next_to_a_same_named_impostor(tmp_path, capsys):
+    """A file named like a curated model, from another repository, never answers to its name."""
+    _place_gguf(tmp_path, "google/gemma-gguf/gemma-Q4_0.gguf")
+    _place_gguf(tmp_path, "bartowski/gemma-clone-GGUF/gemma-Q4_0.gguf")
+    declarations = [("google/gemma-gguf", "gemma-Q4_0.gguf", "llamacpp:gemma-Q4_0")]
+
+    generate_models_ini(tmp_path, declarations)
+
+    config = _read_models_ini(tmp_path)
+    assert sorted(config.sections()) == ["bartowski/gemma-clone-GGUF/gemma-Q4_0", "gemma-Q4_0"]
+    # The curated name serves the curated file, whatever else is installed.
+    assert config["gemma-Q4_0"]["model"].endswith("google/gemma-gguf/gemma-Q4_0.gguf")
+
+
+def test_models_ini_ad_hoc_names_are_stable_across_regenerations(tmp_path, capsys):
+    """models.ini is regenerated on every download and delete; ad-hoc names never move."""
     _place_gguf(tmp_path, "unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
     duplicate = tmp_path / "bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf"
     _place_gguf(tmp_path, "bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
@@ -747,7 +768,7 @@ def test_models_ini_returns_to_the_stem_once_the_duplicate_is_gone(tmp_path, cap
     duplicate.unlink()
     generate_models_ini(tmp_path)
 
-    assert _read_models_ini(tmp_path).sections() == ["SmolLM2-Q4_K_M"]
+    assert _read_models_ini(tmp_path).sections() == ["unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M"]
 
 
 # --------------------------------------------------------------------------- #

--- a/containers/bricks/models-downloader/tests/test_list_models.py
+++ b/containers/bricks/models-downloader/tests/test_list_models.py
@@ -831,6 +831,60 @@ def test_main_never_emits_location_keys(monkeypatch, capsys, tmp_path):
     assert all(not key.startswith("_") for m in models for key in m)
 
 
+def test_main_supports_promoting_an_ad_hoc_model_to_the_curated_list(monkeypatch, capsys, tmp_path):
+    """An ad-hoc install adopted by a later catalog release becomes that curated model.
+
+    Nothing on the board changes — the same files and record are re-read against the
+    new catalog: the entry lists as installed under its curated id (the old path
+    id disappears), and the recorded inputs, made against no declaration, flag it
+    outdated so the host can offer the pinned re-download.
+    """
+    promoted_yaml = (
+        SAMPLE_YAML
+        + """\
+ - "llamacpp:SmolLM2-135M-Instruct-Q4_K_M":
+    name: "SmolLM2 135M"
+    supported_boards: ["ventunoq"]
+    deployment:
+      handler: "hf-handler"
+      platforms:
+        - ventunoq:
+            variables:
+              model_url: "https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/blob/pinned0sha/SmolLM2-135M-Instruct-Q4_K_M.gguf"
+              models_repository: "llamacpp"
+              model_directory: "unsloth/SmolLM2-135M-Instruct-GGUF"
+"""
+    )
+    # Release N: downloaded ad hoc, no catalog entry.
+    models_dir, _models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    repo = models_dir / "llamacpp" / "unsloth" / "SmolLM2-135M-Instruct-GGUF"
+    _make_gguf(str(repo / "SmolLM2-135M-Instruct-Q4_K_M.gguf"))
+    _write_metadata_file(
+        str(repo),
+        "model_origin: user_configured\n"
+        "model_id: llamacpp:unsloth/SmolLM2-135M-Instruct-GGUF/SmolLM2-135M-Instruct-Q4_K_M\n"
+        "inputs:\n"
+        "  model_url: llamacpp:unsloth/SmolLM2-135M-Instruct-GGUF:Q4_K_M\n"
+        "  models_repository: llamacpp\n"
+        "  model_directory: unsloth/SmolLM2-135M-Instruct-GGUF\n",
+    )
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    assert [m["id"] for m in models if "SmolLM2" in m["id"]] == ["llamacpp:unsloth/SmolLM2-135M-Instruct-GGUF/SmolLM2-135M-Instruct-Q4_K_M"]
+
+    # Release N+1: the catalog now declares the same location.
+    list_models._SEARCH_DIR_CACHE.clear()
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, promoted_yaml)
+    smol = [m for m in models if "SmolLM2" in m["id"]]
+    assert len(smol) == 1
+    entry = smol[0]
+    assert entry["id"] == "llamacpp:SmolLM2-135M-Instruct-Q4_K_M"
+    assert entry["model_origin"] == "builtin"
+    assert entry["installed"] is True
+    # Downloaded with the ad-hoc inputs, not the pinned URL the entry declares.
+    assert entry["outdated"] is True
+    assert entry["outdated_fields"] == ["model_url"]
+
+
 MULTI_BOARD_YAML = """\
 models:
  - "llamacpp:multi-Q4_0":

--- a/containers/bricks/models-downloader/tests/test_list_models.py
+++ b/containers/bricks/models-downloader/tests/test_list_models.py
@@ -831,6 +831,64 @@ def test_main_never_emits_location_keys(monkeypatch, capsys, tmp_path):
     assert all(not key.startswith("_") for m in models for key in m)
 
 
+MULTI_BOARD_YAML = """\
+models:
+ - "llamacpp:multi-Q4_0":
+    name: "Multi board"
+    supported_boards: ["ventunoq", "unoq"]
+    deployment:
+      handler: "hf-handler"
+      platforms:
+        - ventunoq:
+            variables:
+              model_url: "https://huggingface.co/org/multi-gguf/blob/ventunosha/multi-Q4_0.gguf"
+              models_repository: "llamacpp"
+              model_directory: "org/multi-gguf"
+        - unoq:
+            variables:
+              model_url: "https://huggingface.co/org/multi-gguf/blob/unosha/multi-Q4_0.gguf"
+              models_repository: "llamacpp"
+              model_directory: "org/multi-gguf"
+"""
+
+
+def test_main_lists_a_multi_platform_entry_once(monkeypatch, capsys, tmp_path):
+    """An entry declaring several board platforms is one model, not one row per board."""
+    models_dir, models = _run_main(monkeypatch, capsys, tmp_path, MULTI_BOARD_YAML)
+    assert [m["id"] for m in models] == ["llamacpp:multi-Q4_0"]
+
+    # And the single row is the one the filesystem merge updates.
+    _make_gguf(str(models_dir / "llamacpp" / "org" / "multi-gguf" / "multi-Q4_0.gguf"))
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, MULTI_BOARD_YAML)
+    assert len(models) == 1
+    assert models[0]["installed"] is True
+
+
+def test_main_dedup_prefers_the_platform_of_the_listed_board(monkeypatch, capsys, tmp_path):
+    """When per-board variables differ, the outdated check must use this board's."""
+    models_dir, _models = _run_main(monkeypatch, capsys, tmp_path, MULTI_BOARD_YAML)
+    repo = models_dir / "llamacpp" / "org" / "multi-gguf"
+    _make_gguf(str(repo / "multi-Q4_0.gguf"))
+    # Downloaded from the revision the unoq platform declares.
+    _write_metadata_file(
+        str(repo),
+        "inputs:\n"
+        '  model_url: "https://huggingface.co/org/multi-gguf/blob/unosha/multi-Q4_0.gguf"\n'
+        "  models_repository: llamacpp\n"
+        "  model_directory: org/multi-gguf\n",
+    )
+
+    monkeypatch.setenv("BOARD_NAME", "unoq")
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, MULTI_BOARD_YAML)
+    assert models[0]["outdated"] is False
+
+    monkeypatch.setenv("BOARD_NAME", "ventunoq")
+    list_models._SEARCH_DIR_CACHE.clear()
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, MULTI_BOARD_YAML)
+    assert models[0]["outdated"] is True
+    assert models[0]["outdated_fields"] == ["model_url"]
+
+
 def test_gguf_basename():
     url = "https://huggingface.co/org/repo/blob/main/model-Q4_0.gguf"
     assert list_models.gguf_basename(url) == "model-Q4_0.gguf"

--- a/containers/bricks/models-downloader/tests/test_list_models.py
+++ b/containers/bricks/models-downloader/tests/test_list_models.py
@@ -176,17 +176,29 @@ def test_name_from_marker_root_fallback():
 # find_llamacpp_models
 # --------------------------------------------------------------------------- #
 def test_find_llamacpp_single_model(tmp_path):
+    """An ad-hoc model is named by its path — stable, and unique by construction."""
     base = tmp_path / "models"
     _make_gguf(str(base / "llamacpp" / "repo" / "model-a.gguf"))
     results = list_models.find_llamacpp_models(str(base))
     assert len(results) == 1
     entry = results[0]
-    assert entry["id"] == "llamacpp:model-a"
-    assert entry["name"] == "model-a"
+    assert entry["id"] == "llamacpp:repo/model-a"
+    assert entry["name"] == "repo/model-a"
     assert entry["handler"] == "llamacpp"
     assert entry["installed"] is True
     assert entry["downloading"] is False
     assert "mmproj" not in entry
+
+
+def test_find_llamacpp_declared_model_keeps_its_stem_name(tmp_path):
+    """A file at a location models-list.yaml declares keeps the stem the entry's id uses."""
+    base = tmp_path / "models"
+    _make_gguf(str(base / "llamacpp" / "repo" / "model-a.gguf"))
+    declarations = [("repo", "model-a.gguf", "llamacpp:model-a")]
+    results = list_models.find_llamacpp_models(str(base), declarations)
+    assert len(results) == 1
+    assert results[0]["id"] == "llamacpp:model-a"
+    assert results[0]["name"] == "model-a"
 
 
 def test_find_llamacpp_groups_mmproj(tmp_path):
@@ -198,7 +210,7 @@ def test_find_llamacpp_groups_mmproj(tmp_path):
     # The mmproj file is grouped into the text model, not listed separately.
     assert len(results) == 1
     entry = results[0]
-    assert entry["name"] == "moondream2-text-model-f16"
+    assert entry["name"] == "moondream/moondream2-gguf/moondream2-text-model-f16"
     assert entry["mmproj"].endswith("moondream2-mmproj-f16.gguf")
     # disk size is the sum of both files (1 MB + 0.5 MB).
     assert entry["disk_size_mb"] == 1.5
@@ -227,9 +239,10 @@ def test_find_llamacpp_empty_folder_with_marker(tmp_path):
     results = list_models.find_llamacpp_models(str(base))
     assert len(results) == 1
     entry = results[0]
-    # Name comes from the .gguf filename in the marker url.
-    assert entry["id"] == "llamacpp:gemma-4-E2B_q4_0-it"
-    assert entry["name"] == "gemma-4-E2B_q4_0-it"
+    # Ad-hoc pending download: the .gguf filename from the marker url, qualified by
+    # location — the same id the finished install will get.
+    assert entry["id"] == "llamacpp:google/gemma-4-E2B-it-qat-q4_0-gguf/gemma-4-E2B_q4_0-it"
+    assert entry["name"] == "google/gemma-4-E2B-it-qat-q4_0-gguf/gemma-4-E2B_q4_0-it"
     assert entry["installed"] is False
     assert entry["downloading"] is True
 
@@ -256,11 +269,13 @@ def test_find_llamacpp_marker_leaves_another_quantization_installed(tmp_path):
     )
 
     results = {entry["id"]: entry for entry in list_models.find_llamacpp_models(str(base))}
-    assert results["llamacpp:Qwen3-0.6B-Q4_0"]["installed"] is True
-    assert results["llamacpp:Qwen3-0.6B-Q4_0"]["downloading"] is False
+    installed = results["llamacpp:unsloth/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_0"]
+    assert installed["installed"] is True
+    assert installed["downloading"] is False
     # The one on its way is still surfaced from the marker, next to the installed one.
-    assert results["llamacpp:Qwen3-0.6B-Q3_K_S"]["installed"] is False
-    assert results["llamacpp:Qwen3-0.6B-Q3_K_S"]["downloading"] is True
+    pending = results["llamacpp:unsloth/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q3_K_S"]
+    assert pending["installed"] is False
+    assert pending["downloading"] is True
 
 
 def test_find_llamacpp_marker_for_a_gguf_on_disk_lists_it_once(tmp_path):
@@ -271,7 +286,7 @@ def test_find_llamacpp_marker_for_a_gguf_on_disk_lists_it_once(tmp_path):
 
     results = list_models.find_llamacpp_models(str(base))
     assert len(results) == 1
-    assert results[0]["id"] == "llamacpp:Qwen3-0.6B-Q3_K_S"
+    assert results[0]["id"] == "llamacpp:unsloth/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q3_K_S"
     assert results[0]["downloading"] is True
 
 
@@ -587,7 +602,7 @@ def test_main_lists_an_unlisted_model_with_its_metadata(monkeypatch, capsys, tmp
     _write_metadata_file(repo, "handler: hf-handler\nmodel_id: llamacpp:mistral.Q4_0\nmodel_origin: user_configured\n")
 
     _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
-    entries = [m for m in models if m["id"] == "llamacpp:mistral.Q4_0"]
+    entries = [m for m in models if m["id"] == "llamacpp:TheBloke/Mistral-7B-Instruct-v0.2-GGUF/mistral.Q4_0"]
     assert len(entries) == 1
     entry = entries[0]
     assert entry["installed"] is True

--- a/containers/bricks/models-downloader/tests/test_list_models.py
+++ b/containers/bricks/models-downloader/tests/test_list_models.py
@@ -712,6 +712,121 @@ def test_main_installed_only_filter(monkeypatch, capsys, tmp_path):
     assert all(m["installed"] for m in models)
 
 
+# --------------------------------------------------------------------------- #
+# Identical GGUF file names from different repositories
+# --------------------------------------------------------------------------- #
+def test_find_llamacpp_same_file_name_in_two_repos_lists_two_models(tmp_path):
+    """Two repositories publishing the same file name are two models, not one.
+
+    Each gets a path-qualified id with its own path, size and download record —
+    the file-stem id would alias them, and delete/status/size would act on
+    whichever file happened to win.
+    """
+    base = tmp_path / "models"
+    unsloth = base / "llamacpp" / "unsloth" / "SmolLM2-GGUF"
+    bartowski = base / "llamacpp" / "bartowski" / "SmolLM2-GGUF"
+    _make_gguf(str(unsloth / "SmolLM2-Q4_K_M.gguf"), size_bytes=1024 * 1024)
+    _make_gguf(str(bartowski / "SmolLM2-Q4_K_M.gguf"), size_bytes=2 * 1024 * 1024)
+    _write_metadata_file(str(unsloth), "inputs:\n  model_url: llamacpp:unsloth/SmolLM2-GGUF:Q4_K_M\n")
+    _write_metadata_file(str(bartowski), "inputs:\n  model_url: llamacpp:bartowski/SmolLM2-GGUF:Q4_K_M\n")
+
+    results = {entry["id"]: entry for entry in list_models.find_llamacpp_models(str(base))}
+
+    assert set(results) == {
+        "llamacpp:unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M",
+        "llamacpp:bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M",
+    }
+    for owner, size in (("unsloth", 1.0), ("bartowski", 2.0)):
+        entry = results[f"llamacpp:{owner}/SmolLM2-GGUF/SmolLM2-Q4_K_M"]
+        assert entry["path"].endswith(f"{owner}/SmolLM2-GGUF/SmolLM2-Q4_K_M.gguf")
+        assert entry["disk_size_mb"] == size
+        # Each entry carries its own download record, never the other repository's.
+        assert owner in entry["download_metadata"]["inputs"]["model_url"]
+
+
+def test_main_lists_same_named_ad_hoc_downloads_separately(monkeypatch, capsys, tmp_path):
+    """The reported bug: two ad-hoc downloads sharing a file name merged into one entry."""
+    models_dir, _models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    _make_gguf(str(models_dir / "llamacpp" / "unsloth" / "SmolLM2-GGUF" / "SmolLM2-Q4_K_M.gguf"))
+    _make_gguf(str(models_dir / "llamacpp" / "bartowski" / "SmolLM2-GGUF" / "SmolLM2-Q4_K_M.gguf"))
+
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    smol = sorted(m["id"] for m in models if "SmolLM2" in m["id"])
+    assert smol == [
+        "llamacpp:bartowski/SmolLM2-GGUF/SmolLM2-Q4_K_M",
+        "llamacpp:unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M",
+    ]
+
+
+def test_main_ad_hoc_download_cannot_masquerade_as_a_declared_model(monkeypatch, capsys, tmp_path):
+    """A file named like a curated model, from another repository, is not that model.
+
+    The declared entry stays not-installed and the ad-hoc file is listed under a
+    path-qualified id: merging them would let delete/status act on the wrong files.
+    """
+    models_dir, _models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    _make_gguf(str(models_dir / "llamacpp" / "bartowski" / "gemma-clone-GGUF" / "gemma-4-E2B_q4_0-it.gguf"))
+
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    assert _gemma_entry(models)["installed"] is False
+    clones = [m for m in models if m["id"] == "llamacpp:bartowski/gemma-clone-GGUF/gemma-4-E2B_q4_0-it"]
+    assert len(clones) == 1
+    assert clones[0]["installed"] is True
+    assert clones[0]["model_origin"] == "user_configured"
+
+
+def test_main_declared_model_merges_next_to_its_same_named_clone(monkeypatch, capsys, tmp_path):
+    """With both the declared file and a same-named clone on disk, each keeps its identity."""
+    models_dir, _models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    _install_gemma(models_dir)
+    _make_gguf(str(models_dir / "llamacpp" / "bartowski" / "gemma-clone-GGUF" / "gemma-4-E2B_q4_0-it.gguf"))
+
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    gemma = _gemma_entry(models)
+    assert gemma["installed"] is True
+    assert gemma["path"].endswith("google/gemma-4-E2B-it-qat-q4_0-gguf/gemma-4-E2B_q4_0-it.gguf")
+    clones = [m for m in models if m["id"] == "llamacpp:bartowski/gemma-clone-GGUF/gemma-4-E2B_q4_0-it"]
+    assert len(clones) == 1
+
+
+def test_main_merges_a_pending_declared_download_by_location(monkeypatch, capsys, tmp_path):
+    """A curated download in progress (marker, no GGUF yet) folds into its entry."""
+    models_dir, _models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    repo = os.path.join(str(models_dir), *GEMMA_REPO)
+    os.makedirs(repo)
+    write_marker(
+        str(repo),
+        handler="hf-handler",
+        model_url="https://huggingface.co/google/gemma-4-E2B-it-qat-q4_0-gguf/blob/main/gemma-4-E2B_q4_0-it.gguf",
+    )
+
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    entry = _gemma_entry(models)
+    assert entry["installed"] is False
+    assert entry["downloading"] is True
+    assert entry["model_origin"] == "builtin"
+
+
+def test_main_never_emits_location_keys(monkeypatch, capsys, tmp_path):
+    models_dir, _models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    _install_gemma(models_dir)
+    _make_gguf(str(models_dir / "llamacpp" / "TheBloke" / "Mistral-GGUF" / "mistral.Q4_0.gguf"))
+
+    _models_dir, models = _run_main(monkeypatch, capsys, tmp_path, SAMPLE_YAML)
+    assert all(not key.startswith("_") for m in models for key in m)
+
+
+def test_gguf_basename():
+    url = "https://huggingface.co/org/repo/blob/main/model-Q4_0.gguf"
+    assert list_models.gguf_basename(url) == "model-Q4_0.gguf"
+    assert list_models.gguf_basename(url + "?download=true") == "model-Q4_0.gguf"
+    # A compact key pins a file only when its quantization field names one.
+    assert list_models.gguf_basename("llamacpp:org/repo:model-Q4_0.gguf") == "model-Q4_0.gguf"
+    assert list_models.gguf_basename("llamacpp:org/repo:Q4_K_M") is None
+    assert list_models.gguf_basename("org/repo") is None
+    assert list_models.gguf_basename("") is None
+
+
 def test_main_missing_yaml_exits(monkeypatch, capsys, tmp_path):
     monkeypatch.setattr(
         "sys.argv",


### PR DESCRIPTION
## Problem

A model's id was derived from the GGUF file name alone. Different HF repositories publish identically named files, so two separate downloads ended up sharing one id, with user-visible failures:

1. Delete removed the wrong files
2. Weights could be swapped silently
3. Reported sizes were wrong
4. A file named like a curated model could appear as a never-installed curated model

## Fix

- **Identity comes from the catalog and the filesystem** (see `common/gguf_naming.py`): a GGUF at a location models-list.yaml declares is that specific curated model and keeps its stem name; every other file is ad-hoc and named by its repo-qualified path (`unsloth/SmolLM2-GGUF/SmolLM2-Q4_K_M`).
- Applied identically everywhere a name appears — listing ids (`llamacpp:<name>`), `models.ini` sections, fallback metadata id — preserving the id ⇄ section ⇄ served-name contract the LLM brick relies on.
- Applied identically to listing ids (`llamacpp:<name>`), `models.ini` sections, and the metadata fallback id, preserving the contract the LLM brick relies on.
- **Curated models matched by location**: a scanned file merges into a models-list.yaml entry only if found at the entry's declared `model_directory` with the filename its `model_url` defines.
- Both runners' `configure-llamacpp.py` mirror the section naming (they regenerate `models.ini` at startup).
- **The metadata record is now required for a completed HF download**: the host deletes an ad-hoc model by the recorded inputs, so they are required to avoid leaving an unmanageable install. AI Hub / Edge Impulse stay best-effort (their models are managed from the catalog).
- **Runners bake models-list.yaml** and apply the same naming when regenerating `models.ini` at startup to correctly reconstruct whether a model is a curated one.
- Fixed a `str == Path` comparison in `delete_matched_files` that disabled its "never remove the base directory" guard.
- Fixed a listing issue where a multi-platform catalog should display a single entry, using the listed board's variables for the outdated check.

## Compatibility

Curated ids, `models.ini` sections, and installs are unchanged, including legacy ones. Ad-hoc ids change to the path-qualified form.
