### PR TITLE
Report model_id and size when downloading HF models

### DIFF
--- a/containers/bricks/models-downloader/src/common/model_metadata.py
+++ b/containers/bricks/models-downloader/src/common/model_metadata.py
@@ -193,7 +193,7 @@ def metadata_payload(handler, inputs=None, identity=None, downloaded_at=None):
     return payload
 
 
-def write_metadata(model_dir, handler, env=None, models_list_path=MODELS_LIST_PATH, extra_input_keys=(), fallback_model_id=None):
+def write_metadata(model_dir, handler, env=None, models_list_path=MODELS_LIST_PATH, extra_input_keys=(), fallback_model_id=None, identity=None):
     """Write ``<model_dir>/.arduino_metadata.yaml`` atomically; return its path or None.
 
     Called after a successful download and *before* clearing the ``.download``
@@ -203,6 +203,11 @@ def write_metadata(model_dir, handler, env=None, models_list_path=MODELS_LIST_PA
 
     *fallback_model_id* names the model when models-list.yaml does not declare it; pass
     one whenever the handler can download something the list has never heard of.
+
+    *identity* is an already-resolved ``identify_model`` result. A handler that reports
+    the id to the host as well as recording it here passes the same dict to both, so
+    the two can never name the model differently; leave it out to have it resolved
+    here (then *fallback_model_id* applies).
     """
     path = os.path.join(model_dir, METADATA_NAME)
     tmp = path + ".tmp"
@@ -210,7 +215,7 @@ def write_metadata(model_dir, handler, env=None, models_list_path=MODELS_LIST_PA
         payload = metadata_payload(
             handler,
             inputs=collect_inputs(env, extra_input_keys),
-            identity=identify_model(env, models_list_path, fallback_model_id),
+            identity=identity if identity is not None else identify_model(env, models_list_path, fallback_model_id),
         )
         os.makedirs(model_dir, exist_ok=True)
         with open(tmp, "w") as f:

--- a/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
+++ b/containers/bricks/models-downloader/src/hugging_face/hf_downloader.py
@@ -99,7 +99,7 @@ import json
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from common.download_marker import MARKER_NAME, read_marker, write_marker
 from common.gguf_naming import catalog_gguf_declarations, gguf_model_name
-from common.model_metadata import is_bookkeeping_name, write_metadata
+from common.model_metadata import identify_model, is_bookkeeping_name, write_metadata
 
 # Quantization used when a model key names only a repository. Q4_0 is the quantization
 # every llama.cpp GGUF repository publishes and the one all curated entries use.
@@ -128,12 +128,29 @@ HF_FILE_MARKERS = ("resolve", "blob")
 URL_FORMAT_HINT = "Expected format: https://huggingface.co/<owner>/<repo>/resolve/<revision>/<file>.gguf (/blob/ also works)"
 
 
-def emit_json_info(description: str, artifacts: list[str] | None = None, downloading: bool | None = None):
+def emit_json_info(
+    description: str,
+    artifacts: list[str] | None = None,
+    downloading: bool | None = None,
+    model_id: str | None = None,
+    size_mb: float | None = None,
+):
+    """Print an ``info`` event.
+
+    ``model_id`` and ``size_mb`` are what the host would otherwise have to re-derive
+    from the artifact filenames or read back with a listing run, so a completed
+    download reports them here instead. Both are omitted when absent: an ordinary
+    progress message is unchanged, and an older host ignores them.
+    """
     data: dict = {"event": "info", "description": description}
     if artifacts is not None:
         data["artifacts"] = artifacts
     if downloading is not None:
         data["downloading"] = downloading
+    if model_id is not None:
+        data["model_id"] = model_id
+    if size_mb is not None:
+        data["size_mb"] = size_mb
     print(json.dumps(data), flush=True)
 
 
@@ -769,6 +786,27 @@ def fallback_model_id(model_type: str, downloaded: list[str], models_dir: str) -
     return f"{model_type or 'llamacpp'}:{name}"
 
 
+def downloaded_size_mb(downloaded: list[str]) -> float | None:
+    """Total size in MB of the files a download wrote, or None if any cannot be read.
+
+    Counts the mmproj file along with the main GGUF, which is what ``list_models.py``
+    reports as ``disk_size_mb`` for the same model, so the size a caller is told on
+    completion matches the one a later listing gives it. Rounded per file and then
+    again on the sum for the same reason: rounding the byte total once instead can
+    differ by a hundredth of a megabyte per file — nothing in itself, but enough to
+    make a caller see the size change the first time a listing runs.
+    """
+    if not downloaded:
+        return None
+    total = 0.0
+    for path in downloaded:
+        try:
+            total += round(os.stat(path).st_size / 1024 / 1024, 2)
+        except OSError:
+            return None
+    return round(total, 2)
+
+
 def no_match_message(repo_id: str, pattern: str) -> str:
     """Explain that nothing matched *pattern*, listing the GGUF files the repo does have.
 
@@ -1040,6 +1078,18 @@ def main():
         # Generate models.ini file
         generate_models_ini(Path(args.output_dir))
     else:
+        # The model directory is the repo id: the download always lands in
+        # <output_dir>/<repo_id>. models-list.yaml usually spells it out, but it is
+        # redundant — repo_id is a substring of the model URL (and of the model key),
+        # so derive it when the variable is not set rather than recording nothing.
+        model_directory = os.environ.get("model_directory") or repo_id
+        # Environment the metadata record is built from, with model_directory filled
+        # in: it feeds both the "inputs" block and the models-list.yaml lookup that
+        # identifies the model. ChainMap rather than {**os.environ, ...} because on
+        # Windows os.environ upper-cases its keys when copied, which would drop every
+        # lowercase download variable; chaining delegates the lookup instead.
+        metadata_env = ChainMap({"model_directory": model_directory}, os.environ)
+
         # Per-repo ".download" marker: present => prior run killed mid-download, discard
         # what it left and retry; absent but the requested files present => complete.
         # Marker first, files second — the reverse of --check, because the leftovers of
@@ -1049,8 +1099,20 @@ def main():
             emit_json_info(f"Removing incomplete previous download: {repo_id}")
             discard_incomplete_download(output_dir, args.output_dir, interrupted_patterns(marker))
         if is_installed(output_dir, patterns):
-            installed = ", ".join(p.name for p in matching_files(output_dir, patterns))
-            emit_json_info(f"Model exists: {repo_id} ({installed})")
+            present = sorted(str(p.resolve()) for p in matching_files(output_dir, patterns) if p.suffix == ".gguf")
+            installed = ", ".join(Path(p).name for p in present)
+            # Named here as well as after a transfer: a caller asking for a model gets
+            # its id back whether this run had to fetch anything or not — derived from
+            # the files this request matched, the same way the download path derives
+            # it, so the two cannot disagree about a repository holding several
+            # quantizations.
+            identity = identify_model(metadata_env, fallback_model_id=fallback_model_id(source["model_type"], present, args.output_dir))
+            emit_json_info(
+                f"Model exists: {repo_id} ({installed})",
+                artifacts=present,
+                model_id=identity["model_id"],
+                size_mb=downloaded_size_mb(present),
+            )
             return
         if os.path.isdir(output_dir) and not has_model_content(output_dir):
             # Bookkeeping-only leftover (e.g. killed between makedirs and the marker
@@ -1063,18 +1125,6 @@ def main():
         # Nothing has been written yet, and the model URL or key comes from the host
         # configuration: check what it points at before creating a directory for it.
         validate_hub_source_or_exit(source, args.hf_token)
-
-        # The model directory is the repo id: the download always lands in
-        # <output_dir>/<repo_id>. models-list.yaml usually spells it out, but it is
-        # redundant — repo_id is a substring of the model URL (and of the model key),
-        # so derive it when the variable is not set rather than recording nothing.
-        model_directory = os.environ.get("model_directory") or repo_id
-        # Environment the metadata record is built from, with model_directory filled
-        # in: it feeds both the "inputs" block and the models-list.yaml lookup that
-        # identifies the model. ChainMap rather than {**os.environ, ...} because on
-        # Windows os.environ upper-cases its keys when copied, which would drop every
-        # lowercase download variable; chaining delegates the lookup instead.
-        metadata_env = ChainMap({"model_directory": model_directory}, os.environ)
 
         os.makedirs(output_dir, exist_ok=True)
         write_marker(
@@ -1152,23 +1202,21 @@ def main():
         # Generate models.ini file
         generate_models_ini(Path(args.output_dir))
 
-        # Report the absolute path(s) of the downloaded model file(s): the files this
-        # request named, not every quantization the shared repository directory holds —
-        # a sibling was not downloaded now, and must not name this model either.
+        # The absolute path(s) of the downloaded model file(s): the files this request
+        # named, not every quantization the shared repository directory holds — a
+        # sibling was not downloaded now, and must not name this model either.
         downloaded = sorted(str(p.resolve()) for p in matching_files(output_dir, patterns) if p.suffix == ".gguf")
-        emit_json_info(f"Downloaded to: {output_dir}", artifacts=downloaded)
+
+        # Resolved once and used for both the record and the completion event, so the
+        # id the host is told is the id on disk. Any repository can be downloaded
+        # without a models-list.yaml entry, so name it after the file that arrived
+        # rather than leaving it unidentified.
+        identity = identify_model(metadata_env, fallback_model_id=fallback_model_id(source["model_type"], downloaded, args.output_dir))
 
         # Record what was downloaded, then clear the in-progress marker: while the
         # marker is still there the repo directory counts as incomplete, so a crash
         # in between makes the next run retry instead of leaving it unrecorded.
-        recorded = write_metadata(
-            output_dir,
-            handler="hf-handler",
-            env=metadata_env,
-            # Any repository can be downloaded without a models-list.yaml entry, so name
-            # it after the file that arrived rather than leaving it unidentified.
-            fallback_model_id=fallback_model_id(source["model_type"], downloaded, args.output_dir),
-        )
+        recorded = write_metadata(output_dir, handler="hf-handler", env=metadata_env, identity=identity)
         if recorded is None:
             # The record is required, not best-effort: the host deletes an ad-hoc model
             # by the inputs recorded here, so an installed-but-unrecorded model could
@@ -1176,6 +1224,15 @@ def main():
             # run discard and retry.
             emit_json_error(f"Downloaded {repo_id}, but its metadata record could not be written; the download will be retried")
             raise SystemExit(1)
+
+        # Reported after the record write on purpose: a failed record fails the
+        # download, and a completion event before the error would contradict it.
+        emit_json_info(
+            f"Downloaded to: {output_dir}",
+            artifacts=downloaded,
+            model_id=identity["model_id"],
+            size_mb=downloaded_size_mb(downloaded),
+        )
 
         marker = Path(output_dir) / MARKER_NAME
         if marker.exists():

--- a/containers/bricks/models-downloader/tests/test_hf_downloader.py
+++ b/containers/bricks/models-downloader/tests/test_hf_downloader.py
@@ -33,6 +33,7 @@ from hugging_face.hf_downloader import (
     delete_matched_files,
     discard_incomplete_download,
     download_matched_files,
+    downloaded_size_mb,
     fallback_model_id,
     generate_models_ini,
     gguf_pattern,
@@ -1166,3 +1167,73 @@ def test_download_fails_when_the_record_cannot_be_written(tmp_path, monkeypatch,
     assert exc.value.code == 1
     assert read_events(capsys)[-1]["event"] == "error"
     assert (models_dir / "unsloth" / "Qwen3-0.6B-GGUF" / MARKER_NAME).is_file()
+
+
+# --------------------------------------------------------------------------- #
+# downloaded_size_mb
+# --------------------------------------------------------------------------- #
+def test_downloaded_size_mb_sums_the_files_like_the_listing(tmp_path):
+    main = tmp_path / "model-Q4_0.gguf"
+    main.write_bytes(b"\0" * (2 * 1024 * 1024))
+    mmproj = tmp_path / "mmproj-BF16.gguf"
+    mmproj.write_bytes(b"\0" * (1024 * 1024))
+
+    assert downloaded_size_mb([str(main), str(mmproj)]) == 3.0
+
+
+def test_downloaded_size_mb_without_files_or_with_unreadable_ones(tmp_path):
+    assert downloaded_size_mb([]) is None
+    assert downloaded_size_mb([str(tmp_path / "gone.gguf")]) is None
+
+
+# --------------------------------------------------------------------------- #
+# main(): the completion events name and size the model
+# --------------------------------------------------------------------------- #
+def test_download_event_reports_the_model_id_and_size(tmp_path, monkeypatch, stub_download, capsys):
+    """The host learns the id and size on completion, instead of re-deriving them or
+    running a listing container right after a multi-GB transfer. The id is the one
+    the listing derives for the same file: path-qualified for an ad-hoc download.
+    """
+    import list_models
+
+    base = tmp_path / "models"
+    models_dir = base / "llamacpp"
+    models_dir.mkdir(parents=True)
+
+    _run_main(monkeypatch, "--model-url", "unsloth/Qwen3-0.6B-GGUF:Q3_K_S", "--output-dir", str(models_dir))
+
+    done = read_events(capsys)[-1]
+    assert done["description"].startswith("Downloaded to:")
+    assert done["model_id"] == "llamacpp:unsloth/Qwen3-0.6B-GGUF/Q3_K_S"
+    assert done["size_mb"] == 0.0  # the stub writes a 1-byte file
+    listed = list_models.find_llamacpp_models(str(base))
+    assert [m["id"] for m in listed] == [done["model_id"]]
+
+
+def test_download_event_reports_the_curated_id_for_a_declared_location(tmp_path, monkeypatch, stub_download, capsys):
+    """A file landing where the catalog declares it is that curated model, whatever
+    variables the request carried."""
+    monkeypatch.setattr(hf_downloader, "catalog_gguf_declarations", lambda: [("unsloth/Qwen3-0.6B-GGUF", None, "llamacpp:Qwen3-0.6B-Q3_K_S")])
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+
+    _run_main(monkeypatch, "--model-url", "unsloth/Qwen3-0.6B-GGUF:Q3_K_S", "--output-dir", str(models_dir))
+
+    assert read_events(capsys)[-1]["model_id"] == "llamacpp:Q3_K_S"
+
+
+def test_already_installed_request_reports_the_same_identity(tmp_path, monkeypatch, stub_download, capsys):
+    """Asking again for an installed model returns its id and size without a transfer."""
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    _run_main(monkeypatch, "--model-url", "unsloth/Qwen3-0.6B-GGUF:Q3_K_S", "--output-dir", str(models_dir))
+    downloaded_event = read_events(capsys)[-1]
+
+    _run_main(monkeypatch, "--model-url", "unsloth/Qwen3-0.6B-GGUF:Q3_K_S", "--output-dir", str(models_dir))
+
+    exists_event = read_events(capsys)[-1]
+    assert exists_event["description"].startswith("Model exists:")
+    assert stub_download == ["*Q3_K_S*.gguf"]  # the second run transferred nothing
+    assert exists_event["model_id"] == downloaded_event["model_id"]
+    assert exists_event["size_mb"] == downloaded_event["size_mb"]
+    assert exists_event["artifacts"] == downloaded_event["artifacts"]


### PR DESCRIPTION
## Problem

A Hugging Face download that no models-list.yaml entry declares gets its id from what landed on disk. The handler never reports the id to the caller, so the host must either re-derive it from the artifact filenames (re-implementing the naming rule) or run a listing container right after a multi-GB transfer. Same for the size.

Supersedes #414, adapted to the catalog-aware naming and the mandatory metadata record.


## Change

The completion `info` event now carries the model's identity and size, and a request for an already-installed model reports the same fields without a transfer:

```json
{
    "event": "info",
    "description": "Downloaded to: /models/unsloth/SmolLM2-135M-Instruct-GGUF",
    "artifacts": [
        ".../SmolLM2-135M-Instruct-Q4_K_M.gguf"
    ],
    "model_id": "llamacpp:unsloth/SmolLM2-135M-Instruct-GGUF/SmolLM2-135M-Instruct-Q4_K_M",
    "size_mb": 105.4
}
```

- Both fields are omitted when absent: ordinary progress messages are unchanged and older hosts ignore them.
- The id comes from the catalog-aware naming, so it is exactly what the listing derives for the same file.
- Identity is resolved once and passed to both the metadata record and the event.
- The completion event moved after the record write.
- `size_mb` counts the mmproj with the main GGUF and rounds the way list_models.py does, so the value doesn't change the first time a listing runs.