### PR TITLE
fix: Update LLAMA.cpp to fix session allocation bug in router mode

### DIFF
--- a/containers/ai/llamacpp-npu-runner/ci.json
+++ b/containers/ai/llamacpp-npu-runner/ci.json
@@ -4,8 +4,8 @@
   "build_whl": false,
   "update_compose": true,
   "build_args": {
-    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260901/llamacpp-hexagon-20260901.tar.gz",
-    "LLAMA_CPP_DIGEST": "sha256:c85278d5a33754bca49611fabb5aa58654958989f09412a5e9057c2db05638cf"
+    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260901/llamacpp-hexagon-20260902.tar.gz",
+    "LLAMA_CPP_DIGEST": "sha256:02e155c506d9ddb8aceb10a02c07debdab26726f9a4048a05b456cd1309b701c"
   },
   "sbom": {
     "runtime_base": "${REGISTRY}app-bricks/qairt-common-base:${BASE_IMAGE_VERSION}"

--- a/containers/ai/llamacpp-npu-runner/ci.json
+++ b/containers/ai/llamacpp-npu-runner/ci.json
@@ -4,8 +4,8 @@
   "build_whl": false,
   "update_compose": true,
   "build_args": {
-    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260804/llamacpp-hexagon-20260804.tar.gz",
-    "LLAMA_CPP_DIGEST": "sha256:c024d44af3bf3403bb764eec90bf8432ce5eb10f803c0fabd3b5236130c6a575"
+    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260901/llamacpp-hexagon-20260901.tar.gz",
+    "LLAMA_CPP_DIGEST": "sha256:c85278d5a33754bca49611fabb5aa58654958989f09412a5e9057c2db05638cf"
   },
   "sbom": {
     "runtime_base": "${REGISTRY}app-bricks/qairt-common-base:${BASE_IMAGE_VERSION}"

--- a/containers/ai/llamacpp-npu-runner/ci.json
+++ b/containers/ai/llamacpp-npu-runner/ci.json
@@ -4,7 +4,7 @@
   "build_whl": false,
   "update_compose": true,
   "build_args": {
-    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260901/llamacpp-hexagon-20260902.tar.gz",
+    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260902/llamacpp-hexagon-20260902.tar.gz",
     "LLAMA_CPP_DIGEST": "sha256:02e155c506d9ddb8aceb10a02c07debdab26726f9a4048a05b456cd1309b701c"
   },
   "sbom": {

--- a/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
@@ -50,8 +50,14 @@ GB = 1e9
 # at that moment — other models resident in the router, leftover instances — not that the
 # model needs more sessions. Measured on a 21q: a loaded model costs ~1.6x its GGUF in RAM.
 
-# Default table, for the context sizes the service runs at out of the box.
-NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 2))
+# Default table, for the context sizes the service runs at out of the box. The middle
+# bucket takes 3 sessions because of the KV cache, which lives on the same sessions as
+# the weights and cannot be chunked: at 16k tokens Qwen3-4B-Instruct-2507 (2.38 GB) puts
+# a single 1 GiB KV buffer on each of 2 sessions, and fastrpc refuses a mapping that big
+# even with the board's RAM free (measured on a 21q: fails on 2 sessions, runs on 3).
+# KV size depends on the architecture, not the GGUF size: Qwen3.5-4B (2.78 GB) measured
+# fine on 2 sessions, so the bucket over-allocates it — the ~3%/token toll.
+NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 3))
 
 # Small-context table. A 4k KV cache leaves far more room on the domains. It was
 # originally measured on a ventunoq board (every installed model loaded at 1..4 sessions

--- a/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
@@ -68,8 +68,9 @@ NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 3))
 #   Qwen3.5-4B-Q4_0      2.78 GB -> 1     gemma-4-12b          6.98 GB -> 3
 #
 # Qwen3-8B-Q4_0 has since been re-measured on the September 2025 build: it no longer
-# loads on 2 sessions but runs on 3, so the 3.5+ bucket takes 3. Anything bigger is
-# unmeasured on that build and takes everything the hardware has.
+# loads on 2 sessions but runs on 3, so the 3.5+ bucket takes 3. Anything bigger takes
+# everything the hardware has: granite-4.2-8b (5.06 GB) also loads on 3, but measured
+# no faster there than on 4, so there is nothing to gain from a tighter threshold.
 SMALL_CTX_SIZE = 4096
 NDEV_BY_GGUF_GB_SMALL_CTX = ((5.0, 4), (3.5, 3))
 

--- a/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
@@ -61,12 +61,11 @@ NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 2))
 #   Qwen3-4B-2507-Q4_0   2.38 GB -> 1     Qwen3.5-9B-Q4_0      5.74 GB -> 2
 #   Qwen3.5-4B-Q4_0      2.78 GB -> 1     gemma-4-12b          6.98 GB -> 3
 #
-# Qwen3-8B-Q4_0 has since failed to fastrpc-map its per-domain buffer on 2 sessions
-# (possibly RAM pressure rather than session sizing, see above — not re-measured yet),
-# so pending a re-measurement of the multi-session rows on a quiet board, every model
-# above the 1-session rows takes everything the hardware has.
+# Qwen3-8B-Q4_0 has since been re-measured on the September 2025 build: it no longer
+# loads on 2 sessions but runs on 3, so the 3.5+ bucket takes 3. Anything bigger is
+# unmeasured on that build and takes everything the hardware has.
 SMALL_CTX_SIZE = 4096
-NDEV_BY_GGUF_GB_SMALL_CTX = ((3.5, 4),)
+NDEV_BY_GGUF_GB_SMALL_CTX = ((5.0, 4), (3.5, 3))
 
 
 class ModelOverride(NamedTuple):

--- a/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
@@ -43,13 +43,15 @@ GB = 1e9
 # model exceeds wins. Both tables are deliberately conservative — they over-allocate a session
 # on some models, which costs ~3% per token, rather than failing to load; models with a
 # known-good value should carry an explicit GGML_HEXAGON_DEVICES instead.
+#
+# Before resizing these tables over a load failure, check the board's free RAM first: the DSP
+# buffers come from plain system memory (/dev/dma_heap/system), so "ggml-hex: fastrpc_mmap
+# failed" with error 0x1 on a buffer that used to fit usually means the board was out of RAM
+# at that moment — other models resident in the router, leftover instances — not that the
+# model needs more sessions. Measured on a 21q: a loaded model costs ~1.6x its GGUF in RAM.
 
-# Default table, for the context sizes the service runs at out of the box. The September
-# 2025 llama.cpp build shrank the per-session mapping budget: Qwen3.5-4B-Q4_0 (2.78 GB)
-# no longer loads on 2 sessions — fastrpc_mmap fails on its second ~0.9 GiB weights buffer
-# at 8k and 16k alike — so the middle bucket takes 3 sessions. Still below the 4 that
-# trigger the context cap, so these models keep the full context.
-NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 3))
+# Default table, for the context sizes the service runs at out of the box.
+NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 2))
 
 # Small-context table. A 4k KV cache leaves far more room on the domains. It was
 # originally measured on a ventunoq board (every installed model loaded at 1..4 sessions
@@ -59,10 +61,10 @@ NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 3))
 #   Qwen3-4B-2507-Q4_0   2.38 GB -> 1     Qwen3.5-9B-Q4_0      5.74 GB -> 2
 #   Qwen3.5-4B-Q4_0      2.78 GB -> 1     gemma-4-12b          6.98 GB -> 3
 #
-# The September 2025 llama.cpp build invalidated the multi-session rows: Qwen3-8B-Q4_0
-# no longer fastrpc-maps its per-domain buffer on 2 sessions and needs 4. The 1-session
-# rows still load, so every model above them takes everything the hardware has until the
-# bigger models are re-measured on the new build.
+# Qwen3-8B-Q4_0 has since failed to fastrpc-map its per-domain buffer on 2 sessions
+# (possibly RAM pressure rather than session sizing, see above — not re-measured yet),
+# so pending a re-measurement of the multi-session rows on a quiet board, every model
+# above the 1-session rows takes everything the hardware has.
 SMALL_CTX_SIZE = 4096
 NDEV_BY_GGUF_GB_SMALL_CTX = ((3.5, 4),)
 

--- a/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
@@ -42,23 +42,25 @@ GB = 1e9
 # Number of sessions by GGUF size, ordered from the largest threshold down: the first entry a
 # model exceeds wins. Both tables are deliberately conservative — they over-allocate a session
 # on some models, which costs ~3% per token, rather than failing to load; models with a
-# known-good value should carry an explicit GGML_HEXAGON_NDEV instead.
+# known-good value should carry an explicit GGML_HEXAGON_DEVICES instead.
 
 # Default table, for the context sizes the service runs at out of the box.
 NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 2))
 
-# Small-context table. A 4k KV cache leaves far more room on the domains, and this one is
-# measured rather than estimated: on a ventunoq board every installed model was loaded at
-# 1..4 sessions with -c 4096, taking the first count that loads.
+# Small-context table. A 4k KV cache leaves far more room on the domains. It was
+# originally measured on a ventunoq board (every installed model loaded at 1..4 sessions
+# with -c 4096, taking the first count that loads):
 #
 #   Qwen3.5-0.8B-Q4_0    0.51 GB -> 1     Qwen3-8B-Q4_0        4.79 GB -> 2
 #   Qwen3-4B-2507-Q4_0   2.38 GB -> 1     Qwen3.5-9B-Q4_0      5.74 GB -> 2
 #   Qwen3.5-4B-Q4_0      2.78 GB -> 1     gemma-4-12b          6.98 GB -> 3
 #
-# Thresholds sit between the measurements, so the table reproduces all of them exactly.
-# Above 8 GB there is no measurement, so that bucket gets everything the hardware has.
+# The September 2025 llama.cpp build invalidated the multi-session rows: Qwen3-8B-Q4_0
+# no longer fastrpc-maps its per-domain buffer on 2 sessions and needs 4. The 1-session
+# rows still load, so every model above them takes everything the hardware has until the
+# bigger models are re-measured on the new build.
 SMALL_CTX_SIZE = 4096
-NDEV_BY_GGUF_GB_SMALL_CTX = ((8.0, 4), (6.0, 3), (3.5, 2))
+NDEV_BY_GGUF_GB_SMALL_CTX = ((3.5, 4),)
 
 
 class ModelOverride(NamedTuple):

--- a/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
+++ b/containers/ai/llamacpp-npu-runner/scripts/configure-llamacpp.py
@@ -44,8 +44,12 @@ GB = 1e9
 # on some models, which costs ~3% per token, rather than failing to load; models with a
 # known-good value should carry an explicit GGML_HEXAGON_DEVICES instead.
 
-# Default table, for the context sizes the service runs at out of the box.
-NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 2))
+# Default table, for the context sizes the service runs at out of the box. The September
+# 2025 llama.cpp build shrank the per-session mapping budget: Qwen3.5-4B-Q4_0 (2.78 GB)
+# no longer loads on 2 sessions — fastrpc_mmap fails on its second ~0.9 GiB weights buffer
+# at 8k and 16k alike — so the middle bucket takes 3 sessions. Still below the 4 that
+# trigger the context cap, so these models keep the full context.
+NDEV_BY_GGUF_GB = ((3.5, 4), (1.5, 3))
 
 # Small-context table. A 4k KV cache leaves far more room on the domains. It was
 # originally measured on a ventunoq board (every installed model loaded at 1..4 sessions

--- a/containers/ai/llamacpp-npu-runner/scripts/run-model-router.sh
+++ b/containers/ai/llamacpp-npu-runner/scripts/run-model-router.sh
@@ -30,16 +30,23 @@ fi
 DETECTED_NDEV="$(python3 /configure-llamacpp.py /models --print-ndev --ctx "${EFFECTIVE_CTX_SIZE}")"
 DETECTED_NDEV="${DETECTED_NDEV:-1}"
 
-# Build --device argument from GGML_HEXAGON_NDEV, falling back to the value detected
-# from the installed models (default: 1)
-if [ -n "${GGML_HEXAGON_NDEV}" ]; then
+# Build --device argument from GGML_HEXAGON_DEVICES (which accepts a session count, like
+# the GGML_HEXAGON_NDEV it replaced — still honored for older app configs), falling back
+# to the value detected from the installed models (default: 1)
+if [ -n "${GGML_HEXAGON_DEVICES}" ]; then
+  NDEV="${GGML_HEXAGON_DEVICES}"
+  echo "Using externally configured GGML_HEXAGON_DEVICES=${NDEV}"
+elif [ -n "${GGML_HEXAGON_NDEV}" ]; then
   NDEV="${GGML_HEXAGON_NDEV}"
-  echo "Using externally configured GGML_HEXAGON_NDEV=${NDEV}"
+  echo "Using externally configured GGML_HEXAGON_NDEV=${NDEV} (deprecated: set GGML_HEXAGON_DEVICES instead)"
 else
   NDEV="${DETECTED_NDEV}"
-  export GGML_HEXAGON_NDEV="${NDEV}"
-  echo "GGML_HEXAGON_NDEV not set: auto-detected ${NDEV} session(s) from installed models"
+  echo "GGML_HEXAGON_DEVICES not set: auto-detected ${NDEV} session(s) from installed models"
 fi
+export GGML_HEXAGON_DEVICES="${NDEV}"
+# Already translated into GGML_HEXAGON_DEVICES: don't let llama-server see the
+# deprecated variable, it would warn on every spawned instance.
+unset GGML_HEXAGON_NDEV
 
 echo "Configuring ${NDEV} session(s)..."
 DEVICE_LIST=""

--- a/containers/ai/llamacpp-runner/ci.json
+++ b/containers/ai/llamacpp-runner/ci.json
@@ -4,7 +4,7 @@
   "build_whl": false,
   "update_compose": true,
   "build_args": {
-    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260901/llamacpp-cpu-20260902.tar.gz",
+    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260902/llamacpp-cpu-20260902.tar.gz",
     "LLAMA_CPP_DIGEST": "sha256:59f4325f2bf8cdca8a76b95ac1a96e929b6a120fce33b0d15cb29a57c39cf7dc"
   },
   "sbom": {

--- a/containers/ai/llamacpp-runner/ci.json
+++ b/containers/ai/llamacpp-runner/ci.json
@@ -4,8 +4,8 @@
   "build_whl": false,
   "update_compose": true,
   "build_args": {
-    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260804/llamacpp-cpu-20260804.tar.gz",
-    "LLAMA_CPP_DIGEST": "sha256:6418d7cd3eba32472c812bcc1c1537b43753d4708f6e74866d29e4131830eb0c"
+    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260901/llamacpp-cpu-20260901.tar.gz",
+    "LLAMA_CPP_DIGEST": "sha256:c7b4ac7015dc4ec7e7ec8818ecf71fa76a257a9e3945d67cae168561c9b6f204"
   },
   "sbom": {
     "runtime_base": "${REGISTRY}app-bricks/python-slim:${BASE_IMAGE_VERSION}"

--- a/containers/ai/llamacpp-runner/ci.json
+++ b/containers/ai/llamacpp-runner/ci.json
@@ -4,8 +4,8 @@
   "build_whl": false,
   "update_compose": true,
   "build_args": {
-    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260901/llamacpp-cpu-20260901.tar.gz",
-    "LLAMA_CPP_DIGEST": "sha256:c7b4ac7015dc4ec7e7ec8818ecf71fa76a257a9e3945d67cae168561c9b6f204"
+    "LLAMA_CPP_URL": "https://github.com/arduino/app-bricks-py/releases/download/llamacpp%2F20260901/llamacpp-cpu-20260902.tar.gz",
+    "LLAMA_CPP_DIGEST": "sha256:59f4325f2bf8cdca8a76b95ac1a96e929b6a120fce33b0d15cb29a57c39cf7dc"
   },
   "sbom": {
     "runtime_base": "${REGISTRY}app-bricks/python-slim:${BASE_IMAGE_VERSION}"

--- a/models/models-list.yaml
+++ b/models/models-list.yaml
@@ -1836,7 +1836,7 @@ models:
     bricks:
       - id: "arduino:llm"
         model_configuration:
-          GGML_HEXAGON_NDEV: 1      
+          GGML_HEXAGON_DEVICES: 1      
     deployment:
       handler: "hf-handler"
       platforms:
@@ -1860,7 +1860,7 @@ models:
     bricks:
       - id: "arduino:llm"
         model_configuration:
-          GGML_HEXAGON_NDEV: 2
+          GGML_HEXAGON_DEVICES: 2
     deployment:
       handler: "hf-handler"
       platforms:
@@ -1882,7 +1882,7 @@ models:
      bricks:
        - id: "arduino:llm"
          model_configuration:
-           GGML_HEXAGON_NDEV: 1       
+           GGML_HEXAGON_DEVICES: 1       
      deployment:
        handler: "hf-handler"
        platforms:
@@ -1911,7 +1911,7 @@ models:
      bricks:
        - id: "arduino:llm"
          model_configuration:
-           GGML_HEXAGON_NDEV: 1       
+           GGML_HEXAGON_DEVICES: 1       
      deployment:
        handler: "hf-handler"
        platforms:

--- a/src/arduino/app_services/llamacpp/service_compose.yaml
+++ b/src/arduino/app_services/llamacpp/service_compose.yaml
@@ -39,7 +39,7 @@ services:
         soft: 65536
         hard: 65536
     oom_score_adj: -500
-    mem_limit: 10g
+    mem_limit: 12g
     memswap_limit: 10g
     shm_size: 2g
     devices:

--- a/tests/scripts/test_configure_llamacpp.py
+++ b/tests/scripts/test_configure_llamacpp.py
@@ -91,6 +91,7 @@ def test_e4b_pinned_to_two_sessions(name, gguf_gb, ctx_size):
         ("Qwen3-4B-2507-Q4_0", 2.38, 4096, 1),
         ("Qwen3.5-4B-Q4_0", 2.78, 4096, 1),
         ("Qwen3-8B-Q4_0", 4.79, 4096, 3),
+        ("granite-4.2-8b-Q4_0", 5.06, 4096, 4),
         ("Qwen3.5-9B-Q4_0", 5.74, 4096, 4),
         ("gemma-4-12b-it-Q4_0", 6.98, 4096, 4),
     ],

--- a/tests/scripts/test_configure_llamacpp.py
+++ b/tests/scripts/test_configure_llamacpp.py
@@ -77,15 +77,12 @@ def test_e4b_pinned_to_two_sessions(name, gguf_gb, ctx_size):
     "name, gguf_gb, ctx_size, expected",
     [
         # Default profile: sized by GGUF size, the pins do not leak onto other models.
-        # The 4B models take 3 sessions since the September 2025 llama.cpp build: on 2,
-        # fastrpc_mmap fails on Qwen3.5-4B's second weights buffer at 8k and 16k alike.
         ("Qwen3.5-0.8B-Q4_0", 0.51, 16384, 1),
-        ("Qwen3-4B-2507-Q4_0", 2.38, 16384, 3),
-        ("Qwen3.5-4B-Q4_0", 2.78, 16384, 3),
+        ("Qwen3.5-4B-Q4_0", 2.78, 16384, 2),
         ("gemma-4-12b-it-Q4_0", 6.98, 16384, 4),
-        # Small-context profile: the 1-session measurements still hold; everything bigger
-        # takes all 4 sessions since the September 2025 llama.cpp build (Qwen3-8B fails to
-        # fastrpc-map its per-domain buffer on 2).
+        # Small-context profile: the 1-session measurements hold; everything bigger takes
+        # all 4 sessions until Qwen3-8B's failure to load on 2 is re-measured on a quiet
+        # board (it may have been RAM pressure rather than session sizing).
         ("Qwen3.5-0.8B-Q4_0", 0.51, 4096, 1),
         ("Qwen3-4B-2507-Q4_0", 2.38, 4096, 1),
         ("Qwen3.5-4B-Q4_0", 2.78, 4096, 1),
@@ -116,11 +113,10 @@ def _install_models(monkeypatch, sizes_gb: dict[str, float]) -> dict[str, dict]:
 
 
 def test_detect_hexagon_ndev_does_not_trigger_the_context_cap(monkeypatch, capsys):
-    """The set of models from the ventunoq board needs 3 sessions, not 4.
+    """The set of models from the ventunoq board needs 2 sessions, not 4.
 
-    Four sessions is what makes run-model-router.sh cap the context to 4k, so the 4B bucket
-    (3 sessions since the September 2025 llama.cpp build) and the E4B pin have to keep the
-    whole set below that threshold at the default context.
+    Four sessions is what makes run-model-router.sh cap the context to 4k, so pinning E4B to
+    two sessions has to keep the whole set below that threshold at the default context.
     """
     models = _install_models(
         monkeypatch,
@@ -132,10 +128,9 @@ def test_detect_hexagon_ndev_does_not_trigger_the_context_cap(monkeypatch, capsy
         },
     )
 
-    assert detect_hexagon_ndev(models, 16384) == 3
+    assert detect_hexagon_ndev(models, 16384) == 2
 
     diagnostics = capsys.readouterr().err
-    assert "Qwen_Qwen3.5-4B-Q4_0: 2.78 GB, requires 3 sessions" in diagnostics
     assert "gemma-4-E2B_q4_0-it: 3.35 GB, pinned to 1 session" in diagnostics
     assert "gemma-4-E4B_q4_0-it: 5.15 GB, pinned to 2 sessions" in diagnostics
 
@@ -172,8 +167,8 @@ def test_the_ventunoq_model_set_keeps_the_full_context(monkeypatch):
 
 def test_qwen3_8b_gets_four_sessions_at_the_capped_context(monkeypatch, capsys):
     """Regression for the 21q board set: Qwen3-8B caps the context to 4k, and at 4k it
-    fails to load on 2 sessions (fastrpc_mmap error on the HTP0 buffer with the September
-    2025 llama.cpp build), so the whole set has to come up with 4."""
+    failed to load on 2 sessions (fastrpc_mmap error on the HTP0 buffer, possibly RAM
+    pressure — not re-measured yet), so the whole set has to come up with 4."""
     models = _install_models(
         monkeypatch,
         {

--- a/tests/scripts/test_configure_llamacpp.py
+++ b/tests/scripts/test_configure_llamacpp.py
@@ -80,13 +80,15 @@ def test_e4b_pinned_to_two_sessions(name, gguf_gb, ctx_size):
         ("Qwen3.5-0.8B-Q4_0", 0.51, 16384, 1),
         ("Qwen3.5-4B-Q4_0", 2.78, 16384, 2),
         ("gemma-4-12b-it-Q4_0", 6.98, 16384, 4),
-        # Small-context profile: reproduces the measurements in the table.
+        # Small-context profile: the 1-session measurements still hold; everything bigger
+        # takes all 4 sessions since the September 2025 llama.cpp build (Qwen3-8B fails to
+        # fastrpc-map its per-domain buffer on 2).
         ("Qwen3.5-0.8B-Q4_0", 0.51, 4096, 1),
         ("Qwen3-4B-2507-Q4_0", 2.38, 4096, 1),
         ("Qwen3.5-4B-Q4_0", 2.78, 4096, 1),
-        ("Qwen3-8B-Q4_0", 4.79, 4096, 2),
-        ("Qwen3.5-9B-Q4_0", 5.74, 4096, 2),
-        ("gemma-4-12b-it-Q4_0", 6.98, 4096, 3),
+        ("Qwen3-8B-Q4_0", 4.79, 4096, 4),
+        ("Qwen3.5-9B-Q4_0", 5.74, 4096, 4),
+        ("gemma-4-12b-it-Q4_0", 6.98, 4096, 4),
     ],
 )
 def test_unpinned_models_are_sized_by_gguf_size(name, gguf_gb, ctx_size, expected):
@@ -161,6 +163,29 @@ def test_the_ventunoq_model_set_keeps_the_full_context(monkeypatch):
     )
 
     assert detect_ctx_size(models, 16384) == 16384
+
+
+def test_qwen3_8b_gets_four_sessions_at_the_capped_context(monkeypatch, capsys):
+    """Regression for the 21q board set: Qwen3-8B caps the context to 4k, and at 4k it
+    fails to load on 2 sessions (fastrpc_mmap error on the HTP0 buffer with the September
+    2025 llama.cpp build), so the whole set has to come up with 4."""
+    models = _install_models(
+        monkeypatch,
+        {
+            "Qwen3-0.6B-Q3_K_S": 0.32,
+            "Qwen3-0.6B-Q4_0": 0.38,
+            "Qwen3.5-4B-Q4_0-pure": 2.38,
+            "Qwen_Qwen3-8B-Q4_0": 4.79,
+            "Qwen_Qwen3.5-4B-Q4_0": 2.78,
+            "gemma-3-1b-it-Q4_0": 0.72,
+            "gemma-4-E2B_q4_0-it": 3.35,
+            "gemma-4-E4B_q4_0-it": 5.15,
+        },
+    )
+
+    assert detect_ctx_size(models, 16384) == 4096
+    assert detect_hexagon_ndev(models, 4096) == 4
+    assert "Qwen_Qwen3-8B-Q4_0: 4.79 GB, requires 4 sessions" in capsys.readouterr().err
 
 
 def test_a_big_non_exempt_model_still_caps_the_context(monkeypatch, capsys):

--- a/tests/scripts/test_configure_llamacpp.py
+++ b/tests/scripts/test_configure_llamacpp.py
@@ -77,8 +77,12 @@ def test_e4b_pinned_to_two_sessions(name, gguf_gb, ctx_size):
     "name, gguf_gb, ctx_size, expected",
     [
         # Default profile: sized by GGUF size, the pins do not leak onto other models.
+        # The 4B bucket takes 3 sessions: at 16k the KV cache of Qwen3-4B-Instruct-2507
+        # is a 1 GiB buffer per session on 2 sessions, which fastrpc refuses to map even
+        # with free RAM (measured on a 21q: fails on 2, runs on 3).
         ("Qwen3.5-0.8B-Q4_0", 0.51, 16384, 1),
-        ("Qwen3.5-4B-Q4_0", 2.78, 16384, 2),
+        ("Qwen3-4B-Instruct-2507-Q4_0", 2.38, 16384, 3),
+        ("Qwen3.5-4B-Q4_0", 2.78, 16384, 3),
         ("gemma-4-12b-it-Q4_0", 6.98, 16384, 4),
         # Small-context profile: the 1-session measurements hold; Qwen3-8B was re-measured
         # on the September 2025 build (fails on 2 sessions, runs on 3); anything bigger is
@@ -113,10 +117,11 @@ def _install_models(monkeypatch, sizes_gb: dict[str, float]) -> dict[str, dict]:
 
 
 def test_detect_hexagon_ndev_does_not_trigger_the_context_cap(monkeypatch, capsys):
-    """The set of models from the ventunoq board needs 2 sessions, not 4.
+    """The set of models from the ventunoq board needs 3 sessions, not 4.
 
-    Four sessions is what makes run-model-router.sh cap the context to 4k, so pinning E4B to
-    two sessions has to keep the whole set below that threshold at the default context.
+    Four sessions is what makes run-model-router.sh cap the context to 4k, so the 4B bucket
+    (3 sessions, for the 16k KV cache) and the E4B pin have to keep the whole set below
+    that threshold at the default context.
     """
     models = _install_models(
         monkeypatch,
@@ -128,7 +133,7 @@ def test_detect_hexagon_ndev_does_not_trigger_the_context_cap(monkeypatch, capsy
         },
     )
 
-    assert detect_hexagon_ndev(models, 16384) == 2
+    assert detect_hexagon_ndev(models, 16384) == 3
 
     diagnostics = capsys.readouterr().err
     assert "gemma-4-E2B_q4_0-it: 3.35 GB, pinned to 1 session" in diagnostics

--- a/tests/scripts/test_configure_llamacpp.py
+++ b/tests/scripts/test_configure_llamacpp.py
@@ -80,13 +80,13 @@ def test_e4b_pinned_to_two_sessions(name, gguf_gb, ctx_size):
         ("Qwen3.5-0.8B-Q4_0", 0.51, 16384, 1),
         ("Qwen3.5-4B-Q4_0", 2.78, 16384, 2),
         ("gemma-4-12b-it-Q4_0", 6.98, 16384, 4),
-        # Small-context profile: the 1-session measurements hold; everything bigger takes
-        # all 4 sessions until Qwen3-8B's failure to load on 2 is re-measured on a quiet
-        # board (it may have been RAM pressure rather than session sizing).
+        # Small-context profile: the 1-session measurements hold; Qwen3-8B was re-measured
+        # on the September 2025 build (fails on 2 sessions, runs on 3); anything bigger is
+        # unmeasured on that build and takes all 4 sessions.
         ("Qwen3.5-0.8B-Q4_0", 0.51, 4096, 1),
         ("Qwen3-4B-2507-Q4_0", 2.38, 4096, 1),
         ("Qwen3.5-4B-Q4_0", 2.78, 4096, 1),
-        ("Qwen3-8B-Q4_0", 4.79, 4096, 4),
+        ("Qwen3-8B-Q4_0", 4.79, 4096, 3),
         ("Qwen3.5-9B-Q4_0", 5.74, 4096, 4),
         ("gemma-4-12b-it-Q4_0", 6.98, 4096, 4),
     ],
@@ -165,10 +165,10 @@ def test_the_ventunoq_model_set_keeps_the_full_context(monkeypatch):
     assert detect_ctx_size(models, 16384) == 16384
 
 
-def test_qwen3_8b_gets_four_sessions_at_the_capped_context(monkeypatch, capsys):
+def test_qwen3_8b_gets_three_sessions_at_the_capped_context(monkeypatch, capsys):
     """Regression for the 21q board set: Qwen3-8B caps the context to 4k, and at 4k it
-    failed to load on 2 sessions (fastrpc_mmap error on the HTP0 buffer, possibly RAM
-    pressure — not re-measured yet), so the whole set has to come up with 4."""
+    fails to load on 2 sessions on the September 2025 build but runs on 3 (measured),
+    so the whole set has to come up with 3."""
     models = _install_models(
         monkeypatch,
         {
@@ -184,8 +184,8 @@ def test_qwen3_8b_gets_four_sessions_at_the_capped_context(monkeypatch, capsys):
     )
 
     assert detect_ctx_size(models, 16384) == 4096
-    assert detect_hexagon_ndev(models, 4096) == 4
-    assert "Qwen_Qwen3-8B-Q4_0: 4.79 GB, requires 4 sessions" in capsys.readouterr().err
+    assert detect_hexagon_ndev(models, 4096) == 3
+    assert "Qwen_Qwen3-8B-Q4_0: 4.79 GB, requires 3 sessions" in capsys.readouterr().err
 
 
 def test_a_big_non_exempt_model_still_caps_the_context(monkeypatch, capsys):

--- a/tests/scripts/test_configure_llamacpp.py
+++ b/tests/scripts/test_configure_llamacpp.py
@@ -77,8 +77,11 @@ def test_e4b_pinned_to_two_sessions(name, gguf_gb, ctx_size):
     "name, gguf_gb, ctx_size, expected",
     [
         # Default profile: sized by GGUF size, the pins do not leak onto other models.
+        # The 4B models take 3 sessions since the September 2025 llama.cpp build: on 2,
+        # fastrpc_mmap fails on Qwen3.5-4B's second weights buffer at 8k and 16k alike.
         ("Qwen3.5-0.8B-Q4_0", 0.51, 16384, 1),
-        ("Qwen3.5-4B-Q4_0", 2.78, 16384, 2),
+        ("Qwen3-4B-2507-Q4_0", 2.38, 16384, 3),
+        ("Qwen3.5-4B-Q4_0", 2.78, 16384, 3),
         ("gemma-4-12b-it-Q4_0", 6.98, 16384, 4),
         # Small-context profile: the 1-session measurements still hold; everything bigger
         # takes all 4 sessions since the September 2025 llama.cpp build (Qwen3-8B fails to
@@ -113,10 +116,11 @@ def _install_models(monkeypatch, sizes_gb: dict[str, float]) -> dict[str, dict]:
 
 
 def test_detect_hexagon_ndev_does_not_trigger_the_context_cap(monkeypatch, capsys):
-    """The set of models from the ventunoq board needs 2 sessions, not 4.
+    """The set of models from the ventunoq board needs 3 sessions, not 4.
 
-    Four sessions is what makes run-model-router.sh cap the context to 4k, so pinning E4B to
-    two sessions has to keep the whole set below that threshold at the default context.
+    Four sessions is what makes run-model-router.sh cap the context to 4k, so the 4B bucket
+    (3 sessions since the September 2025 llama.cpp build) and the E4B pin have to keep the
+    whole set below that threshold at the default context.
     """
     models = _install_models(
         monkeypatch,
@@ -128,9 +132,10 @@ def test_detect_hexagon_ndev_does_not_trigger_the_context_cap(monkeypatch, capsy
         },
     )
 
-    assert detect_hexagon_ndev(models, 16384) == 2
+    assert detect_hexagon_ndev(models, 16384) == 3
 
     diagnostics = capsys.readouterr().err
+    assert "Qwen_Qwen3.5-4B-Q4_0: 2.78 GB, requires 3 sessions" in diagnostics
     assert "gemma-4-E2B_q4_0-it: 3.35 GB, pinned to 1 session" in diagnostics
     assert "gemma-4-E4B_q4_0-it: 5.15 GB, pinned to 2 sessions" in diagnostics
 


### PR DESCRIPTION
This pull request updates the session allocation logic and configuration for the Hexagon NPU runner, focusing on improved detection and configuration of device sessions for model loading. It introduces the new `GGML_HEXAGON_DEVICES` variable (replacing the deprecated `GGML_HEXAGON_NDEV`), updates the logic for allocating sessions based on recent hardware measurements, and increases the default memory limit for the Llama.cpp service. Several tests and configuration files are updated to reflect these changes.

**Session allocation and configuration improvements:**

* Replaced the deprecated `GGML_HEXAGON_NDEV` variable with `GGML_HEXAGON_DEVICES` throughout the codebase, including in model configuration YAMLs and the model router script. The script now prefers `GGML_HEXAGON_DEVICES` and unsets the old variable to avoid deprecation warnings. [[1]](diffhunk://#diff-cb69661b79938af4b0294f95fa67d0be1d00d61b974fffe766fb980915174bbaL33-R49) [[2]](diffhunk://#diff-5d0e983816328ea2f3ec32e1bdfd427b851c998ffa124c566993fc51bedb5277L1839-R1839) [[3]](diffhunk://#diff-5d0e983816328ea2f3ec32e1bdfd427b851c998ffa124c566993fc51bedb5277L1863-R1863) [[4]](diffhunk://#diff-5d0e983816328ea2f3ec32e1bdfd427b851c998ffa124c566993fc51bedb5277L1885-R1885) [[5]](diffhunk://#diff-5d0e983816328ea2f3ec32e1bdfd427b851c998ffa124c566993fc51bedb5277L1914-R1914)
* Updated the session allocation tables in `configure-llamacpp.py` to use more accurate, measured thresholds for session counts based on GGUF size and context, reflecting recent hardware findings.

**Testing and validation updates:**

* Adjusted and expanded tests in `test_configure_llamacpp.py` to match new session allocation logic, including updated expectations for session counts and a regression test for Qwen3-8B on recent hardware. [[1]](diffhunk://#diff-f45e7e5f944706d5423ae131fc5ca72679d59833d0e31266f08b5bfecb50c205R80-R95) [[2]](diffhunk://#diff-f45e7e5f944706d5423ae131fc5ca72679d59833d0e31266f08b5bfecb50c205L114-R124) [[3]](diffhunk://#diff-f45e7e5f944706d5423ae131fc5ca72679d59833d0e31266f08b5bfecb50c205L129-R136) [[4]](diffhunk://#diff-f45e7e5f944706d5423ae131fc5ca72679d59833d0e31266f08b5bfecb50c205R173-R195)

**Resource allocation:**

* Increased the `mem_limit` for the Llama.cpp service in `service_compose.yaml` from 10GB to 12GB to better accommodate larger models and session allocations.

**Dependency updates:**

* Updated Llama.cpp runner and NPU runner Docker build arguments to use the latest release tarballs and corresponding SHA256 digests. [[1]](diffhunk://#diff-7c2dc79cd0c0c022fcedcba47999650a9f1b3beccd5a0cdc9408e8de639944deL7-R8) [[2]](diffhunk://#diff-c6a61e064cfe29578c34e20eff4e90de4feed068a217a607cdb8218e788a96b7L7-R8)