### PR TITLE
feat(pose-estimation): improve runner configurability

### DIFF
--- a/containers/ai/pose-estimation-runner/inference.py
+++ b/containers/ai/pose-estimation-runner/inference.py
@@ -26,7 +26,7 @@ posenet_output = posenet.get_output_details()
 # base image's main.py).
 _config = {
     "min_person_score": MIN_PERSON_SCORE,
-    "draw_uncertain": True,
+    "draw_low_confidence_points": True,
     "draw_bboxes": False,
     "bbox_padding_top": 0.0,
     "bbox_padding_right": 0.0,
@@ -41,10 +41,10 @@ def apply_config(config: dict) -> None:
     if value is not None:
         _config["min_person_score"] = max(0.0, min(1.0, float(value)))
         print(f"config: min_person_score set to {_config['min_person_score']}", flush=True)
-    value = config.get("draw_uncertain")
+    value = config.get("draw_low_confidence_points")
     if value is not None:
-        _config["draw_uncertain"] = bool(value)
-        print(f"config: draw_uncertain set to {_config['draw_uncertain']}", flush=True)
+        _config["draw_low_confidence_points"] = bool(value)
+        print(f"config: draw_low_confidence_points set to {_config['draw_low_confidence_points']}", flush=True)
     value = config.get("draw_bboxes")
     if value is not None:
         _config["draw_bboxes"] = bool(value)
@@ -262,7 +262,7 @@ def inference_callback(rgb_frame: np.ndarray) -> tuple[np.ndarray, dict]:
         person_scores,
         keypoint_scores,
         coords_xy,
-        _config["draw_uncertain"],
+        _config["draw_low_confidence_points"],
         _config["draw_bboxes"],
         _config["bbox_padding_top"],
         _config["bbox_padding_right"],

--- a/containers/ai/pose-estimation-runner/inference.py
+++ b/containers/ai/pose-estimation-runner/inference.py
@@ -65,6 +65,9 @@ def apply_config(config: dict) -> None:
 MIN_CROP_H = 466  # 513/1.1: avoid >10% upscaling blur, which drops joint scores
 MIN_CROP_W = 320  # narrower crops collapse elbow/wrist scores (measured on test images)
 REFRESH_EVERY = 10  # full-frame tracker refresh cadence while cropping (~0.35 s at 29 fps)
+MARGIN_X = 0.35  # lateral margin per side (fraction of box width): covers arms extending sideways
+MARGIN_TOP = 0.40  # top margin (fraction of box height): raised wrists go well above the head
+MARGIN_BOTTOM = 0.15  # bottom margin (fraction of box height)
 
 _last_union_bbox: tuple[int, int, int, int] | None = None
 _frame_count = 0
@@ -79,7 +82,7 @@ def _axis_window(center: float, size: float, limit: int) -> tuple[int, int]:
 
 
 def _crop_rect(img_h: int, img_w: int, bbox: tuple[int, int, int, int]) -> tuple[int, int, int, int] | None:
-    """Crop window around the tracked people, generous on top for raised arms.
+    """Crop window around the tracked people.
 
     Returns (x1, y1, x2, y2), or None when the window degenerates or would be
     the whole frame anyway.
@@ -88,8 +91,8 @@ def _crop_rect(img_h: int, img_w: int, bbox: tuple[int, int, int, int]) -> tuple
     bw, bh = x2 - x1, y2 - y1
     if bw <= 0 or bh <= 0:
         return None
-    mx1, mx2 = x1 - 0.30 * bw, x2 + 0.30 * bw
-    my1, my2 = y1 - 0.45 * bh, y2 + 0.15 * bh  # top bias: raised wrists go well above the head
+    mx1, mx2 = x1 - MARGIN_X * bw, x2 + MARGIN_X * bw
+    my1, my2 = y1 - MARGIN_TOP * bh, y2 + MARGIN_BOTTOM * bh
     cx1, cx2 = _axis_window((mx1 + mx2) / 2, max(mx2 - mx1, MIN_CROP_W), img_w)
     cy1, cy2 = _axis_window((my1 + my2) / 2, max(my2 - my1, MIN_CROP_H), img_h)
     if cx2 - cx1 < 48 or cy2 - cy1 < 48 or (cx2 - cx1 >= img_w and cy2 - cy1 >= img_h):

--- a/containers/ai/pose-estimation-runner/inference.py
+++ b/containers/ai/pose-estimation-runner/inference.py
@@ -24,7 +24,15 @@ posenet_output = posenet.get_output_details()
 
 # Runtime-tunable settings, updated by client config messages (wired in the
 # base image's main.py).
-_config = {"min_person_score": MIN_PERSON_SCORE, "draw_uncertain": True}
+_config = {
+    "min_person_score": MIN_PERSON_SCORE,
+    "draw_uncertain": True,
+    "draw_bboxes": False,
+    "bbox_padding_top": 0.0,
+    "bbox_padding_right": 0.0,
+    "bbox_padding_bottom": 0.0,
+    "bbox_padding_left": 0.0,
+}
 
 
 def apply_config(config: dict) -> None:
@@ -37,6 +45,15 @@ def apply_config(config: dict) -> None:
     if value is not None:
         _config["draw_uncertain"] = bool(value)
         print(f"config: draw_uncertain set to {_config['draw_uncertain']}", flush=True)
+    value = config.get("draw_bboxes")
+    if value is not None:
+        _config["draw_bboxes"] = bool(value)
+        print(f"config: draw_bboxes set to {_config['draw_bboxes']}", flush=True)
+    for key in ("bbox_padding_top", "bbox_padding_right", "bbox_padding_bottom", "bbox_padding_left"):
+        value = config.get(key)
+        if value is not None:
+            _config[key] = max(0.0, min(1.0, float(value)))
+            print(f"config: {key} set to {_config[key]}", flush=True)
 
 
 # Person-tracking crop: instead of the full frame, the model gets a window cut
@@ -237,7 +254,18 @@ def inference_callback(rgb_frame: np.ndarray) -> tuple[np.ndarray, dict]:
     _last_union_bbox = tracked
 
     # Draw predictions on the full frame and get metadata; coordinates in (x, y) format
-    metadata = draw_persons(rgb_frame, person_scores, keypoint_scores, coords_xy, _config["draw_uncertain"])
+    metadata = draw_persons(
+        rgb_frame,
+        person_scores,
+        keypoint_scores,
+        coords_xy,
+        _config["draw_uncertain"],
+        _config["draw_bboxes"],
+        _config["bbox_padding_top"],
+        _config["bbox_padding_right"],
+        _config["bbox_padding_bottom"],
+        _config["bbox_padding_left"],
+    )
     metadata["crop_window"] = crop_window
 
     return rgb_frame, metadata

--- a/containers/ai/pose-estimation-runner/utils/draw.py
+++ b/containers/ai/pose-estimation-runner/utils/draw.py
@@ -184,7 +184,7 @@ def draw_persons(
     person_scores: np.ndarray,
     keypoint_scores: np.ndarray,
     keypoint_coords_xy: np.ndarray,
-    draw_uncertain: bool = True,
+    draw_low_confidence_points: bool = True,
     draw_bboxes: bool = False,
     bbox_padding_top: float = 0.0,
     bbox_padding_right: float = 0.0,
@@ -206,7 +206,7 @@ def draw_persons(
     keypoint_coords_xy
         Keypoint coordinates in (x, y) format mapped to the frame space,
         shape (max_detections, 17, 2).
-    draw_uncertain
+    draw_low_confidence_points
         Mark keypoints below MIN_KEYPOINT_SCORE too, as small hollow dots
         joined by darker lines. Set it to False for an overlay that
         shows only the confident keypoints and connections.
@@ -264,7 +264,7 @@ def draw_persons(
         if edges:
             draw_connections(frame, kp_coords, edges, (255, 255, 255), 2)
 
-        if draw_uncertain and not confident.all():
+        if draw_low_confidence_points and not confident.all():
             uncertain_edges = [(a, b) for a, b in SKELETON_CONNECTION_INDICES if not (confident[a] and confident[b])]
             if uncertain_edges:
                 draw_connections(frame, kp_coords, uncertain_edges, (120, 120, 255), 1)

--- a/containers/ai/pose-estimation-runner/utils/draw.py
+++ b/containers/ai/pose-estimation-runner/utils/draw.py
@@ -145,12 +145,51 @@ def draw_connections(
     )
 
 
+def draw_box_from_xyxy(
+    frame: np.ndarray,
+    top_left: tuple[int, int],
+    bottom_right: tuple[int, int],
+    color: tuple[int, int, int] = (0, 0, 0),
+    size: int = 2,
+):
+    """
+    Draw a rectangle using the provided top left / bottom right corners.
+
+    Parameters
+    ----------
+        frame: np.ndarray
+            np array (H W C x uint8, RGB)
+
+        top_left: tuple[int, int]
+            (x, y) coordinates of the top left corner
+
+        bottom_right: tuple[int, int]
+            (x, y) coordinates of the bottom right corner
+
+        color: tuple[int, int, int]
+            Color of the rectangle lines (RGB)
+
+        size: int
+            Thickness of the rectangle lines
+
+    Returns
+    -------
+        None; modifies frame in place.
+    """
+    cv2.rectangle(frame, top_left, bottom_right, color, size)
+
+
 def draw_persons(
     frame: np.ndarray,
     person_scores: np.ndarray,
     keypoint_scores: np.ndarray,
     keypoint_coords_xy: np.ndarray,
     draw_uncertain: bool = True,
+    draw_bboxes: bool = False,
+    bbox_padding_top: float = 0.0,
+    bbox_padding_right: float = 0.0,
+    bbox_padding_bottom: float = 0.0,
+    bbox_padding_left: float = 0.0,
 ) -> dict:
     """
     Draw the skeleton overlay for each detected pose and build the detection metadata.
@@ -171,6 +210,18 @@ def draw_persons(
         Mark keypoints below MIN_KEYPOINT_SCORE too, as small hollow dots
         joined by darker lines. Set it to False for an overlay that
         shows only the confident keypoints and connections.
+    draw_bboxes
+        Draw each person's bounding box (the same one reported in the
+        metadata) as a yellow rectangle. Off by default.
+    bbox_padding_top
+        Expand each person's bounding box upwards by this fraction of its
+        height. Applied to the reported metadata and the drawn rectangle alike.
+    bbox_padding_right
+        Expand each person's bounding box to the right by this fraction of its width.
+    bbox_padding_bottom
+        Expand each person's bounding box downwards by this fraction of its height.
+    bbox_padding_left
+        Expand each person's bounding box to the left by this fraction of its width.
 
     Returns
     -------
@@ -189,6 +240,26 @@ def draw_persons(
 
         confident = kp_scores >= MIN_KEYPOINT_SCORE
 
+        # Compute the bounding box from the confident keypoints, expanded by the
+        # configured padding and clipped to the frame
+        bbox_coords = kp_coords[confident] if confident.any() else kp_coords
+        x_min, y_min = bbox_coords.min(axis=0)
+        x_max, y_max = bbox_coords.max(axis=0)
+        box_w, box_h = x_max - x_min, y_max - y_min
+        y_min -= bbox_padding_top * box_h
+        y_max += bbox_padding_bottom * box_h
+        x_min -= bbox_padding_left * box_w
+        x_max += bbox_padding_right * box_w
+        bbox_xyxy = [
+            int(np.clip(x_min, 0, width - 1)),
+            int(np.clip(y_min, 0, height - 1)),
+            int(np.clip(x_max, 0, width - 1)),
+            int(np.clip(y_max, 0, height - 1)),
+        ]
+
+        if draw_bboxes:
+            draw_box_from_xyxy(frame, (bbox_xyxy[0], bbox_xyxy[1]), (bbox_xyxy[2], bbox_xyxy[3]), (255, 255, 0), 2)
+
         edges = [(a, b) for a, b in SKELETON_CONNECTION_INDICES if confident[a] and confident[b]]
         if edges:
             draw_connections(frame, kp_coords, edges, (255, 255, 255), 2)
@@ -202,11 +273,6 @@ def draw_persons(
         if confident.any():
             draw_points(frame, kp_coords[confident], (90, 250, 34), 7, (255, 255, 255))
 
-        # Compute the bounding box from the confident keypoints, clipped to the frame
-        bbox_coords = kp_coords[confident] if confident.any() else kp_coords
-        x_min, y_min = bbox_coords.min(axis=0)
-        x_max, y_max = bbox_coords.max(axis=0)
-
         persons_metadata.append({
             "score": float(person_score),
             "keypoints": [
@@ -218,12 +284,7 @@ def draw_persons(
                 }
                 for i in range(len(KEYPOINT_NAMES))
             ],
-            "bounding_box_xyxy": [
-                int(np.clip(x_min, 0, width - 1)),
-                int(np.clip(y_min, 0, height - 1)),
-                int(np.clip(x_max, 0, width - 1)),
-                int(np.clip(y_max, 0, height - 1)),
-            ],
+            "bounding_box_xyxy": bbox_xyxy,
         })
 
     return {"persons": persons_metadata}

--- a/src/arduino/app_bricks/pose_estimation/README.md
+++ b/src/arduino/app_bricks/pose_estimation/README.md
@@ -22,6 +22,9 @@ Integration highlights:
   person disappears, active poses exit after a 0.7 s grace period). Other people
   stay visible through `on_keypoints` but do not fire pose events.
 - `on_enter` / `on_exit` / `on_count_change` enable presence and people-counting automations.
+- `on_readable_change` reports whether the tracked person's skeleton can be read at all:
+  while it cannot, no pose event is emitted, so it is the cue to ask the user to step back
+  into full view.
 - `POSE_NAMES` lists the built-in pose names `on_pose` accepts.
 - `set_confidence` changes the minimum person detection score at runtime; the value is
   applied by the model runner itself, so the skeleton overlay only ever shows what the

--- a/src/arduino/app_bricks/pose_estimation/README.md
+++ b/src/arduino/app_bricks/pose_estimation/README.md
@@ -22,9 +22,9 @@ Integration highlights:
   person disappears, active poses exit after a 0.7 s grace period). Other people
   stay visible through `on_keypoints` but do not fire pose events.
 - `on_enter` / `on_exit` / `on_count_change` enable presence and people-counting automations.
-- `on_readable_change` reports whether the tracked person's skeleton can be read at all:
-  while it cannot, no pose event is emitted, so it is the cue to ask the user to step back
-  into full view.
+- `on_readable_change` reports whether the tracked person's skeleton can be classified: it
+  turns False when the normalization anchors are all guessed, when a joint lands far outside
+  the frame or when the torso collapses, and no pose event is emitted while it stays False.
 - `readable` and `people_count` hold the current value of those two states, for clients that
   connect after the last change and would otherwise wait for the next one.
 - `out_of_frame_tolerance` sets how far past the frame edges a joint may be extrapolated

--- a/src/arduino/app_bricks/pose_estimation/README.md
+++ b/src/arduino/app_bricks/pose_estimation/README.md
@@ -27,6 +27,8 @@ Integration highlights:
   API reports.
 - `set_draw_bboxes` (or `draw_bboxes=True` in the constructor) draws every detected person's
   bounding box on the overlay; off by default.
+- `set_draw_uncertain` (or `draw_uncertain=False` in the constructor) shows or hides the
+  low-confidence keypoint marks on the overlay; shown by default.
 - `set_bbox_padding` (or `bbox_padding` in the constructor) expands every bounding box, CSS
   style: one number for all sides or a (top, right, bottom, left) tuple — top/bottom as a
   fraction of the box height, left/right of its width. It applies to both the reported

--- a/src/arduino/app_bricks/pose_estimation/README.md
+++ b/src/arduino/app_bricks/pose_estimation/README.md
@@ -25,6 +25,8 @@ Integration highlights:
 - `on_readable_change` reports whether the tracked person's skeleton can be read at all:
   while it cannot, no pose event is emitted, so it is the cue to ask the user to step back
   into full view.
+- `readable` and `people_count` hold the current value of those two states, for clients that
+  connect after the last change and would otherwise wait for the next one.
 - `POSE_NAMES` lists the built-in pose names `on_pose` accepts.
 - `set_confidence` changes the minimum person detection score at runtime; the value is
   applied by the model runner itself, so the skeleton overlay only ever shows what the

--- a/src/arduino/app_bricks/pose_estimation/README.md
+++ b/src/arduino/app_bricks/pose_estimation/README.md
@@ -52,10 +52,9 @@ right_ankle.
 
 Detection score: the `confidence` threshold (constructor and `set_confidence`) compares
 against the average of a person's 17 keypoint scores, so it rises with how complete the
-skeleton is as well as with how confident each keypoint is — a fully visible person scores
-far higher than a half-framed one whose visible joints are perfect. Below that threshold,
-one limit stays: a person is not detected at all unless at least one of their keypoints
-scores 0.25 or more, the value the runner uses to start assembling a skeleton.
+skeleton is as well as with how confident each keypoint is. Below that threshold, one limit
+stays: a person is not detected at all unless at least one of their keypoints scores 0.25 or
+more, the value the runner uses to start assembling a skeleton.
 
 Classification note: the pose classifier is a k-NN over a reference database of labeled examples
 shipped with the brick (`assets/pose_classifier.npz`, ~0.6 MB) together with the exact

--- a/src/arduino/app_bricks/pose_estimation/README.md
+++ b/src/arduino/app_bricks/pose_estimation/README.md
@@ -22,6 +22,7 @@ Integration highlights:
   person disappears, active poses exit after a 0.7 s grace period). Other people
   stay visible through `on_keypoints` but do not fire pose events.
 - `on_enter` / `on_exit` / `on_count_change` enable presence and people-counting automations.
+- `POSE_NAMES` lists the built-in pose names `on_pose` accepts.
 - `set_confidence` changes the minimum person detection score at runtime; the value is
   applied by the model runner itself, so the skeleton overlay only ever shows what the
   API reports.

--- a/src/arduino/app_bricks/pose_estimation/README.md
+++ b/src/arduino/app_bricks/pose_estimation/README.md
@@ -27,6 +27,9 @@ Integration highlights:
   into full view.
 - `readable` and `people_count` hold the current value of those two states, for clients that
   connect after the last change and would otherwise wait for the next one.
+- `out_of_frame_tolerance` sets how far past the frame edges a joint may be extrapolated
+  before the skeleton counts as unreadable, as a fraction of the frame size: 0.25 by
+  default, 0 to demand a person entirely inside the picture.
 - `POSE_NAMES` lists the built-in pose names `on_pose` accepts.
 - `set_confidence` changes the minimum person detection score at runtime; the value is
   applied by the model runner itself, so the skeleton overlay only ever shows what the

--- a/src/arduino/app_bricks/pose_estimation/README.md
+++ b/src/arduino/app_bricks/pose_estimation/README.md
@@ -25,6 +25,12 @@ Integration highlights:
 - `set_confidence` changes the minimum person detection score at runtime; the value is
   applied by the model runner itself, so the skeleton overlay only ever shows what the
   API reports.
+- `set_draw_bboxes` (or `draw_bboxes=True` in the constructor) draws every detected person's
+  bounding box on the overlay; off by default.
+- `set_bbox_padding` (or `bbox_padding` in the constructor) expands every bounding box, CSS
+  style: one number for all sides or a (top, right, bottom, left) tuple — top/bottom as a
+  fraction of the box height, left/right of its width. It applies to both the reported
+  `bounding_box_xyxy` and the drawn one; none by default.
 - The skeleton overlay is drawn by the model runner, which serves the annotated video as an
   MJPEG stream on port 5002.
 

--- a/src/arduino/app_bricks/pose_estimation/README.md
+++ b/src/arduino/app_bricks/pose_estimation/README.md
@@ -36,7 +36,7 @@ Integration highlights:
   API reports.
 - `set_draw_bboxes` (or `draw_bboxes=True` in the constructor) draws every detected person's
   bounding box on the overlay; off by default.
-- `set_draw_uncertain` (or `draw_uncertain=False` in the constructor) shows or hides the
+- `set_draw_low_confidence_points` (or `draw_low_confidence_points=False` in the constructor) shows or hides the
   low-confidence keypoint marks on the overlay; shown by default.
 - `set_bbox_padding` (or `bbox_padding` in the constructor) expands every bounding box, CSS
   style: one number for all sides or a (top, right, bottom, left) tuple — top/bottom as a

--- a/src/arduino/app_bricks/pose_estimation/__init__.py
+++ b/src/arduino/app_bricks/pose_estimation/__init__.py
@@ -4,6 +4,7 @@
 
 from arduino.app_bricks.pose_estimation.pose_estimation import (
     KEYPOINT_NAMES,
+    POSE_NAMES,
     Keypoint,
     Person,
     Pose,
@@ -12,6 +13,7 @@ from arduino.app_bricks.pose_estimation.pose_estimation import (
 
 __all__ = [
     "KEYPOINT_NAMES",
+    "POSE_NAMES",
     "Keypoint",
     "Person",
     "Pose",

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -293,7 +293,7 @@ class PoseEstimation:
         if isinstance(confidence, bool) or not isinstance(confidence, (int, float)) or not 0.0 <= float(confidence) <= 1.0:
             raise ValueError(f"confidence must be a number in [0.0, 1.0], got {confidence!r}")
         self._confidence = float(confidence)
-        logger.info(f"detection confidence set to {self._confidence}")
+        logger.debug(f"detection confidence set to {self._confidence}")
 
     def set_draw_bboxes(self, draw_bboxes: bool):
         """Show or hide each detected person's bounding box on the overlay, effective immediately.

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -110,6 +110,7 @@ class PoseEstimation:
         camera: BaseCamera | None = None,
         confidence: float = 0.25,
         count_debounce_sec: float = 0.0,
+        out_of_frame_tolerance: float = OUT_OF_FRAME_TOLERANCE,
         draw_bboxes: bool = False,
         draw_uncertain: bool = True,
         bbox_padding: float | tuple[float, float, float, float] = 0.0,
@@ -129,6 +130,10 @@ class PoseEstimation:
                 dropped detection frame cannot fake it. People appearing are always reported at
                 once. Default is 0 (no debounce). Pose events are not affected: they have their
                 own temporal smoothing.
+            out_of_frame_tolerance (float): How far past the frame edges a joint may be
+                extrapolated before the skeleton counts as unreadable, as a fraction of the
+                frame size: no pose is classified and `on_readable_change` reports False.
+                Default is 0.25; 0 demands every joint inside the picture.
             draw_bboxes (bool): Draw each detected person's bounding box on the skeleton overlay
                 served by the model runner. Off by default. Changeable at runtime with
                 `set_draw_bboxes()`.
@@ -148,6 +153,7 @@ class PoseEstimation:
         self._camera = camera if camera else Camera(fps=30)
         self._confidence = confidence
         self._count_debounce_sec = count_debounce_sec
+        self._out_of_frame_tolerance = out_of_frame_tolerance
         self._draw_bboxes = draw_bboxes
         self._draw_uncertain = draw_uncertain
         self._bbox_padding = self._validate_bbox_padding(bbox_padding)
@@ -664,8 +670,8 @@ class PoseEstimation:
             return None
         if self._frame_hw is not None:
             frame_h, frame_w = self._frame_hw
-            margin_x = OUT_OF_FRAME_TOLERANCE * frame_w
-            margin_y = OUT_OF_FRAME_TOLERANCE * frame_h
+            margin_x = self._out_of_frame_tolerance * frame_w
+            margin_y = self._out_of_frame_tolerance * frame_h
             for name in EMBEDDING_JOINTS:
                 keypoint = person.keypoints[name]
                 if not (-margin_x <= keypoint.x <= frame_w + margin_x and -margin_y <= keypoint.y <= frame_h + margin_y):

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -106,6 +106,7 @@ class PoseEstimation:
         confidence: float = 0.25,
         debounce_sec: float = 0.0,
         draw_bboxes: bool = False,
+        draw_uncertain: bool = True,
         bbox_padding: float | tuple[float, float, float, float] = 0.0,
     ):
         """Initialize the PoseEstimation brick.
@@ -124,6 +125,10 @@ class PoseEstimation:
             draw_bboxes (bool): Draw each detected person's bounding box on the skeleton overlay
                 served by the model runner. Off by default. Changeable at runtime with
                 `set_draw_bboxes()`.
+            draw_uncertain (bool): Mark low-confidence keypoints on the overlay too, as small
+                hollow dots joined by darker lines. On by default; set to False for an overlay
+                that shows only the confident keypoints. Changeable at runtime with
+                `set_draw_uncertain()`.
             bbox_padding (float | tuple[float, float, float, float]): Expand every reported
                 and drawn bounding box, CSS style: a single number applies to all sides, a
                 4-tuple is (top, right, bottom, left). Top/bottom are fractions of the box
@@ -137,6 +142,7 @@ class PoseEstimation:
         self._confidence = confidence
         self._debounce_sec = debounce_sec
         self._draw_bboxes = draw_bboxes
+        self._draw_uncertain = draw_uncertain
         self._bbox_padding = self._validate_bbox_padding(bbox_padding)
 
         # Callbacks
@@ -304,6 +310,21 @@ class PoseEstimation:
         self._draw_bboxes = draw_bboxes
         logger.debug(f"bbox overlay {'enabled' if draw_bboxes else 'disabled'}")
 
+    def set_draw_uncertain(self, draw_uncertain: bool):
+        """Show or hide low-confidence keypoints on the overlay, effective immediately.
+
+        Args:
+            draw_uncertain (bool): True to mark low-confidence keypoints too, False for an
+                overlay that shows only the confident keypoints and connections.
+
+        Raises:
+            ValueError: If draw_uncertain is not a boolean.
+        """
+        if not isinstance(draw_uncertain, bool):
+            raise ValueError(f"draw_uncertain must be a boolean, got {draw_uncertain!r}")
+        self._draw_uncertain = draw_uncertain
+        logger.debug(f"uncertain keypoints overlay {'enabled' if draw_uncertain else 'disabled'}")
+
     def set_bbox_padding(self, padding: float | tuple[float, float, float, float]):
         """Expand every reported and drawn bounding box, effective immediately.
 
@@ -426,6 +447,7 @@ class PoseEstimation:
                         config = {
                             "min_person_score": self._confidence,
                             "draw_bboxes": self._draw_bboxes,
+                            "draw_uncertain": self._draw_uncertain,
                             "bbox_padding_top": top,
                             "bbox_padding_right": right,
                             "bbox_padding_bottom": bottom,

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -37,6 +37,8 @@ logger = Logger("PoseEstimation")
 
 _POSE_CLASSIFIER_PATH = Path(__file__).resolve().parent / "assets" / "pose_classifier.npz"
 
+_UNREADABLE_HOLD_SEC = 0.5
+
 """Names of the built-in poses accepted by `on_pose`."""
 POSE_NAMES: tuple[str, ...] = load_pose_classifier(_POSE_CLASSIFIER_PATH)[2]
 
@@ -162,6 +164,8 @@ class PoseEstimation:
         self._person_count = 0
         self._count_candidate: int | None = None
         self._count_since = 0.0
+        self._readable = False
+        self._readable_since: float | None = None
         self._is_running = False
 
         self._camera_frame_queue = queue.Queue(maxsize=2)
@@ -224,6 +228,8 @@ class PoseEstimation:
         )
         self._pose_last_ts = None
         self._pose_last_person = None
+        self._readable = False
+        self._readable_since = None
 
     def on_keypoints(self, callback: Callable[[Person], None] | None):
         """Register a callback invoked once per detected person, for every processed frame.
@@ -286,6 +292,25 @@ class PoseEstimation:
                 None to unregister.
         """
         self._register_callback("count", callback)
+
+    def on_readable_change(self, callback: Callable[[bool], None] | None):
+        """Register a callback for when the tracked person becomes readable, or stops being.
+
+        The pose classifier needs the skeleton to be complete enough to judge: joints
+        wildly outside the frame, guessed anchors or a collapsed torso make the frame
+        unreadable, and no pose event is emitted while it stays that way. Becoming
+        readable is reported at once, losing it only when it holds.
+
+        Args:
+            callback (Callable[[bool], None]): Function to call with True when the tracked
+                person's pose can be read, False when it cannot. None to unregister.
+        """
+        self._register_callback("readable", callback)
+
+    @property
+    def readable(self) -> bool:
+        """Whether the tracked person's pose can be read right now."""
+        return self._readable
 
     def set_confidence(self, confidence: float):
         """Change the minimum detection score for a person, effective immediately.
@@ -564,6 +589,8 @@ class PoseEstimation:
             probs = self._classify_person(tracked)
             self._pose_last_probs = probs
 
+        self._update_readable(probs is not None, now)
+
         events = self._pose_ema.update(probs, dt, person_present=bool(people))
         if not events:
             return
@@ -583,6 +610,18 @@ class PoseEstimation:
                     bounding_box_xyxy=bbox,
                 ),
             )
+
+    def _update_readable(self, readable: bool, now: float):
+        """Dispatch readability changes: gained at once, lost only when it holds."""
+        if readable == self._readable:
+            self._readable_since = None
+            return
+        if self._readable_since is None:
+            self._readable_since = now
+        if readable or (now - self._readable_since) >= _UNREADABLE_HOLD_SEC:
+            self._readable = readable
+            self._readable_since = None
+            self._submit_callback("readable", readable)
 
     @staticmethod
     def _box_area(box: tuple[int, int, int, int]) -> int:

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -300,7 +300,7 @@ class PoseEstimation:
         """
         self._register_callback("count", callback)
 
-    def on_readable_change(self, callback: Callable[[bool], None] | None):
+    def on_readable_change(self, callback: Callable[[bool], None] | None) -> None:
         """Register a callback for when the tracked person becomes readable, or stops being.
 
         The pose classifier needs the skeleton to be complete enough to judge: joints
@@ -338,7 +338,7 @@ class PoseEstimation:
         self._confidence = float(confidence)
         logger.debug(f"detection confidence set to {self._confidence}")
 
-    def set_draw_bboxes(self, draw_bboxes: bool):
+    def set_draw_bboxes(self, draw_bboxes: bool) -> None:
         """Show or hide each detected person's bounding box on the overlay, effective immediately.
 
         Args:
@@ -353,7 +353,7 @@ class PoseEstimation:
         self._draw_bboxes = draw_bboxes
         logger.debug(f"bbox overlay {'enabled' if draw_bboxes else 'disabled'}")
 
-    def set_draw_low_confidence_points(self, draw_low_confidence_points: bool):
+    def set_draw_low_confidence_points(self, draw_low_confidence_points: bool) -> None:
         """Show or hide low-confidence keypoints on the overlay, effective immediately.
 
         Args:
@@ -368,7 +368,7 @@ class PoseEstimation:
         self._draw_low_confidence_points = draw_low_confidence_points
         logger.debug(f"uncertain keypoints overlay {'enabled' if draw_low_confidence_points else 'disabled'}")
 
-    def set_bbox_padding(self, padding: float | tuple[float, float, float, float]):
+    def set_bbox_padding(self, padding: float | tuple[float, float, float, float]) -> None:
         """Expand every reported and drawn bounding box, effective immediately.
 
         The value passed replaces the current padding entirely.
@@ -623,7 +623,7 @@ class PoseEstimation:
                 ),
             )
 
-    def _update_readable(self, readable: bool, now: float):
+    def _update_readable(self, readable: bool, now: float) -> None:
         """Dispatch readability changes: gained at once, lost only when it holds."""
         if readable == self._readable:
             self._readable_since = None

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -107,7 +107,7 @@ class PoseEstimation:
         self,
         camera: BaseCamera | None = None,
         confidence: float = 0.25,
-        debounce_sec: float = 0.0,
+        count_debounce_sec: float = 0.0,
         draw_bboxes: bool = False,
         draw_uncertain: bool = True,
         bbox_padding: float | tuple[float, float, float, float] = 0.0,
@@ -122,9 +122,10 @@ class PoseEstimation:
                 the mean of the person's 17 keypoint scores, so partly visible people score lower.
                 Applied by the model runner, so detections below it are neither emitted nor drawn
                 on the overlay. Changeable at runtime with `set_confidence()`.
-            debounce_sec (float): Minimum seconds a presence or people-count change must be stable
-                before `on_enter`/`on_exit`/`on_count_change` fire again. Filters out detection
-                flicker. Default is 0 (no debounce).
+            count_debounce_sec (float): Minimum seconds a presence or people-count change must
+                be stable before `on_enter`/`on_exit`/`on_count_change` fire again. Filters out
+                detection flicker. Default is 0 (no debounce). Pose events are not affected: they
+                have their own temporal smoothing.
             draw_bboxes (bool): Draw each detected person's bounding box on the skeleton overlay
                 served by the model runner. Off by default. Changeable at runtime with
                 `set_draw_bboxes()`.
@@ -143,7 +144,7 @@ class PoseEstimation:
         """
         self._camera = camera if camera else Camera(fps=30)
         self._confidence = confidence
-        self._debounce_sec = debounce_sec
+        self._count_debounce_sec = count_debounce_sec
         self._draw_bboxes = draw_bboxes
         self._draw_uncertain = draw_uncertain
         self._bbox_padding = self._validate_bbox_padding(bbox_padding)
@@ -520,13 +521,13 @@ class PoseEstimation:
 
         # Dispatch person enter/exit events, debounced to filter out detection flicker
         present = count > 0
-        if present != self._person_present and (now - self._presence_change_ts) >= self._debounce_sec:
+        if present != self._person_present and (now - self._presence_change_ts) >= self._count_debounce_sec:
             self._person_present = present
             self._presence_change_ts = now
             self._submit_callback("enter" if present else "exit")
 
         # Dispatch people count change events, debounced as well
-        if count != self._person_count and (now - self._count_change_ts) >= self._debounce_sec:
+        if count != self._person_count and (now - self._count_change_ts) >= self._count_debounce_sec:
             self._person_count = count
             self._count_change_ts = now
             self._submit_callback("count", count)

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -312,6 +312,11 @@ class PoseEstimation:
         """Whether the tracked person's pose can be read right now."""
         return self._readable
 
+    @property
+    def people_count(self) -> int:
+        """How many people are in view right now, the value `on_count_change` last reported."""
+        return self._person_count
+
     def set_confidence(self, confidence: float):
         """Change the minimum detection score for a person, effective immediately.
 

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -122,10 +122,11 @@ class PoseEstimation:
                 the mean of the person's 17 keypoint scores, so partly visible people score lower.
                 Applied by the model runner, so detections below it are neither emitted nor drawn
                 on the overlay. Changeable at runtime with `set_confidence()`.
-            count_debounce_sec (float): Minimum seconds a presence or people-count change must
-                be stable before `on_enter`/`on_exit`/`on_count_change` fire again. Filters out
-                detection flicker. Default is 0 (no debounce). Pose events are not affected: they
-                have their own temporal smoothing.
+            count_debounce_sec (float): Minimum seconds a person leaving, or the people count
+                dropping, must hold before `on_exit`/`on_count_change` report it, so that a
+                dropped detection frame cannot fake it. People appearing are always reported at
+                once. Default is 0 (no debounce). Pose events are not affected: they have their
+                own temporal smoothing.
             draw_bboxes (bool): Draw each detected person's bounding box on the skeleton overlay
                 served by the model runner. Off by default. Changeable at runtime with
                 `set_draw_bboxes()`.
@@ -157,9 +158,10 @@ class PoseEstimation:
 
         # State tracking
         self._person_present = False
-        self._presence_change_ts = 0.0
+        self._presence_since: float | None = None
         self._person_count = 0
-        self._count_change_ts = 0.0
+        self._count_candidate: int | None = None
+        self._count_since = 0.0
         self._is_running = False
 
         self._camera_frame_queue = queue.Queue(maxsize=2)
@@ -521,16 +523,27 @@ class PoseEstimation:
 
         # Dispatch person enter/exit events, debounced to filter out detection flicker
         present = count > 0
-        if present != self._person_present and (now - self._presence_change_ts) >= self._count_debounce_sec:
-            self._person_present = present
-            self._presence_change_ts = now
-            self._submit_callback("enter" if present else "exit")
+        if present == self._person_present:
+            self._presence_since = None
+        else:
+            if self._presence_since is None:
+                self._presence_since = now
+            if present or (now - self._presence_since) >= self._count_debounce_sec:
+                self._person_present = present
+                self._presence_since = None
+                self._submit_callback("enter" if present else "exit")
 
         # Dispatch people count change events, debounced as well
-        if count != self._person_count and (now - self._count_change_ts) >= self._count_debounce_sec:
-            self._person_count = count
-            self._count_change_ts = now
-            self._submit_callback("count", count)
+        if count == self._person_count:
+            self._count_candidate = None
+        else:
+            if self._count_candidate != count:
+                self._count_candidate = count
+                self._count_since = now
+            if count > self._person_count or (now - self._count_since) >= self._count_debounce_sec:
+                self._person_count = count
+                self._count_candidate = None
+                self._submit_callback("count", count)
 
         # Dispatch keypoint events (not debounced: they are the raw detection stream)
         if people:

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -112,7 +112,7 @@ class PoseEstimation:
         count_debounce_sec: float = 0.0,
         out_of_frame_tolerance: float = OUT_OF_FRAME_TOLERANCE,
         draw_bboxes: bool = False,
-        draw_uncertain: bool = True,
+        draw_low_confidence_points: bool = True,
         bbox_padding: float | tuple[float, float, float, float] = 0.0,
     ):
         """Initialize the PoseEstimation brick.
@@ -137,10 +137,10 @@ class PoseEstimation:
             draw_bboxes (bool): Draw each detected person's bounding box on the skeleton overlay
                 served by the model runner. Off by default. Changeable at runtime with
                 `set_draw_bboxes()`.
-            draw_uncertain (bool): Mark low-confidence keypoints on the overlay too, as small
+            draw_low_confidence_points (bool): Mark low-confidence keypoints on the overlay too, as small
                 hollow dots joined by darker lines. On by default; set to False for an overlay
                 that shows only the confident keypoints. Changeable at runtime with
-                `set_draw_uncertain()`.
+                `set_draw_low_confidence_points()`.
             bbox_padding (float | tuple[float, float, float, float]): Expand every reported
                 and drawn bounding box, CSS style: a single number applies to all sides, a
                 4-tuple is (top, right, bottom, left). Top/bottom are fractions of the box
@@ -155,7 +155,7 @@ class PoseEstimation:
         self._count_debounce_sec = count_debounce_sec
         self._out_of_frame_tolerance = out_of_frame_tolerance
         self._draw_bboxes = draw_bboxes
-        self._draw_uncertain = draw_uncertain
+        self._draw_low_confidence_points = draw_low_confidence_points
         self._bbox_padding = self._validate_bbox_padding(bbox_padding)
 
         # Callbacks
@@ -352,20 +352,20 @@ class PoseEstimation:
         self._draw_bboxes = draw_bboxes
         logger.debug(f"bbox overlay {'enabled' if draw_bboxes else 'disabled'}")
 
-    def set_draw_uncertain(self, draw_uncertain: bool):
+    def set_draw_low_confidence_points(self, draw_low_confidence_points: bool):
         """Show or hide low-confidence keypoints on the overlay, effective immediately.
 
         Args:
-            draw_uncertain (bool): True to mark low-confidence keypoints too, False for an
+            draw_low_confidence_points (bool): True to mark low-confidence keypoints too, False for an
                 overlay that shows only the confident keypoints and connections.
 
         Raises:
-            ValueError: If draw_uncertain is not a boolean.
+            ValueError: If draw_low_confidence_points is not a boolean.
         """
-        if not isinstance(draw_uncertain, bool):
-            raise ValueError(f"draw_uncertain must be a boolean, got {draw_uncertain!r}")
-        self._draw_uncertain = draw_uncertain
-        logger.debug(f"uncertain keypoints overlay {'enabled' if draw_uncertain else 'disabled'}")
+        if not isinstance(draw_low_confidence_points, bool):
+            raise ValueError(f"draw_low_confidence_points must be a boolean, got {draw_low_confidence_points!r}")
+        self._draw_low_confidence_points = draw_low_confidence_points
+        logger.debug(f"uncertain keypoints overlay {'enabled' if draw_low_confidence_points else 'disabled'}")
 
     def set_bbox_padding(self, padding: float | tuple[float, float, float, float]):
         """Expand every reported and drawn bounding box, effective immediately.
@@ -489,7 +489,7 @@ class PoseEstimation:
                         config = {
                             "min_person_score": self._confidence,
                             "draw_bboxes": self._draw_bboxes,
-                            "draw_uncertain": self._draw_uncertain,
+                            "draw_low_confidence_points": self._draw_low_confidence_points,
                             "bbox_padding_top": top,
                             "bbox_padding_right": right,
                             "bbox_padding_bottom": bottom,

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -37,6 +37,9 @@ logger = Logger("PoseEstimation")
 
 _POSE_CLASSIFIER_PATH = Path(__file__).resolve().parent / "assets" / "pose_classifier.npz"
 
+"""Names of the built-in poses accepted by `on_pose`."""
+POSE_NAMES: tuple[str, ...] = load_pose_classifier(_POSE_CLASSIFIER_PATH)[2]
+
 
 @dataclass
 class Keypoint:

--- a/src/arduino/app_bricks/pose_estimation/pose_estimation.py
+++ b/src/arduino/app_bricks/pose_estimation/pose_estimation.py
@@ -64,7 +64,8 @@ class Person:
             keypoint name (see `KEYPOINT_NAMES`). Low-confidence keypoints are
             included; filter by their score.
         bounding_box_xyxy (tuple[int, int, int, int]): (x1, y1, x2, y2) box
-            enclosing the person's confident keypoints, in frame coordinates.
+            enclosing the person's confident keypoints, expanded by the
+            configured bbox padding (none by default), in frame coordinates.
     """
 
     keypoints: dict[str, Keypoint]
@@ -86,7 +87,8 @@ class Pose:
         keypoints (dict[str, Keypoint]): The person's 17 keypoints, keyed by
             keypoint name (see `KEYPOINT_NAMES`).
         bounding_box_xyxy (tuple[int, int, int, int]): (x1, y1, x2, y2) box
-            enclosing the person's confident keypoints, in frame coordinates.
+            enclosing the person's confident keypoints, expanded by the
+            configured bbox padding (none by default), in frame coordinates.
     """
 
     name: str
@@ -103,6 +105,8 @@ class PoseEstimation:
         camera: BaseCamera | None = None,
         confidence: float = 0.25,
         debounce_sec: float = 0.0,
+        draw_bboxes: bool = False,
+        bbox_padding: float | tuple[float, float, float, float] = 0.0,
     ):
         """Initialize the PoseEstimation brick.
 
@@ -117,6 +121,14 @@ class PoseEstimation:
             debounce_sec (float): Minimum seconds a presence or people-count change must be stable
                 before `on_enter`/`on_exit`/`on_count_change` fire again. Filters out detection
                 flicker. Default is 0 (no debounce).
+            draw_bboxes (bool): Draw each detected person's bounding box on the skeleton overlay
+                served by the model runner. Off by default. Changeable at runtime with
+                `set_draw_bboxes()`.
+            bbox_padding (float | tuple[float, float, float, float]): Expand every reported
+                and drawn bounding box, CSS style: a single number applies to all sides, a
+                4-tuple is (top, right, bottom, left). Top/bottom are fractions of the box
+                height, left/right of its width, each in [0.0, 1.0]. Default is 0 (no
+                expansion). Changeable at runtime with `set_bbox_padding()`.
 
         Raises:
             RuntimeError: If the model runner host address could not be resolved.
@@ -124,6 +136,8 @@ class PoseEstimation:
         self._camera = camera if camera else Camera(fps=30)
         self._confidence = confidence
         self._debounce_sec = debounce_sec
+        self._draw_bboxes = draw_bboxes
+        self._bbox_padding = self._validate_bbox_padding(bbox_padding)
 
         # Callbacks
         self._callbacks: dict[str, Callable] = {}
@@ -275,6 +289,49 @@ class PoseEstimation:
         self._confidence = float(confidence)
         logger.info(f"detection confidence set to {self._confidence}")
 
+    def set_draw_bboxes(self, draw_bboxes: bool):
+        """Show or hide each detected person's bounding box on the overlay, effective immediately.
+
+        Args:
+            draw_bboxes (bool): True to draw every detected person's bounding box on the
+                skeleton overlay served by the model runner, False to hide the boxes.
+
+        Raises:
+            ValueError: If draw_bboxes is not a boolean.
+        """
+        if not isinstance(draw_bboxes, bool):
+            raise ValueError(f"draw_bboxes must be a boolean, got {draw_bboxes!r}")
+        self._draw_bboxes = draw_bboxes
+        logger.debug(f"bbox overlay {'enabled' if draw_bboxes else 'disabled'}")
+
+    def set_bbox_padding(self, padding: float | tuple[float, float, float, float]):
+        """Expand every reported and drawn bounding box, effective immediately.
+
+        The value passed replaces the current padding entirely.
+
+        Args:
+            padding (float | tuple[float, float, float, float]): CSS style: a single number
+                applies to all sides, a 4-tuple is (top, right, bottom, left). Top/bottom are
+                fractions of the box height, left/right of its width, each in [0.0, 1.0].
+
+        Raises:
+            ValueError: If padding is not a number in [0.0, 1.0] or a 4-tuple of them.
+        """
+        self._bbox_padding = self._validate_bbox_padding(padding)
+        top, right, bottom, left = self._bbox_padding
+        logger.debug(f"bbox padding set to top={top}, right={right}, bottom={bottom}, left={left}")
+
+    @staticmethod
+    def _validate_bbox_padding(padding: float | tuple[float, float, float, float]) -> tuple[float, float, float, float]:
+        """Normalize a CSS-style padding value to a (top, right, bottom, left) tuple."""
+        values = padding if isinstance(padding, (tuple, list)) else (padding, padding, padding, padding)
+        if len(values) != 4:
+            raise ValueError(f"padding must be a number or a (top, right, bottom, left) tuple, got {padding!r}")
+        for value in values:
+            if isinstance(value, bool) or not isinstance(value, (int, float)) or not 0.0 <= float(value) <= 1.0:
+                raise ValueError(f"padding values must be numbers in [0.0, 1.0], got {value!r}")
+        return tuple(float(value) for value in values)
+
     def on_frame(self, callback: Callable[[np.ndarray], None] | None):
         """Register a callback that receives each raw camera frame.
 
@@ -363,11 +420,20 @@ class PoseEstimation:
         while self._is_running:
             try:
                 async with websockets.connect(self._ws_send_url) as ws:
-                    sent_confidence: float | None = None
+                    sent_config: dict | None = None
                     while self._is_running:
-                        if self._confidence != sent_confidence:
-                            await ws.send(json.dumps({"config": {"min_person_score": self._confidence}}))
-                            sent_confidence = self._confidence
+                        top, right, bottom, left = self._bbox_padding
+                        config = {
+                            "min_person_score": self._confidence,
+                            "draw_bboxes": self._draw_bboxes,
+                            "bbox_padding_top": top,
+                            "bbox_padding_right": right,
+                            "bbox_padding_bottom": bottom,
+                            "bbox_padding_left": left,
+                        }
+                        if config != sent_config:
+                            await ws.send(json.dumps({"config": config}))
+                            sent_config = config
                         try:
                             frame = await asyncio.get_event_loop().run_in_executor(None, self._camera_frame_queue.get, True, 0.1)
                         except queue.Empty:

--- a/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
+++ b/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
@@ -440,6 +440,63 @@ class TestPoseEvents:
         assert not called.wait(timeout=0.3)
 
 
+class TestReadableCallback:
+    def _feed(self, pe: PoseEstimation, steps: int, start: float) -> float:
+        now = start
+        for _ in range(steps):
+            now += 0.1
+            pe._update_pose_classification([_person()], now)
+        return now
+
+    def test_readable_is_gained_at_once_and_lost_on_hold(self, pe: PoseEstimation, monkeypatch):
+        states = []
+        gained, lost = threading.Event(), threading.Event()
+
+        def on_readable(value: bool):
+            states.append(value)
+            (gained if value else lost).set()
+
+        pe.on_readable_change(on_readable)
+
+        monkeypatch.setattr(pe, "_classify_person", lambda p: {"standing": 1.0})
+        now = self._feed(pe, steps=2, start=0.0)
+        _wait(gained, "readable")
+        time.sleep(0.1)
+
+        monkeypatch.setattr(pe, "_classify_person", lambda p: None)
+        self._feed(pe, steps=10, start=now)
+        _wait(lost, "unreadable")
+
+        assert states == [True, False]
+
+    def test_the_property_holds_the_reported_state(self, pe: PoseEstimation, monkeypatch):
+        assert pe.readable is False
+
+        monkeypatch.setattr(pe, "_classify_person", lambda p: {"standing": 1.0})
+        now = self._feed(pe, steps=2, start=0.0)
+        assert pe.readable is True
+
+        monkeypatch.setattr(pe, "_classify_person", lambda p: None)
+        self._feed(pe, steps=10, start=now)
+        assert pe.readable is False
+
+    def test_a_single_unreadable_frame_is_ignored(self, pe: PoseEstimation, monkeypatch):
+        states = []
+        pe.on_readable_change(states.append)
+
+        monkeypatch.setattr(pe, "_classify_person", lambda p: {"standing": 1.0})
+        now = self._feed(pe, steps=2, start=0.0)
+        time.sleep(0.1)
+
+        monkeypatch.setattr(pe, "_classify_person", lambda p: None)
+        now = self._feed(pe, steps=1, start=now)
+        monkeypatch.setattr(pe, "_classify_person", lambda p: {"standing": 1.0})
+        self._feed(pe, steps=3, start=now)
+
+        time.sleep(0.2)
+        assert states == [True]
+
+
 class TestSetConfidence:
     def test_updates_the_filter_and_validates_input(self, pe: PoseEstimation):
         pe.set_confidence(0.8)

--- a/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
+++ b/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
@@ -48,7 +48,7 @@ def pe(monkeypatch: pytest.MonkeyPatch):
 @pytest.fixture()
 def pe_debounced(monkeypatch: pytest.MonkeyPatch):
     """Return a PoseEstimation instance with a 0.3s debounce."""
-    yield from _make_instance(monkeypatch, debounce_sec=0.3)
+    yield from _make_instance(monkeypatch, count_debounce_sec=0.3)
 
 
 def _make_instance(monkeypatch: pytest.MonkeyPatch, **kwargs):

--- a/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
+++ b/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
@@ -51,6 +51,12 @@ def pe_debounced(monkeypatch: pytest.MonkeyPatch):
     yield from _make_instance(monkeypatch, count_debounce_sec=0.3)
 
 
+@pytest.fixture()
+def pe_strict(monkeypatch: pytest.MonkeyPatch):
+    """Return a PoseEstimation instance that refuses any joint outside the frame."""
+    yield from _make_instance(monkeypatch, out_of_frame_tolerance=0.0)
+
+
 def _make_instance(monkeypatch: pytest.MonkeyPatch, **kwargs):
     fake_compose = {"services": {"pose-runner": {}}}
     monkeypatch.setattr(
@@ -358,6 +364,15 @@ class TestPoseEvents:
 
         pe._frame_hw = None
         assert pe._classify_person(far_out) is not None
+
+    def test_zero_tolerance_demands_every_joint_inside_the_frame(self, pe_strict: PoseEstimation):
+        pe_strict._frame_hw = (480, 640)
+        assert pe_strict._classify_person(_person()) is not None
+
+        just_outside = _person()
+        kp = just_outside.keypoints["left_ankle"]
+        just_outside.keypoints["left_ankle"] = Keypoint(name=kp.name, x=kp.x, y=481, score=kp.score)
+        assert pe_strict._classify_person(just_outside) is None
 
     def test_a_tip_extrapolated_outside_from_a_seen_joint_is_still_readable(self, pe: PoseEstimation):
         pe._frame_hw = (480, 640)

--- a/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
+++ b/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
@@ -414,3 +414,42 @@ class TestSetConfidence:
         with pytest.raises(ValueError):
             pe.set_confidence(True)
         assert pe._confidence == 0.8
+
+
+class TestSetDrawBboxes:
+    def test_updates_the_flag_and_validates_input(self, pe: PoseEstimation):
+        assert pe._draw_bboxes is False
+
+        pe.set_draw_bboxes(True)
+        assert pe._draw_bboxes is True
+
+        with pytest.raises(ValueError):
+            pe.set_draw_bboxes(1)
+        with pytest.raises(ValueError):
+            pe.set_draw_bboxes("on")
+        with pytest.raises(ValueError):
+            pe.set_draw_bboxes(None)
+        assert pe._draw_bboxes is True
+
+
+class TestSetBboxPadding:
+    def test_replaces_the_padding_and_validates_input(self, pe: PoseEstimation):
+        assert pe._bbox_padding == (0.0, 0.0, 0.0, 0.0)
+
+        pe.set_bbox_padding((0.15, 0.20, 0.15, 0.20))  # (top, right, bottom, left), come CSS
+        assert pe._bbox_padding == (0.15, 0.20, 0.15, 0.20)
+
+        pe.set_bbox_padding(0.1)  # scalare: tutti i lati
+        assert pe._bbox_padding == (0.1, 0.1, 0.1, 0.1)
+
+        with pytest.raises(ValueError):
+            pe.set_bbox_padding(1.5)
+        with pytest.raises(ValueError):
+            pe.set_bbox_padding((0.1, 0.2))
+        with pytest.raises(ValueError):
+            pe.set_bbox_padding((0.1, 0.2, 0.3, -0.1))
+        with pytest.raises(ValueError):
+            pe.set_bbox_padding("high")
+        with pytest.raises(ValueError):
+            pe.set_bbox_padding(True)
+        assert pe._bbox_padding == (0.1, 0.1, 0.1, 0.1)

--- a/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
+++ b/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
@@ -432,6 +432,20 @@ class TestSetDrawBboxes:
         assert pe._draw_bboxes is True
 
 
+class TestSetDrawUncertain:
+    def test_updates_the_flag_and_validates_input(self, pe: PoseEstimation):
+        assert pe._draw_uncertain is True
+
+        pe.set_draw_uncertain(False)
+        assert pe._draw_uncertain is False
+
+        with pytest.raises(ValueError):
+            pe.set_draw_uncertain(0)
+        with pytest.raises(ValueError):
+            pe.set_draw_uncertain("off")
+        assert pe._draw_uncertain is False
+
+
 class TestSetBboxPadding:
     def test_replaces_the_padding_and_validates_input(self, pe: PoseEstimation):
         assert pe._bbox_padding == (0.0, 0.0, 0.0, 0.0)

--- a/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
+++ b/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
@@ -180,6 +180,15 @@ class TestPresenceCallbacks:
         _wait(done, "count change callbacks")
         assert counts == [1, 2]
 
+    def test_people_count_property_holds_the_reported_count(self, pe: PoseEstimation):
+        assert pe.people_count == 0
+
+        pe._process_detection(_detection_with([_pose_dict(), _pose_dict(x=300)]))
+        assert pe.people_count == 2
+
+        pe._process_detection(_detection_with([]))
+        assert pe.people_count == 0
+
     def test_low_confidence_poses_are_filtered(self, pe: PoseEstimation):
         entered = threading.Event()
         got_keypoints = threading.Event()

--- a/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
+++ b/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
@@ -555,16 +555,16 @@ class TestSetDrawBboxes:
 
 class TestSetDrawUncertain:
     def test_updates_the_flag_and_validates_input(self, pe: PoseEstimation):
-        assert pe._draw_uncertain is True
+        assert pe._draw_low_confidence_points is True
 
-        pe.set_draw_uncertain(False)
-        assert pe._draw_uncertain is False
+        pe.set_draw_low_confidence_points(False)
+        assert pe._draw_low_confidence_points is False
 
         with pytest.raises(ValueError):
-            pe.set_draw_uncertain(0)
+            pe.set_draw_low_confidence_points(0)
         with pytest.raises(ValueError):
-            pe.set_draw_uncertain("off")
-        assert pe._draw_uncertain is False
+            pe.set_draw_low_confidence_points("off")
+        assert pe._draw_low_confidence_points is False
 
 
 class TestSetBboxPadding:

--- a/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
+++ b/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
@@ -207,6 +207,42 @@ class TestPresenceCallbacks:
         pe_debounced._process_detection(_detection_with([]))
         _wait(exited, "debounced exit callback")
 
+    def test_dropped_detection_frame_never_fires_exit(self, pe_debounced: PoseEstimation):
+        exited = threading.Event()
+        pe_debounced.on_exit(lambda: exited.set())
+
+        pe_debounced._process_detection(_detection_with([_pose_dict()]))
+        pe_debounced._process_detection(_detection_with([]))
+        pe_debounced._process_detection(_detection_with([_pose_dict()]))
+
+        time.sleep(0.4)
+        pe_debounced._process_detection(_detection_with([_pose_dict()]))
+
+        assert not exited.wait(timeout=0.1), "a dropped frame must not fire exit"
+
+    def test_people_count_grows_at_once_and_drops_on_hold(self, pe_debounced: PoseEstimation):
+        counts = []
+        dropped = threading.Event()
+
+        def on_count(count: int):
+            counts.append(count)
+            if counts == [1, 2, 1]:
+                dropped.set()
+
+        pe_debounced.on_count_change(on_count)
+
+        pe_debounced._process_detection(_detection_with([_pose_dict()]))
+        time.sleep(0.1)  # Let the first callback complete to avoid the busy-discard
+        pe_debounced._process_detection(_detection_with([_pose_dict(), _pose_dict(x=300)]))
+        time.sleep(0.1)
+        pe_debounced._process_detection(_detection_with([_pose_dict()]))
+
+        assert counts == [1, 2], "a growing count is immediate, a dropping one is not"
+
+        time.sleep(0.3)
+        pe_debounced._process_detection(_detection_with([_pose_dict()]))
+        _wait(dropped, "debounced count drop")
+
 
 # ---------------------------------------------------------------------------
 # Keypoint stream callback tests

--- a/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
+++ b/tests/arduino/app_bricks/pose_estimation/test_pose_estimation.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from arduino.app_bricks.pose_estimation import KEYPOINT_NAMES, Keypoint, Person, PoseEstimation
+from arduino.app_bricks.pose_estimation import KEYPOINT_NAMES, POSE_NAMES, Keypoint, Person, PoseEstimation
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -93,6 +93,10 @@ def test_stop_resets_the_temporal_state_with_the_asset_thresholds(pe):
 # ---------------------------------------------------------------------------
 # Detection parsing tests
 # ---------------------------------------------------------------------------
+
+
+def test_pose_names_lists_the_asset_poses():
+    assert POSE_NAMES == ("left_arm_raised", "right_arm_raised", "sitting", "standing")
 
 
 class TestDetectionParsing:


### PR DESCRIPTION
Adds configurations option to the pose estimation runner:
- `draw_bboxes` draws every detected person's bounding box on the runner stream, and `bbox_padding` (with a CSS-style shorthand: one number or a top/right/bottom/left tuple, as fractions of the box size) expands it. The padding also applies to the reported `bounding_box_xyxy`, so the drawn box and the API always agree; defaults keep today's behavior.
- `draw_uncertain` toggle (low-confidence keypoint marks) is now exposed from the brick too.

Also retunes the tracking crop margins from 30/45/15 to 35/40/15 (lateral/top/bottom): with 30 a held T pose lost the extended arm out of the crop window, and 40 on top keeps enough slack for raised wrists. Tuned live on the board with two people of different heights.