### PR TITLE
fix(camera): resync FPS throttling when V4L driver overrides requested rate

### DIFF
--- a/src/arduino/app_peripherals/camera/base_camera.py
+++ b/src/arduino/app_peripherals/camera/base_camera.py
@@ -55,7 +55,6 @@ class BaseCamera(ABC):
         self._camera_lock = threading.Lock()
         self._is_started = False
         self._last_capture_time = time.monotonic()
-        self._desired_interval = 1.0 / fps if fps > 0 else 0
 
         # Auto-reconnection parameters
         self.auto_reconnect = auto_reconnect
@@ -73,6 +72,16 @@ class BaseCamera(ABC):
     def status(self) -> Literal["disconnected", "connected", "streaming", "paused"]:
         """Read-only property for camera status."""
         return self._status
+
+    @property
+    def fps(self) -> int:
+        """Frames per second the camera captures at."""
+        return self._fps
+
+    @fps.setter
+    def fps(self, value: int) -> None:
+        self._fps = value
+        self._desired_interval = 1.0 / value if value > 0 else 0
 
     @property
     def _none_frame_threshold(self) -> int:

--- a/src/arduino/app_peripherals/camera/v4l_camera.py
+++ b/src/arduino/app_peripherals/camera/v4l_camera.py
@@ -281,9 +281,11 @@ class V4LCamera(BaseCamera):
                     logger.warning(f"Camera {self.name} returned invalid FPS value: {configured_fps}. Cannot verify FPS setting.")
                 else:
                     actual_fps = int(configured_fps)
-                    if actual_fps != self.fps:
+                    if actual_fps < self.fps:
                         logger.warning(f"Camera {self.name} FPS set to {actual_fps} instead of requested {self.fps}")
                         self.fps = actual_fps
+                    elif actual_fps > self.fps:
+                        logger.info(f"Camera {self.name} driver runs at {actual_fps} FPS, throttling to requested {self.fps} FPS")
 
             # Verify camera with a test read
             ret, frame = self._cap.read()

--- a/tests/arduino/app_peripherals/camera/test_base_camera.py
+++ b/tests/arduino/app_peripherals/camera/test_base_camera.py
@@ -86,6 +86,16 @@ def test_base_camera_init_invalid():
         MockedCamera(fps=0)
 
 
+def test_fps_setter_resyncs_throttling_interval():
+    """Test that updating fps recomputes the software throttling interval."""
+    camera = MockedCamera(fps=10)
+    assert camera._desired_interval == pytest.approx(1 / 10)
+
+    camera.fps = 20
+    assert camera.fps == 20
+    assert camera._desired_interval == pytest.approx(1 / 20)
+
+
 def test_is_started_state_transitions():
     """Test is_started return value through different state transitions."""
     camera = MockedCamera()

--- a/tests/arduino/app_peripherals/camera/test_v4l_camera.py
+++ b/tests/arduino/app_peripherals/camera/test_v4l_camera.py
@@ -179,6 +179,31 @@ class TestV4LCameraStartStop:
         camera.start()
 
         assert camera.fps == 15
+        assert camera._desired_interval == pytest.approx(1 / 15)
+        assert camera.is_started()
+
+    @patch("arduino.app_peripherals.camera.v4l_camera.cv2.VideoCapture")
+    def test_hardware_adaptation_fps_downscale_emulation(self, mock_videocapture, mock_successful_connect):
+        """Test that V4LCamera keeps the requested FPS when the driver rate is higher."""
+
+        def get_caps(prop):
+            if prop == cv2.CAP_PROP_FRAME_WIDTH:
+                return 640
+            elif prop == cv2.CAP_PROP_FRAME_HEIGHT:
+                return 480
+            elif prop == cv2.CAP_PROP_FPS:
+                return 30
+            return 0
+
+        mock_successful_connect.get.side_effect = get_caps
+        mock_videocapture.return_value = mock_successful_connect
+
+        # Request 15fps on a device whose driver keeps 30fps: software throttling emulates it
+        camera = V4LCamera(resolution=(640, 480), fps=15)
+        camera.start()
+
+        assert camera.fps == 15
+        assert camera._desired_interval == pytest.approx(1 / 15)
         assert camera.is_started()
 
     @patch("arduino.app_peripherals.camera.v4l_camera.cv2.VideoCapture")


### PR DESCRIPTION
## Problem

When a USB (V4L) camera does not accept the requested FPS, `V4LCamera._open_camera()` overwrites `self.fps` with the driver-reported value, but the software throttling interval (`BaseCamera._desired_interval`) is computed only once in `__init__` from the *requested* FPS and is never resynced. The two values diverge, breaking every consumer of `self.fps`: e.g. requesting 15 fps on a UVC camera that keeps 30 fps makes `record_avi(duration=5)` produce a 2× time-lapse (frames acquired at 15 fps, AVI written at 30 fps) instead of a real-time 5 s recording. The desync was also re-triggered on every auto-reconnection, since `_read_frame()` calls `_open_camera()` again.

## Changes

- `src/arduino/app_peripherals/camera/base_camera.py`: `fps` is now a property on `BaseCamera` whose setter recomputes `_desired_interval`, removing this class of desync for all camera types. No public API change: the attribute is read and assigned exactly as before.
- `src/arduino/app_peripherals/camera/v4l_camera.py`: hardware FPS adaptation in `V4LCamera._open_camera()` is now applied only downwards. If the driver reports a *lower* rate, `fps` is overridden with a warning (and the throttle interval resyncs via the setter); if the driver reports a *higher* rate, the requested FPS is kept and software throttling emulates it (informational log only).

Only `V4LCamera` mutated `fps` at runtime: `CSICamera` enforces FPS via GStreamer caps, and IP/WebSocket cameras never touch it, so their behavior is unchanged.

## Tests

- `test_hardware_adaptation_fps_downscale_emulation` (new): request 15 fps on a 30 fps device → `fps` stays 15, throttle interval is 1/15.
- `test_hardware_adaptation_fps_mismatch` (updated): request 30 fps on a 15 fps device → also asserts the throttle interval is resynced to 1/15.
- `test_fps_setter_resyncs_throttling_interval` (new): assigning `fps` on `BaseCamera` recomputes `_desired_interval`.
